### PR TITLE
bring back prefetching of links

### DIFF
--- a/apps/scan/src/app/(home)/(overview)/_components/top-facilitators/_components/card.tsx
+++ b/apps/scan/src/app/(home)/(overview)/_components/top-facilitators/_components/card.tsx
@@ -26,7 +26,7 @@ export const FacilitatorCard: React.FC<Props> = ({ facilitator, stats }) => {
   const { chain } = useChain();
 
   return (
-    <Link href={`/facilitator/${facilitator.id}`} prefetch={false}>
+    <Link href={`/facilitator/${facilitator.id}`}>
       <Card className="grid grid-cols-1 md:grid-cols-7 hover:border-primary hover:bg-card/80 transition-colors">
         <div className="flex flex-col col-span-5">
           <div className="flex items-center gap-2 p-4">

--- a/apps/scan/src/app/(home)/facilitators/_components/facilitators/columns.tsx
+++ b/apps/scan/src/app/(home)/facilitators/_components/facilitators/columns.tsx
@@ -37,7 +37,6 @@ export const columns: ExtendedColumnDef<ColumnType>[] = [
     cell: ({ row }) => (
       <Link
         href={`/facilitator/${row.original.facilitator_id}`}
-        prefetch={false}
         className="flex items-center gap-1"
       >
         <Image

--- a/apps/scan/src/app/(home)/resources/(overview)/_components/carousel/origin-card/index.tsx
+++ b/apps/scan/src/app/(home)/resources/(overview)/_components/carousel/origin-card/index.tsx
@@ -28,11 +28,7 @@ export const OriginCard: React.FC<Props> = ({ origin }) => {
     origin.origins.find(o => o.favicon) ?? origin.origins[0]!;
 
   return (
-    <Link
-      href={`/server/${originWithMetadata.id}`}
-      prefetch={false}
-      className="h-full"
-    >
+    <Link href={`/server/${originWithMetadata.id}`} className="h-full">
       <Card className="h-full flex flex-col hover:border-primary transition-colors cursor-pointer group">
         <div className="flex flex-row items-start gap-2 flex-1">
           <CardHeader className="w-full overflow-hidden p-3">

--- a/apps/scan/src/app/@breadcrumbs/_components/breadcrumb.tsx
+++ b/apps/scan/src/app/@breadcrumbs/_components/breadcrumb.tsx
@@ -39,13 +39,12 @@ export const Breadcrumb = <T extends string>({
       href={href}
       className={cn(disabled && 'pointer-events-none', className)}
       aria-disabled={disabled}
-      prefetch={false}
     >
       <div className="flex items-center gap-2 cursor-pointer min-w-0">
         {(Fallback !== null || image !== null) && (
           <Avatar
             className={cn(
-              'rounded-md overflow-hidden bg-card size-5 flex-shrink-0',
+              'rounded-md overflow-hidden bg-card size-5 shrink-0',
               mobileHideImage && 'hidden md:block'
             )}
           >

--- a/apps/scan/src/app/_components/error/card.tsx
+++ b/apps/scan/src/app/_components/error/card.tsx
@@ -33,7 +33,7 @@ export const ErrorCard: React.FC<ErrorComponentProps> = ({
               Reset
             </Button>
           ) : (
-            <Link href="/" className="flex-1" prefetch={false}>
+            <Link href="/" className="flex-1">
               <Button variant="outline" className="w-full">
                 Back to Home
               </Button>

--- a/apps/scan/src/app/_components/layout/nav/index.tsx
+++ b/apps/scan/src/app/_components/layout/nav/index.tsx
@@ -68,7 +68,6 @@ export const Nav = <T extends string>({ tabs }: Props<T>) => {
                     buttonRefs[index] = el;
                   }
                 }}
-                prefetch={false}
               >
                 <MotionTab href={tab.href} subRoutes={tab.subRoutes}>
                   <span className="flex items-center gap-2 whitespace-nowrap">

--- a/apps/scan/src/app/_components/layout/page-utils.tsx
+++ b/apps/scan/src/app/_components/layout/page-utils.tsx
@@ -141,7 +141,7 @@ export const Section = <T extends string>({
       <div className="flex flex-col gap-1">
         <div className="flex justify-between items-center">
           {href ? (
-            <Link href={href} prefetch={false}>
+            <Link href={href}>
               <Header />
             </Link>
           ) : (

--- a/apps/scan/src/app/_components/origins.tsx
+++ b/apps/scan/src/app/_components/origins.tsx
@@ -45,7 +45,7 @@ export const Origins: React.FC<Props> = ({
   if (origins.length === 1) {
     const origin = origins[0];
     return (
-      <Link href={`/server/${origin!.id}`} prefetch={false}>
+      <Link href={`/server/${origin!.id}`}>
         <OriginsContainer
           Icon={({ className }) => (
             <Favicon url={origin!.favicon} className={className} />
@@ -78,7 +78,7 @@ export const Origins: React.FC<Props> = ({
       )}
       title={
         <>
-          <Link href={`/server/${origins[0]!.id}`} prefetch={false}>
+          <Link href={`/server/${origins[0]!.id}`}>
             <span className="truncate">
               {new URL(origins[0]!.origin).hostname}
             </span>

--- a/apps/scan/src/app/_components/seller.tsx
+++ b/apps/scan/src/app/_components/seller.tsx
@@ -39,7 +39,7 @@ export const Seller: React.FC<Props> = ({
 
   if (!origins || origins.length === 0) {
     return (
-      <Link href={`/recipient/${address}`} prefetch={false}>
+      <Link href={`/recipient/${address}`}>
         <Address
           address={address}
           className={cn('text-xs font-medium', addressClassName)}

--- a/apps/scan/src/app/layout.tsx
+++ b/apps/scan/src/app/layout.tsx
@@ -147,7 +147,7 @@ export default async function RootLayout({
                         >
                           <div className="min-h-screen flex flex-col relative">
                             <LogoContainer>
-                              <Link href="/" prefetch={false}>
+                              <Link href="/">
                                 <Logo className="size-full aspect-square" />
                               </Link>
                             </LogoContainer>

--- a/apps/scan/src/app/recipient/[address]/(overview)/_components/header/buttons.tsx
+++ b/apps/scan/src/app/recipient/[address]/(overview)/_components/header/buttons.tsx
@@ -14,7 +14,7 @@ export const HeaderButtons: React.FC<Props> = ({ hasOrigins, address }) => {
   return (
     <ButtonsContainer>
       {hasOrigins && (
-        <Link href={`/recipient/${address}/resources`} prefetch={false}>
+        <Link href={`/recipient/${address}/resources`}>
           <Button variant="turbo">
             <TestTubeDiagonal className="size-4" />
             Try Resources

--- a/apps/scan/src/app/server/[id]/(overview)/_components/header/buttons.tsx
+++ b/apps/scan/src/app/server/[id]/(overview)/_components/header/buttons.tsx
@@ -99,7 +99,6 @@ export const HeaderButtons: React.FC<Props> = ({ origin }) => {
                 resources: resources.map(resource => resource.id),
               },
             }}
-            prefetch={false}
           >
             {createAgentButton}
           </Link>
@@ -114,13 +113,13 @@ export const HeaderButtons: React.FC<Props> = ({ origin }) => {
 export const LoadingHeaderButtons = () => {
   return (
     <ButtonsContainer>
-      <Link href={`/composer/chat`} prefetch={false}>
+      <Link href={`/composer/chat`}>
         <Button variant="turbo">
           <MessagesSquare className="size-4" />
           Try in Chat
         </Button>
       </Link>
-      <Link href={`/resources/register`} prefetch={false}>
+      <Link href={`/resources/register`}>
         <Button variant="outline">
           <Bot className="size-4" />
           Create Agent


### PR DESCRIPTION
Turned off when hydration boundary inside of suspense wasnt solved. Can bring this back. Makes navgation much snappier