### PR TITLE
feat: Warm Hompage Cache

### DIFF
--- a/src/app/api/cron/warm-cache/route.ts
+++ b/src/app/api/cron/warm-cache/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from 'next/server';
+import { subMonths, differenceInSeconds, subSeconds } from 'date-fns';
+import { api } from '@/trpc/server';
+import { defaultSellersSorting } from '@/app/_contexts/sorting/sellers/default';
+import { defaultTransfersSorting } from '@/app/_contexts/sorting/transfers/default';
+
+/**
+ * Cache warming endpoint for homepage queries
+ * Should be called every 5 minutes via cron to keep cache fresh
+ */
+export async function GET() {
+  try {
+    const endDate = new Date();
+    const startDate = subMonths(endDate, 1);
+    const limit = 100;
+
+    // Warm all homepage caches in parallel - using the same tRPC calls as the homepage
+    await Promise.all([
+      // Overall Stats - current period
+      api.stats.getOverallStatistics({
+        startDate,
+        endDate,
+      }),
+
+      // Overall Stats - previous period (for comparison)
+      api.stats.getOverallStatistics({
+        startDate: subSeconds(
+          startDate,
+          differenceInSeconds(endDate, startDate)
+        ),
+        endDate: startDate,
+      }),
+
+      // Bucketed Statistics - for charts
+      api.stats.getBucketedStatistics({
+        startDate,
+        endDate,
+        numBuckets: 32,
+      }),
+
+      // Top Facilitators - all time, no date filters
+      api.facilitators.list({}),
+
+      // Top Servers (Bazaar) - list
+      api.sellers.list.bazaar({
+        startDate,
+        endDate,
+        sorting: defaultSellersSorting,
+      }),
+
+      // Top Servers (Bazaar) - overall stats
+      api.stats.bazaar.overallStatistics({
+        startDate,
+        endDate,
+      }),
+
+      // Latest Transactions
+      api.transfers.list({
+        limit,
+        sorting: defaultTransfersSorting,
+        startDate,
+        endDate,
+      }),
+
+      // All Sellers
+      api.sellers.list.all({
+        startDate,
+        endDate,
+        sorting: defaultSellersSorting,
+      }),
+    ]);
+
+    return NextResponse.json({
+      success: true,
+      timestamp: new Date().toISOString(),
+      message: 'Cache warmed successfully',
+    });
+  } catch (error) {
+    console.error('Error warming cache:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,12 +1,24 @@
 import { unstable_cache } from 'next/cache';
 
 /**
- * Round a date to the nearest minute for stable cache keys
+ * Global cache duration in minutes
+ * This should match the interval used for date rounding to prevent cache fragmentation
  */
-const roundDateToMinute = (date?: Date): string | undefined => {
+export const CACHE_DURATION_MINUTES = 5;
+const CACHE_DURATION_SECONDS = CACHE_DURATION_MINUTES * 60;
+
+/**
+ * Round a date to the nearest cache interval for stable cache keys
+ */
+const roundDateToInterval = (date?: Date): string | undefined => {
   if (!date) return undefined;
   const rounded = new Date(date);
-  rounded.setSeconds(0, 0);
+  rounded.setMinutes(
+    Math.floor(rounded.getMinutes() / CACHE_DURATION_MINUTES) *
+      CACHE_DURATION_MINUTES,
+    0,
+    0
+  );
   return rounded.toISOString();
 };
 
@@ -66,7 +78,7 @@ const createCachedQueryBase = <TInput, TOutput>(config: {
       },
       [config.cacheKeyPrefix, cacheKey],
       {
-        revalidate: config.revalidate ?? 60,
+        revalidate: config.revalidate ?? CACHE_DURATION_SECONDS,
         tags: config.tags,
       }
     )();
@@ -161,8 +173,8 @@ export const createStandardCacheKey = (
       // Skip undefined values
       continue;
     } else if (value instanceof Date) {
-      // Round dates to nearest minute
-      normalized[key] = roundDateToMinute(value);
+      // Round dates to nearest cache interval
+      normalized[key] = roundDateToInterval(value);
     } else if (Array.isArray(value)) {
       // Sort arrays for consistent keys
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/src/services/cdp/sql/facilitators/bucketed.ts
+++ b/src/services/cdp/sql/facilitators/bucketed.ts
@@ -133,6 +133,6 @@ export const getBucketedFacilitatorsStatistics = createCachedArrayQuery({
   cacheKeyPrefix: 'bucketed-facilitators-statistics',
   createCacheKey: input => createStandardCacheKey(input),
   dateFields: ['bucket_start'],
-  revalidate: 60,
+
   tags: ['facilitators-statistics'],
 });

--- a/src/services/cdp/sql/facilitators/list.ts
+++ b/src/services/cdp/sql/facilitators/list.ts
@@ -105,6 +105,6 @@ export const listTopFacilitators = createCachedArrayQuery({
   cacheKeyPrefix: 'facilitators-list',
   createCacheKey: input => createStandardCacheKey(input),
   dateFields: ['latest_block_timestamp'],
-  revalidate: 60,
+
   tags: ['facilitators'],
 });

--- a/src/services/cdp/sql/sellers/list.ts
+++ b/src/services/cdp/sql/sellers/list.ts
@@ -99,7 +99,7 @@ const _listTopSellersCached = createCachedPaginatedQuery({
   createCacheKey: ({ input, pagination }) =>
     createStandardCacheKey({ ...input, limit: pagination.limit }),
   dateFields: ['latest_block_timestamp'],
-  revalidate: 60,
+
   tags: ['sellers'],
 });
 

--- a/src/services/cdp/sql/stats/bucketed.ts
+++ b/src/services/cdp/sql/stats/bucketed.ts
@@ -127,6 +127,6 @@ export const getBucketedStatistics = createCachedArrayQuery({
   cacheKeyPrefix: 'bucketed-statistics',
   createCacheKey: input => createStandardCacheKey(input),
   dateFields: ['bucket_start'],
-  revalidate: 60,
+
   tags: ['statistics'],
 });

--- a/src/services/cdp/sql/stats/overall.ts
+++ b/src/services/cdp/sql/stats/overall.ts
@@ -80,6 +80,6 @@ export const getOverallStatistics = createCachedQuery({
   cacheKeyPrefix: 'overall-statistics',
   createCacheKey: input => createStandardCacheKey(input),
   dateFields: ['latest_block_timestamp'],
-  revalidate: 60,
+
   tags: ['statistics'],
 });

--- a/src/services/cdp/sql/transfers/list.ts
+++ b/src/services/cdp/sql/transfers/list.ts
@@ -91,6 +91,6 @@ export const listFacilitatorTransfers = createCachedPaginatedQuery({
   cacheKeyPrefix: 'transfers-list',
   createCacheKey: input => createStandardCacheKey(input),
   dateFields: ['block_timestamp'],
-  revalidate: 60,
+
   tags: ['transfers'],
 });

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/warm-cache",
+      "schedule": "*/5 * * * *"
+    }
+  ]
+}


### PR DESCRIPTION
Moves cache back to 5min. Sets up a cron Vercel function to hit all the homepage TRPC routes every 5 mins and keep the cache warm.