### PR TITLE
Removed duplicate resource tab entry from home page layout

### DIFF
--- a/src/app/(home)/layout.tsx
+++ b/src/app/(home)/layout.tsx
@@ -42,11 +42,6 @@ export default function HomeLayout({
             href: '/networks',
           },
           {
-            label: 'Resources',
-            href: '/resources',
-            subRoutes: ['/resources/register'],
-          },
-          {
             label: 'Ecosystem',
             href: '/ecosystem',
           },


### PR DESCRIPTION
<img width="1242" height="319" alt="image" src="https://github.com/user-attachments/assets/d8b2209b-7ed9-42c3-9d1a-f61977b447b4" />

Solves #153  