### PR TITLE
fix: preserve content-encoding in proxy (issue #328 #339)

### DIFF
--- a/apps/proxy/src/routes/proxy.ts
+++ b/apps/proxy/src/routes/proxy.ts
@@ -7,7 +7,6 @@ import { randomUUID } from 'crypto';
 import type { Context } from 'hono';
 
 const RESPONSE_HEADER_BLOCKLIST = new Set([
-  'content-encoding',
   'transfer-encoding',
   'content-length',
 ]);


### PR DESCRIPTION
### Summary

This PR addresses [#328](https://github.com/Merit-Systems/x402scan/issues/328) [#339](https://github.com/Merit-Systems/x402scan/issues/339).

When using the `x402` proxy to call compressed JSON APIs, browsers sometimes see garbled response bodies instead of valid JSON. This happens because the proxy removes the `Content-Encoding` response header while streaming the original (still compressed) body.

This PR preserves the upstream `Content-Encoding` header so that browsers can correctly decompress and parse the response.

### Background / Reproduction

- Proxy endpoint:  
  `https://proxy.x402scan.com/api/proxy`

- Example usage (simplified):

  ```text
  https://proxy.x402scan.com/api/proxy?url=<URL_ENCODED_TARGET>&share_data=true
  ```

  where `<URL_ENCODED_TARGET>` might be something like:

  ```text
  https%3A%2F%2Fapi.example.com%2Fmint%2Fdynamic%3Famount%3D100
  ```

- Upstream API responds with:

  - `Content-Type: application/json`
  - `Content-Encoding: zstd` (or another compression algorithm)
  - Body: valid JSON when decompressed, e.g. `{"success": true}`

- In the browser devtools, the proxied response body sometimes appears as:

  ```text
  (�/�X�{"success":true}
  ```

  which is clearly compressed bytes being rendered as text.

### Root cause

- File: [apps/proxy/src/routes/proxy.ts](cci:7://file:///Users/wang/workspace/projects/hacker/x402/x402scan/apps/proxy/src/routes/proxy.ts:0:0-0:0)
- The proxy currently defines:

  ```ts
  const RESPONSE_HEADER_BLOCKLIST = new Set([
    'content-encoding',
    'transfer-encoding',
    'content-length',
  ]);
  ```

- When forwarding the upstream response, it streams `upstreamResponse.body` directly:

  ```ts
  return new Response(upstreamResponse.body, {
    status: upstreamResponse.status,
    statusText: upstreamResponse.statusText,
    headers: responseHeaders,
  });
  ```

- The body is not modified by the proxy, but `Content-Encoding` is removed from the headers.  
  As a result, browsers assume the body is plain text and do not decompress it, which leads to the garbled output.

### Changes

- In [apps/proxy/src/routes/proxy.ts](cci:7://file:///Users/wang/workspace/projects/hacker/x402/x402scan/apps/proxy/src/routes/proxy.ts:0:0-0:0), update the response header blocklist to **stop removing `content-encoding`**:

  ```ts
  const RESPONSE_HEADER_BLOCKLIST = new Set([
    'transfer-encoding',
    'content-length',
  ]);
  ```

- We still block:
  - `transfer-encoding` — to avoid inconsistent chunking metadata when proxying.
  - `content-length` — to avoid mismatches between advertised and actual body length when streaming.

- The proxy continues to act as a streaming, mostly-transparent CORS proxy: it forwards the upstream body as-is and preserves the encoding information so the browser can handle decompression.

- **Before** this change:
  - The response body in devtools may look like compressed gibberish (e.g. `(�/�X�{"success":true}`).

- **After** this change:
  - The browser correctly decompresses the body.
  - The devtools response tab shows valid JSON (e.g. `{"success": true}`).