### PR TITLE
Removed the duplicated "Resources" tab from the UI.

### DIFF
--- a/src/app/(home)/layout.tsx
+++ b/src/app/(home)/layout.tsx
@@ -25,11 +25,6 @@ export default function HomeLayout({
               ]
             : []),
           {
-            label: 'Resources',
-            href: '/resources',
-            subRoutes: ['/resources/register'],
-          },
-          {
             label: 'Transactions',
             href: '/transactions',
           },


### PR DESCRIPTION
The tab appeared twice. I guess it was a mismanaged merge conflict :)