### PR TITLE
Add OpenAPI spec upload for bulk resource registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "sync:resources": "curl -X GET http://localhost:3000/api/resources/sync && curl -X GET http://localhost:3000/api/resources/ping"
   },
   "dependencies": {
+    "@apidevtools/swagger-parser": "^12.1.0",
     "@auth/prisma-adapter": "^2.10.0",
     "@coinbase/cdp-hooks": "^0.0.42",
     "@coinbase/cdp-sdk": "^1.38.3",
@@ -38,6 +39,7 @@
     "@prisma/adapter-neon": "^6.16.3",
     "@prisma/client": "^6.16.2",
     "@radix-ui/react-avatar": "^1.1.10",
+    "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.7",
@@ -81,6 +83,7 @@
     "siwe": "^3.0.0",
     "sonner": "^2.0.7",
     "superjson": "^2.2.2",
+    "swagger-parser": "^10.0.3",
     "tailwind-merge": "^3.3.1",
     "uuid": "^13.0.0",
     "viem": "^2.37.9",
@@ -98,6 +101,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/swagger-parser": "^7.0.1",
     "@types/ws": "^8.18.1",
     "@vitest/ui": "^3.2.4",
     "dotenv": "^17.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@apidevtools/swagger-parser':
+        specifier: ^12.1.0
+        version: 12.1.0(openapi-types@12.1.3)
       '@auth/prisma-adapter':
         specifier: ^2.10.0
         version: 2.10.0(@prisma/client@6.16.2(prisma@6.16.2(magicast@0.3.5)(typescript@5.9.2))(typescript@5.9.2))
@@ -38,6 +41,9 @@ importers:
       '@radix-ui/react-avatar':
         specifier: ^1.1.10
         version: 1.1.10(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-checkbox':
+        specifier: ^1.3.3
+        version: 1.3.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-collapsible':
         specifier: ^1.1.12
         version: 1.1.12(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -167,6 +173,9 @@ importers:
       superjson:
         specifier: ^2.2.2
         version: 2.2.2
+      swagger-parser:
+        specifier: ^10.0.3
+        version: 10.0.3(openapi-types@12.1.3)
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
@@ -213,6 +222,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.1.9(@types/react@19.1.13)
+      '@types/swagger-parser':
+        specifier: ^7.0.1
+        version: 7.0.1(openapi-types@12.1.3)
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
@@ -273,6 +285,30 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@apidevtools/json-schema-ref-parser@14.0.1':
+    resolution: {integrity: sha512-Oc96zvmxx1fqoSEdUmfmvvb59/KDOnUoJ7s2t7bISyAn0XEz57LCCw8k2Y4Pf3mwKaZLMciESALORLgfe2frCw==}
+    engines: {node: '>= 16'}
+
+  '@apidevtools/json-schema-ref-parser@9.1.2':
+    resolution: {integrity: sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==}
+
+  '@apidevtools/openapi-schemas@2.1.0':
+    resolution: {integrity: sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==}
+    engines: {node: '>=10'}
+
+  '@apidevtools/swagger-methods@3.0.2':
+    resolution: {integrity: sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==}
+
+  '@apidevtools/swagger-parser@10.0.3':
+    resolution: {integrity: sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==}
+    peerDependencies:
+      openapi-types: '>=7'
+
+  '@apidevtools/swagger-parser@12.1.0':
+    resolution: {integrity: sha512-e5mJoswsnAX0jG+J09xHFYQXb/bUc5S3pLpMxUuRUA2H8T2kni3yEoyz2R3Dltw5f4A6j6rPNMpWTK+iVDFlng==}
+    peerDependencies:
+      openapi-types: '>=7'
 
   '@arr/every@1.0.1':
     resolution: {integrity: sha512-UQFQ6SgyJ6LX42W8rHCs8KVc0JS0tzVL9ct4XYedJukskYVWTo49tNiMEK9C2HTyarbNiT/RVIRSY82vH+6sTg==}
@@ -1003,6 +1039,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@jsdevtools/ono@7.1.3':
+    resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
+
   '@jsonhero/path@1.0.21':
     resolution: {integrity: sha512-gVUDj/92acpVoJwsVJ/RuWOaHyG4oFzn898WNGQItLCTQ+hOaVlEaImhwE1WqOTf+l3dGOUkbSiVKlb3q1hd1Q==}
 
@@ -1575,6 +1614,19 @@ packages:
 
   '@radix-ui/react-avatar@1.1.10':
     resolution: {integrity: sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-checkbox@1.3.3':
+    resolution: {integrity: sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2772,6 +2824,10 @@ packages:
   '@types/retry@0.12.2':
     resolution: {integrity: sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==}
 
+  '@types/swagger-parser@7.0.1':
+    resolution: {integrity: sha512-RWfhw0/AQBuh/+8PA8IHeVhZe2h7YiIQ0nVAjJRByKrHL+BxWxaT056lVX3akfrxdKU5IPxSqPPZYgay3OQfCA==}
+    deprecated: This is a stub types definition. swagger-parser provides its own type definitions, so you do not need this installed.
+
   '@types/tinycolor2@1.4.6':
     resolution: {integrity: sha512-iEN8J0BoMnsWBqjVbWH/c0G0Hh7O21lpR2/+PrvAVgWdzL7eexIFm4JN/Wn10PTcmNdtS6U67r499mlWMXOxNw==}
 
@@ -3217,8 +3273,19 @@ packages:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
 
+  ajv-draft-04@1.0.0:
+    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ajv@8.17.1:
+    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
   ansi-escapes@7.1.1:
     resolution: {integrity: sha512-Zhl0ErHcSRUaVfGUeUdDuLgpkEo8KIFjB4Y9uAc46ScOpdDiU1Dbyplh7qWJeJ/ZHpbyMSM26+X3BySgnIz40Q==}
@@ -3453,6 +3520,9 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
+
+  call-me-maybe@1.0.2:
+    resolution: {integrity: sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -4283,6 +4353,9 @@ packages:
   fast-stable-stringify@1.0.0:
     resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
 
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
   fastestsmallesttextencoderdecoder@1.0.22:
     resolution: {integrity: sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==}
 
@@ -4856,6 +4929,9 @@ packages:
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
@@ -4982,6 +5058,14 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash.get@4.4.2:
+    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -5441,6 +5525,9 @@ packages:
 
   openapi-fetch@0.13.8:
     resolution: {integrity: sha512-yJ4QKRyNxE44baQ9mY5+r/kAzZ8yXMemtNAOFwOzRXJscdjSxxzWSNlyBAr+o5JjkUw9Lc3W7OIoca0cY3PYnQ==}
+
+  openapi-types@12.1.3:
+    resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
 
   openapi-typescript-helpers@0.0.15:
     resolution: {integrity: sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==}
@@ -5922,6 +6009,10 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   require-in-the-middle@7.5.2:
     resolution: {integrity: sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==}
     engines: {node: '>=8.6.0'}
@@ -6293,6 +6384,10 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  swagger-parser@10.0.3:
+    resolution: {integrity: sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==}
+    engines: {node: '>=10'}
+
   tailwind-merge@3.3.1:
     resolution: {integrity: sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==}
 
@@ -6641,6 +6736,10 @@ packages:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
 
+  validator@13.15.15:
+    resolution: {integrity: sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==}
+    engines: {node: '>= 0.10'}
+
   valtio@1.13.2:
     resolution: {integrity: sha512-Qik0o+DSy741TmkqmRfjq+0xpZBXi/Y6+fXZLn0xNF1z/waFMbE3rkivv5Zcf9RrMUp6zswf2J7sbh2KBlba5A==}
     engines: {node: '>=12.20.0'}
@@ -6934,6 +7033,11 @@ packages:
     resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
     engines: {node: '>=12.20'}
 
+  z-schema@5.0.5:
+    resolution: {integrity: sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==}
+    engines: {node: '>=8.0.0'}
+    hasBin: true
+
   zod-error@1.5.0:
     resolution: {integrity: sha512-zzopKZ/skI9iXpqCEPj+iLCKl9b88E43ehcU+sbRoHuwGd9F1IDVGQ70TyO6kmfiRL1g4IXkjsXK+g1gLYl4WQ==}
 
@@ -7027,6 +7131,42 @@ snapshots:
   '@adraffy/ens-normalize@1.11.1': {}
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@apidevtools/json-schema-ref-parser@14.0.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      js-yaml: 4.1.0
+
+  '@apidevtools/json-schema-ref-parser@9.1.2':
+    dependencies:
+      '@jsdevtools/ono': 7.1.3
+      '@types/json-schema': 7.0.15
+      call-me-maybe: 1.0.2
+      js-yaml: 4.1.0
+
+  '@apidevtools/openapi-schemas@2.1.0': {}
+
+  '@apidevtools/swagger-methods@3.0.2': {}
+
+  '@apidevtools/swagger-parser@10.0.3(openapi-types@12.1.3)':
+    dependencies:
+      '@apidevtools/json-schema-ref-parser': 9.1.2
+      '@apidevtools/openapi-schemas': 2.1.0
+      '@apidevtools/swagger-methods': 3.0.2
+      '@jsdevtools/ono': 7.1.3
+      call-me-maybe: 1.0.2
+      openapi-types: 12.1.3
+      z-schema: 5.0.5
+
+  '@apidevtools/swagger-parser@12.1.0(openapi-types@12.1.3)':
+    dependencies:
+      '@apidevtools/json-schema-ref-parser': 14.0.1
+      '@apidevtools/openapi-schemas': 2.1.0
+      '@apidevtools/swagger-methods': 3.0.2
+      ajv: 8.17.1
+      ajv-draft-04: 1.0.0(ajv@8.17.1)
+      call-me-maybe: 1.0.2
+      openapi-types: 12.1.3
 
   '@arr/every@1.0.1': {}
 
@@ -7708,6 +7848,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@jsdevtools/ono@7.1.3': {}
+
   '@jsonhero/path@1.0.21': {}
 
   '@lit-labs/ssr-dom-shim@1.4.0': {}
@@ -8350,6 +8492,22 @@ snapshots:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.13)(react@19.1.0)
       '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.1.13)(react@19.1.0)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.13)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.13
+      '@types/react-dom': 19.1.9(@types/react@19.1.13)
+
+  '@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.13)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.13)(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.13)(react@19.1.0)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.13)(react@19.1.0)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.13)(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:
@@ -10208,6 +10366,12 @@ snapshots:
 
   '@types/retry@0.12.2': {}
 
+  '@types/swagger-parser@7.0.1(openapi-types@12.1.3)':
+    dependencies:
+      swagger-parser: 10.0.3(openapi-types@12.1.3)
+    transitivePeerDependencies:
+      - openapi-types
+
   '@types/tinycolor2@1.4.6': {}
 
   '@types/trusted-types@2.0.7': {}
@@ -11529,12 +11693,23 @@ snapshots:
     dependencies:
       humanize-ms: 1.2.1
 
+  ajv-draft-04@1.0.0(ajv@8.17.1):
+    optionalDependencies:
+      ajv: 8.17.1
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.17.1:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-escapes@7.1.1:
     dependencies:
@@ -11819,6 +11994,8 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
+
+  call-me-maybe@1.0.2: {}
 
   callsites@3.1.0: {}
 
@@ -12887,6 +13064,8 @@ snapshots:
 
   fast-stable-stringify@1.0.0: {}
 
+  fast-uri@3.1.0: {}
+
   fastestsmallesttextencoderdecoder@1.0.22: {}
 
   fastq@1.19.1:
@@ -13476,6 +13655,8 @@ snapshots:
 
   json-schema-traverse@0.4.1: {}
 
+  json-schema-traverse@1.0.0: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json-stringify-safe@5.0.1: {}
@@ -13602,6 +13783,10 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash.get@4.4.2: {}
+
+  lodash.isequal@4.5.0: {}
 
   lodash.merge@4.6.2: {}
 
@@ -14158,6 +14343,8 @@ snapshots:
   openapi-fetch@0.13.8:
     dependencies:
       openapi-typescript-helpers: 0.0.15
+
+  openapi-types@12.1.3: {}
 
   openapi-typescript-helpers@0.0.15: {}
 
@@ -14770,6 +14957,8 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-from-string@2.0.2: {}
+
   require-in-the-middle@7.5.2(supports-color@10.2.2):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
@@ -15269,6 +15458,12 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  swagger-parser@10.0.3(openapi-types@12.1.3):
+    dependencies:
+      '@apidevtools/swagger-parser': 10.0.3(openapi-types@12.1.3)
+    transitivePeerDependencies:
+      - openapi-types
+
   tailwind-merge@3.3.1: {}
 
   tailwindcss@4.1.13: {}
@@ -15652,6 +15847,8 @@ snapshots:
   uuid@8.3.2: {}
 
   uuid@9.0.1: {}
+
+  validator@13.15.15: {}
 
   valtio@1.13.2(@types/react@19.1.13)(react@19.1.0):
     dependencies:
@@ -16168,6 +16365,14 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.1: {}
+
+  z-schema@5.0.5:
+    dependencies:
+      lodash.get: 4.4.2
+      lodash.isequal: 4.5.0
+      validator: 13.15.15
+    optionalDependencies:
+      commander: 9.5.0
 
   zod-error@1.5.0:
     dependencies:

--- a/src/app/(home)/resources/register/_components/openapi-form.tsx
+++ b/src/app/(home)/resources/register/_components/openapi-form.tsx
@@ -1,0 +1,367 @@
+'use client';
+
+import { useState } from 'react';
+import { AlertTriangle, Upload, FileText, CheckCircle2 } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Checkbox } from '@/components/ui/checkbox';
+
+interface RegistrationResult {
+  url: string;
+  method: string;
+  operationId?: string;
+  summary?: string;
+  success: boolean;
+  result?: any;
+  error?: string;
+}
+
+interface OpenAPIResult {
+  success: boolean;
+  dryRun?: boolean;
+  info?: {
+    title?: string;
+    version?: string;
+    description?: string;
+  };
+  totalEndpoints: number;
+  registered?: number;
+  failed?: number;
+  results?: RegistrationResult[];
+  resources?: any[];
+}
+
+export const OpenAPIUploadForm = () => {
+  const [baseUrl, setBaseUrl] = useState('');
+  const [spec, setSpec] = useState('');
+  const [dryRun, setDryRun] = useState(true);
+  const [isPending, setIsPending] = useState(false);
+  const [result, setResult] = useState<OpenAPIResult | null>(null);
+
+  const handleSubmit = async () => {
+    setIsPending(true);
+    try {
+      const response = await fetch('/api/v1/resources/register-from-openapi', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ baseUrl, spec, dryRun }),
+      });
+
+      const data = await response.json();
+
+      if (data.error) {
+        toast.error(data.message || 'Failed to process OpenAPI spec');
+        setResult(null);
+        return;
+      }
+
+      setResult(data);
+
+      if (dryRun) {
+        toast.success(`Found ${data.totalEndpoints} endpoints`);
+      } else {
+        toast.success(
+          `Registered ${data.registered} of ${data.totalEndpoints} endpoints`
+        );
+      }
+    } catch (error) {
+      toast.error('Failed to process OpenAPI spec');
+      console.error(error);
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  const handleReset = () => {
+    setBaseUrl('');
+    setSpec('');
+    setDryRun(true);
+    setResult(null);
+  };
+
+  const isValidUrl = baseUrl.trim() !== '' && baseUrl.startsWith('http');
+  const isValidSpec = spec.trim() !== '';
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          {result ? 'OpenAPI Spec Processed' : 'Register from OpenAPI Spec'}
+        </CardTitle>
+        <CardDescription>
+          {result
+            ? `Processed ${result.totalEndpoints} endpoints from your OpenAPI specification.`
+            : 'Upload or paste an OpenAPI 3.x specification to register multiple resources at once.'}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {result ? (
+          <div className="flex flex-col gap-4">
+            {/* API Info */}
+            {result.info && (
+              <div className="bg-muted p-4 rounded-md">
+                <h3 className="font-semibold">{result.info.title}</h3>
+                {result.info.version && (
+                  <p className="text-sm text-muted-foreground">
+                    Version: {result.info.version}
+                  </p>
+                )}
+                {result.info.description && (
+                  <p className="text-sm text-muted-foreground mt-2">
+                    {result.info.description}
+                  </p>
+                )}
+              </div>
+            )}
+
+            {/* Summary */}
+            <div className="flex gap-4 justify-around bg-muted p-4 rounded-md">
+              <div className="text-center">
+                <p className="text-2xl font-bold">{result.totalEndpoints}</p>
+                <p className="text-sm text-muted-foreground">
+                  Total Endpoints
+                </p>
+              </div>
+              {!result.dryRun && (
+                <>
+                  <div className="text-center">
+                    <p className="text-2xl font-bold text-green-600">
+                      {result.registered}
+                    </p>
+                    <p className="text-sm text-muted-foreground">Registered</p>
+                  </div>
+                  <div className="text-center">
+                    <p className="text-2xl font-bold text-red-600">
+                      {result.failed}
+                    </p>
+                    <p className="text-sm text-muted-foreground">Failed</p>
+                  </div>
+                </>
+              )}
+            </div>
+
+            {/* Preview or Results */}
+            {result.dryRun && result.resources && (
+              <div className="border rounded-md p-4">
+                <h4 className="font-semibold mb-2">Preview (Dry Run)</h4>
+                <p className="text-sm text-muted-foreground mb-4">
+                  These endpoints will be registered when you submit:
+                </p>
+                <div className="max-h-64 overflow-auto space-y-2">
+                  {result.resources.slice(0, 10).map((resource, idx) => (
+                    <div
+                      key={idx}
+                      className="flex items-center gap-2 p-2 bg-muted rounded text-xs"
+                    >
+                      <span className="font-mono font-semibold text-primary">
+                        {resource.method}
+                      </span>
+                      <span className="font-mono flex-1 truncate">
+                        {resource.url}
+                      </span>
+                    </div>
+                  ))}
+                  {result.resources.length > 10 && (
+                    <p className="text-xs text-muted-foreground text-center">
+                      ... and {result.resources.length - 10} more
+                    </p>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* Registration Results */}
+            {!result.dryRun && result.results && (
+              <div className="border rounded-md p-4">
+                <div className="flex items-center justify-between mb-4">
+                  <h4 className="font-semibold">Registration Results</h4>
+                  <Dialog>
+                    <DialogTrigger asChild>
+                      <Button variant="ghost" size="sm">
+                        View Details
+                      </Button>
+                    </DialogTrigger>
+                    <DialogContent className="max-w-3xl max-h-[80vh] overflow-auto">
+                      <DialogHeader>
+                        <DialogTitle>Detailed Results</DialogTitle>
+                        <DialogDescription>
+                          Registration results for all endpoints
+                        </DialogDescription>
+                      </DialogHeader>
+                      <div className="space-y-2">
+                        {result.results.map((res, idx) => (
+                          <div
+                            key={idx}
+                            className="flex items-start gap-2 p-3 border rounded"
+                          >
+                            {res.success ? (
+                              <CheckCircle2 className="size-4 text-green-600 mt-0.5 shrink-0" />
+                            ) : (
+                              <AlertTriangle className="size-4 text-red-600 mt-0.5 shrink-0" />
+                            )}
+                            <div className="flex-1 min-w-0">
+                              <div className="flex gap-2 items-center mb-1">
+                                <span className="font-mono font-semibold text-xs text-primary">
+                                  {res.method}
+                                </span>
+                                <span className="font-mono text-xs truncate">
+                                  {res.url}
+                                </span>
+                              </div>
+                              {res.summary && (
+                                <p className="text-xs text-muted-foreground">
+                                  {res.summary}
+                                </p>
+                              )}
+                              {res.error && (
+                                <p className="text-xs text-red-600 mt-1">
+                                  {res.error}
+                                </p>
+                              )}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </DialogContent>
+                  </Dialog>
+                </div>
+                <div className="space-y-2 max-h-48 overflow-auto">
+                  {result.results
+                    .filter(r => !r.success)
+                    .slice(0, 5)
+                    .map((res, idx) => (
+                      <div
+                        key={idx}
+                        className="flex items-center gap-2 p-2 bg-red-600/10 border border-red-600/20 rounded text-xs"
+                      >
+                        <AlertTriangle className="size-4 text-red-600 shrink-0" />
+                        <div className="flex-1 min-w-0">
+                          <div className="font-mono truncate">{res.url}</div>
+                          {res.error && (
+                            <div className="text-muted-foreground">
+                              {res.error}
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                </div>
+              </div>
+            )}
+
+            {result.dryRun && (
+              <div className="bg-yellow-600/10 border border-yellow-600/20 rounded-md p-3 flex items-start gap-2">
+                <AlertTriangle className="size-5 text-yellow-600 shrink-0 mt-0.5" />
+                <div>
+                  <p className="font-semibold text-sm">Dry Run Mode</p>
+                  <p className="text-xs text-muted-foreground">
+                    Uncheck "Dry Run" and submit again to actually register
+                    these resources.
+                  </p>
+                </div>
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-1">
+              <Label>Base URL</Label>
+              <Input
+                type="url"
+                placeholder="https://api.example.com"
+                value={baseUrl}
+                onChange={e => setBaseUrl(e.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">
+                The base URL where your API is hosted
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-1">
+              <Label>OpenAPI Specification</Label>
+              <Textarea
+                placeholder='Paste your OpenAPI 3.x spec here (JSON or YAML)...'
+                value={spec}
+                onChange={e => setSpec(e.target.value)}
+                className="font-mono text-xs min-h-[300px]"
+              />
+              <p className="text-xs text-muted-foreground">
+                Supports OpenAPI 3.0 and 3.1 in JSON or YAML format
+              </p>
+            </div>
+
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="dryRun"
+                checked={dryRun}
+                onCheckedChange={checked => setDryRun(checked as boolean)}
+              />
+              <label
+                htmlFor="dryRun"
+                className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+              >
+                Dry run (preview endpoints without registering)
+              </label>
+            </div>
+          </div>
+        )}
+      </CardContent>
+      <CardFooter className="gap-2">
+        {result ? (
+          <>
+            {result.dryRun ? (
+              <>
+                <Button variant="outline" onClick={handleReset} className="flex-1">
+                  Cancel
+                </Button>
+                <Button
+                  variant="turbo"
+                  onClick={() => {
+                    setDryRun(false);
+                    setResult(null);
+                  }}
+                  className="flex-1"
+                >
+                  Register All Endpoints
+                </Button>
+              </>
+            ) : (
+              <Button variant="turbo" onClick={handleReset} className="w-full">
+                Register Another
+              </Button>
+            )}
+          </>
+        ) : (
+          <Button
+            variant="turbo"
+            disabled={isPending || !isValidUrl || !isValidSpec}
+            onClick={handleSubmit}
+            className="w-full"
+          >
+            {isPending ? 'Processing...' : dryRun ? 'Preview Endpoints' : 'Register All'}
+          </Button>
+        )}
+      </CardFooter>
+    </Card>
+  );
+};

--- a/src/app/(home)/resources/register/page.tsx
+++ b/src/app/(home)/resources/register/page.tsx
@@ -1,5 +1,6 @@
 import { Body, Heading } from '@/app/_components/layout/page-utils';
 import { RegisterResourceForm } from './_components/form';
+import { OpenAPIUploadForm } from './_components/openapi-form';
 import { OutputSchema } from './_components/schema';
 
 export default function RegisterResourcePage() {
@@ -7,11 +8,14 @@ export default function RegisterResourcePage() {
     <div>
       <Heading
         title="Register Resource"
-        description="Add a resource to be tracked by x402scan."
+        description="Add resources to be tracked by x402scan."
       />
       <Body>
-        <RegisterResourceForm />
-        <OutputSchema />
+        <div className="space-y-8">
+          <RegisterResourceForm />
+          <OpenAPIUploadForm />
+          <OutputSchema />
+        </div>
       </Body>
     </div>
   );

--- a/src/app/api/v1/resources/register-from-openapi/route.ts
+++ b/src/app/api/v1/resources/register-from-openapi/route.ts
@@ -1,0 +1,134 @@
+import { NextRequest, NextResponse } from 'next/server';
+import z from 'zod';
+import { parseOpenAPISpec, constructResourceUrl } from '@/services/openapi-parser';
+
+const inputSchema = z.object({
+  baseUrl: z.string().url('Base URL must be a valid URL'),
+  spec: z.union([
+    z.string().min(1, 'Spec cannot be empty'),
+    z.object({}).passthrough(),
+  ]),
+  dryRun: z.boolean().optional().default(false),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const parseResult = inputSchema.safeParse(body);
+
+    if (!parseResult.success) {
+      return NextResponse.json(
+        {
+          error: true,
+          type: 'validation',
+          message: 'Invalid input',
+          issues: parseResult.error.issues,
+        },
+        { status: 400 }
+      );
+    }
+
+    const { baseUrl, spec, dryRun } = parseResult.data;
+
+    // Parse the OpenAPI spec
+    let parsedSpec;
+    try {
+      parsedSpec = await parseOpenAPISpec(spec);
+    } catch (error) {
+      return NextResponse.json(
+        {
+          error: true,
+          type: 'parsing',
+          message: error instanceof Error ? error.message : 'Failed to parse OpenAPI spec',
+        },
+        { status: 400 }
+      );
+    }
+
+    // Build resource URLs from endpoints
+    const resources = parsedSpec.endpoints.map(endpoint => ({
+      url: constructResourceUrl(baseUrl, endpoint.path),
+      method: endpoint.method,
+      operationId: endpoint.operationId,
+      summary: endpoint.summary,
+      description: endpoint.description,
+    }));
+
+    // If dry run, just return what would be registered
+    if (dryRun) {
+      return NextResponse.json({
+        success: true,
+        dryRun: true,
+        info: parsedSpec.info,
+        totalEndpoints: resources.length,
+        resources,
+      });
+    }
+
+    // Register each resource using the existing endpoint
+    const registrationResults = [];
+    
+    for (let i = 0; i < resources.length; i++) {
+      const resource = resources[i];
+      
+      // Add delay between requests to avoid overwhelming Neon database
+      if (i > 0) {
+        await new Promise(resolve => setTimeout(resolve, 1000)); // 1 second delay
+      }
+      
+      try {
+        const response = await fetch(
+          new URL('/api/v1/resources/register', request.nextUrl.origin),
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ 
+              url: resource.url,
+            }),
+          }
+        );
+
+        const result = await response.json();
+        
+        registrationResults.push({
+          url: resource.url,
+          method: resource.method,
+          operationId: resource.operationId,
+          summary: resource.summary,
+          success: !result.error,
+          result,
+        });
+      } catch (error) {
+        registrationResults.push({
+          url: resource.url,
+          method: resource.method,
+          operationId: resource.operationId,
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    const successCount = registrationResults.filter(r => r.success).length;
+    const failedCount = registrationResults.filter(r => !r.success).length;
+
+    return NextResponse.json({
+      success: true,
+      info: parsedSpec.info,
+      totalEndpoints: resources.length,
+      registered: successCount,
+      failed: failedCount,
+      results: registrationResults,
+    });
+  } catch (error) {
+    console.error('Error processing OpenAPI spec:', error);
+    return NextResponse.json(
+      {
+        error: true,
+        type: 'server',
+        message: error instanceof Error ? error.message : 'Internal server error',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { CheckIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/src/services/openapi-parser.ts
+++ b/src/services/openapi-parser.ts
@@ -1,0 +1,113 @@
+import SwaggerParser from '@apidevtools/swagger-parser';
+import type { OpenAPIV3, OpenAPIV3_1 } from 'openapi-types';
+
+export interface ParsedEndpoint {
+  path: string;
+  method: string;
+  operationId?: string;
+  summary?: string;
+  description?: string;
+  parameters?: (OpenAPIV3.ParameterObject | OpenAPIV3_1.ParameterObject)[];
+  requestBody?: OpenAPIV3.RequestBodyObject | OpenAPIV3_1.RequestBodyObject;
+  responses?: OpenAPIV3.ResponsesObject | OpenAPIV3_1.ResponsesObject;
+}
+
+export interface ParsedOpenAPISpec {
+  info: {
+    title?: string;
+    version?: string;
+    description?: string;
+  };
+  servers?: string[];
+  endpoints: ParsedEndpoint[];
+}
+
+export async function parseOpenAPISpec(
+  spec: string | object
+): Promise<ParsedOpenAPISpec> {
+  try {
+    // If spec is a string, try to parse it as JSON first
+    let specObj: any;
+    if (typeof spec === 'string') {
+      try {
+        specObj = JSON.parse(spec);
+      } catch {
+        // If not JSON, assume it's YAML and let swagger-parser handle it
+        specObj = spec;
+      }
+    } else {
+      specObj = spec;
+    }
+
+    // Parse and validate the OpenAPI spec
+    const api = (await SwaggerParser.validate(specObj)) as 
+      OpenAPIV3.Document | OpenAPIV3_1.Document;
+    
+    const parsedEndpoints: ParsedEndpoint[] = [];
+
+    if (!api.paths) {
+      throw new Error('No paths found in OpenAPI spec');
+    }
+
+    // Extract server URLs
+    const servers = api.servers?.map(server => server.url) || [];
+
+    // Extract all endpoints
+    for (const [path, pathItem] of Object.entries(api.paths)) {
+      if (!pathItem) continue;
+
+      const methods: Array<keyof OpenAPIV3.PathItemObject> = [
+        'get',
+        'post',
+        'put',
+        'delete',
+        'patch',
+        'options',
+        'head',
+        'trace',
+      ];
+
+      for (const method of methods) {
+        const operation = pathItem[method] as 
+          OpenAPIV3.OperationObject | OpenAPIV3_1.OperationObject | undefined;
+        
+        if (!operation) continue;
+
+        parsedEndpoints.push({
+          path,
+          method: method.toUpperCase(),
+          operationId: operation.operationId,
+          summary: operation.summary,
+          description: operation.description,
+          parameters: operation.parameters as any,
+          requestBody: operation.requestBody as any,
+          responses: operation.responses,
+        });
+      }
+    }
+
+    return {
+      info: {
+        title: api.info.title,
+        version: api.info.version,
+        description: api.info.description,
+      },
+      servers,
+      endpoints: parsedEndpoints,
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to parse OpenAPI spec: ${errorMessage}`);
+  }
+}
+
+// Helper to construct full URL from base URL and path
+export function constructResourceUrl(baseUrl: string, path: string): string {
+  // Remove trailing slash from baseUrl
+  const cleanBaseUrl = baseUrl.replace(/\/$/, '');
+  
+  // Ensure path starts with /
+  const cleanPath = path.startsWith('/') ? path : `/${path}`;
+  
+  return `${cleanBaseUrl}${cleanPath}`;
+}


### PR DESCRIPTION
Features:
- Parse OpenAPI 3.0/3.1 specifications (JSON/YAML)
- New /api/v1/resources/register-from-openapi endpoint
- UI component for uploading/pasting OpenAPI specs
- Dry run mode to preview endpoints before registration
- Batch registration with rate limiting (1s delay between requests)
- Detailed success/failure reporting for each endpoint
- Added required dependencies and UI components

Usage:
Users can now paste their OpenAPI spec and base URL to register all API endpoints at once, instead of one at a time.

Resolves #97