### PR TITLE
feat: add Mart.fun treasury address to PayAI facilitator

### DIFF
--- a/packages/facilitators/src/facilitators/payai.ts
+++ b/packages/facilitators/src/facilitators/payai.ts
@@ -28,6 +28,12 @@ export const payaiFacilitator = {
         tokens: [USDC_SOLANA_TOKEN],
         dateOfFirstTransaction: new Date('2025-07-01'),
       },
+      {
+        // Mart.fun treasury address for tracking revenue
+        address: 'AHbUXPpSKGzxkD9L3ynbvcdHVGf6LxhaMRg68hx8DpuJ',
+        tokens: [USDC_SOLANA_TOKEN],
+        dateOfFirstTransaction: new Date('2025-11-02'),
+      },
     ],
     [Network.BASE]: [
       {


### PR DESCRIPTION
Adds the Mart.fun treasury address to the PayAI facilitator configuration to enable transaction tracking on x402scan.

## Changes
- Added Solana treasury address: `AHbUXPpSKGzxkD9L3ynbvcdHVGf6LxhaMRg68hx8DpuJ`
- Set start date: November 2, 2025
- Enables tracking of transactions from https://mart.fun

## Validation
- ✅ Build passes (`pnpm run build`)
- ✅ TypeScript types compile successfully

## Related Resources
- Platform: https://mart.fun
- API: https://api.mart.fun
- Treasury (Solscan): https://solscan.io/address/AHbUXPpSKGzxkD9L3ynbvcdHVGf6LxhaMRg68hx8DpuJ

# NOTE: DELETE THIS TEMPLATE IF YOU ARE NOT ADDING A NEW FACILITATOR

# Add Facilitator

## Summary
- Faciliator Name: `<Name>`
- URL: `<https://...>`
- Website: `<https://...>`
- Twitter: `<@handle>`
- Short description: `<what the facilitator does in 1 to 2 sentences>`

## Required changes
- [ ] Added config file at `packages/facilitators/src/facilitators`
- [ ] Exported in `packages/facilitators/src/facilitators/index.ts`
- [ ] Appended to `packages/facilitators/src/lists/all.ts`
- [ ] Chose a **new unique color** not used by other facilitators
- [ ] Updated `README.md` with a one-line entry under Facilitators
- [ ] `dateOfFirstTransaction` is correct and matches on-chain history
- [ ] Facilitator has **at least 10 USDC transfers**
- [ ] Added image to `apps/scan/public`
- [ ] Make sure we support that chain
- [ ] Make sure all EVM addresses are lowercase
