### PR TITLE
Add Polygon support to Ultravioleta DAO facilitator

### DIFF
--- a/packages/external/facilitators/src/facilitators/ultravioletadao.ts
+++ b/packages/external/facilitators/src/facilitators/ultravioletadao.ts
@@ -1,5 +1,9 @@
 import { Network } from '../types';
-import { USDC_BASE_TOKEN, USDC_SOLANA_TOKEN } from '../constants';
+import {
+  USDC_BASE_TOKEN,
+  USDC_SOLANA_TOKEN,
+  USDC_POLYGON_TOKEN,
+} from '../constants';
 
 import type { Facilitator, FacilitatorConfig } from '../types';
 
@@ -27,6 +31,13 @@ export const ultravioletadaoFacilitator = {
         address: '0x103040545ac5031a11e8c03dd11324c7333a13c7',
         tokens: [USDC_BASE_TOKEN],
         dateOfFirstTransaction: new Date('2025-10-30'),
+      },
+    ],
+    [Network.POLYGON]: [
+      {
+        address: '0x103040545ac5031a11e8c03dd11324c7333a13c7',
+        tokens: [USDC_POLYGON_TOKEN],
+        dateOfFirstTransaction: new Date('2025-11-09'),
       },
     ],
     [Network.SOLANA]: [


### PR DESCRIPTION
## Summary
- Add Polygon network support to Ultravioleta DAO facilitator
- Configure USDC transfers on Polygon using address `0x103040545ac5031a11e8c03dd11324c7333a13c7`
- Set first transaction date to 2025-11-09

## Changes
- Import `USDC_POLYGON_TOKEN` token configuration
- Add Polygon chain configuration with same facilitator address as Base network
- Enable USDC transfers on Polygon blockchain

## Technical Details
- Facilitator address: `0x103040545ac5031a11e8c03dd11324c7333a13c7`
- Token: USDC on Polygon
- Sync start date: 2025-11-09
- Modified file: `packages/facilitators/src/facilitators/ultravioletadao.ts`