### PR TITLE
fix: Searchbar Positioning

### DIFF
--- a/src/app/_contexts/search/provider.tsx
+++ b/src/app/_contexts/search/provider.tsx
@@ -75,6 +75,7 @@ export const SearchProvider = ({ children }: { children: React.ReactNode }) => {
         open={isOpen}
         onOpenChange={setIsOpen}
         shouldFilter={false}
+        className="top-[20%] translate-y-0"
       >
         <CommandInput
           placeholder="Search for an address, origin, or resource..."


### PR DESCRIPTION
Currently the searchbar (cmd+k) jumps around in y-position as keys are typed and it toggles between loading and results. This toggles height between 150px and 300px, adjusting the center-y positioning.

Now we fix 20% from top.