### PR TITLE
Add Onchain to Ecosystem Page

### DIFF
--- a/apps/scan/src/lib/ecosystem/list.ts
+++ b/apps/scan/src/lib/ecosystem/list.ts
@@ -151,7 +151,7 @@ export const ecosystemItems: EcosystemItem[] = [
   {
     name: 'Onchain',
     description:
-      'Onchain is x402\'s Intelligent Intermediary Layer for Aggregating Facilitators.',
+      "Onchain is x402's Intelligent Intermediary Layer for Aggregating Facilitators.",
     logoUrl: 'https://www.x402.org/logos/onchain.png',
     websiteUrl: 'https://onchain.fi',
     category: 'Services/Endpoints',


### PR DESCRIPTION
## Description

Adds Onchain to the x402scan ecosystem list under the **Services/Endpoints** category.

## What is Onchain?

Onchain is x402's intelligent intermediary layer that aggregates multiple facilitators (Coinbase CDP, x402.rs, Daydreams, Aurracloud, etc) into a single API integration with automatic failover and smart routing.

## Changes Made

- Added Onchain entry to `src/lib/ecosystem/list.ts`
- Category: `Services/Endpoints`
- Logo: References existing `https://www.x402.org/logos/onchain.png`
- Website: `https://onchain.fi`

## Why This Matters

Onchain reduces integration complexity for x402 developers by providing a single API that routes across multiple facilitators, increasing reliability and removing vendor lock-in.

**Live on Base mainnet with progressive multi-network expansion.**

## Checklist

- [x] Added to ecosystem list
- [x] Logo URL verified and accessible
- [x] Website live at https://onchain.fi
- [x] Category matches project type
- [x] Description is clear and concise