### PR TITLE
feat: reworked resources field rendering 

### DIFF
--- a/src/app/_components/resources/executor/form.tsx
+++ b/src/app/_components/resources/executor/form.tsx
@@ -127,14 +127,16 @@ function FieldSection({
 
   return (
     <div className="space-y-3">
+      <h3 className="text-sm font-medium">
+        {title}
+        {hasRequired && (
+          <span className="ml-1 text-xs text-muted-foreground">
+            (Required)
+          </span>
+        )}
+      </h3>
       {hasRequired && (
         <>
-          <h3 className="text-sm font-medium">
-            {title}
-            <span className="ml-1 text-xs text-muted-foreground">
-              (Required)
-            </span>
-          </h3>
           {requiredFields.map(field => (
             <FieldRow
               key={`${prefix}-${field.name}`}


### PR DESCRIPTION
Improved resources field rendering

1. required and optional parameters are now sorted. required parameteres come at top
2. for optional parameters, we collapse them by default


<img width="1142" height="392" alt="image" src="https://github.com/user-attachments/assets/9ad02142-4186-4d7b-a5c4-71f83997398a" />


<img width="1137" height="801" alt="image" src="https://github.com/user-attachments/assets/9fd894a0-937f-4a05-84f0-6ec189d92bf7" />

resolves #107

first and third points are addressed. second point already addressed in this pr: https://github.com/Merit-Systems/x402scan/pull/119