### PR TITLE
fix: creating agents with one resource

### DIFF
--- a/scan/src/app/composer/agents/new/page.tsx
+++ b/scan/src/app/composer/agents/new/page.tsx
@@ -4,7 +4,6 @@ import { CreateAgentForm } from '../../_components/new-agent/form';
 import { auth } from '@/auth';
 import z from 'zod';
 
-
 const initialResourceIdsSchema = z
   .union([z.uuid(), z.array(z.uuid())])
   .transform(value => (Array.isArray(value) ? value : [value]))
@@ -16,8 +15,6 @@ export default async function NewAgentPage({
   const { resources } = await searchParams;
 
   const initialResourceIds = initialResourceIdsSchema.safeParse(resources);
-
-  console.log('initialResourceIds', initialResourceIds);
 
   const session = await auth();
 


### PR DESCRIPTION
Problem: When you pass a single resource in the URL (?resources=single-id), Next.js treats it as a string. But when you pass multiple resources (?resources=id1&resources=id2), Next.js automatically converts it to an array. The Zod validation z.array(z.uuid()) expected an array, causing it to fail with a single resource.

Solution: Accept both types