### PR TITLE
fix: support shared OG images across different origins

### DIFF
--- a/apps/scan/prisma/migrations/20251106190535_remove_unique_constraint_from_og/migration.sql
+++ b/apps/scan/prisma/migrations/20251106190535_remove_unique_constraint_from_og/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "public"."OgImage_url_key";

--- a/apps/scan/prisma/schema.prisma
+++ b/apps/scan/prisma/schema.prisma
@@ -206,7 +206,7 @@ model ResourceRequestMetadata {
 model OgImage {
   id          String  @id @default(uuid())
   originId    String
-  url         String  @unique
+  url         String
   height      Int?
   width       Int?
   title       String?


### PR DESCRIPTION
OG Image Uniqueness Fix

fixes #287 

Removed global `@unique` constraint from `OgImage.url` to allow multiple origins to share the same OG image URL. Refactored `upsertOrigin()` from nested upsert to explicit transaction using composite key `[originId, url]` for per-origin uniqueness.

**Changes:**
- Schema: Dropped `@unique` on `url` field, kept `@@unique([originId, url])`
- Code: Split into transaction - first upsert origin to get `originId`, then upsert OG images with composite key
- Migration: `DROP INDEX "OgImage_url_key"`