### PR TITLE
Prevent developer page tests from affecting resource health metrics

### DIFF
--- a/apps/scan/src/app/_components/resource-fetch/chains/evm.tsx
+++ b/apps/scan/src/app/_components/resource-fetch/chains/evm.tsx
@@ -26,6 +26,7 @@ interface Props<TData = unknown> {
   options?: Omit<UseMutationOptions<X402FetchResponse<TData>>, 'mutationFn'>;
   isTool?: boolean;
   text?: string;
+  skipTracking?: boolean;
 }
 
 export const FetchEvm: React.FC<Props> = ({
@@ -37,6 +38,7 @@ export const FetchEvm: React.FC<Props> = ({
   options,
   isTool = false,
   text,
+  skipTracking = false,
 }) => {
   const { data: walletClient, isLoading: isLoadingWalletClient } =
     useWalletClient();
@@ -49,6 +51,7 @@ export const FetchEvm: React.FC<Props> = ({
     init: typeof requestInit === 'function' ? requestInit(chain) : requestInit,
     options,
     isTool,
+    skipTracking,
   });
 
   const { data: balance, isLoading: isLoadingBalance } = useEvmTokenBalance({

--- a/apps/scan/src/app/_components/resource-fetch/chains/svm.tsx
+++ b/apps/scan/src/app/_components/resource-fetch/chains/svm.tsx
@@ -27,6 +27,7 @@ interface Props<TData = unknown> {
   options?: Omit<UseMutationOptions<X402FetchResponse<TData>>, 'mutationFn'>;
   isTool?: boolean;
   text?: string;
+  skipTracking?: boolean;
 }
 
 export const FetchSvm: React.FC<Props> = ({
@@ -37,6 +38,7 @@ export const FetchSvm: React.FC<Props> = ({
   options,
   isTool = false,
   text,
+  skipTracking = false,
 }) => {
   const { connectedWallet } = useSolanaWallet();
 
@@ -74,6 +76,7 @@ export const FetchSvm: React.FC<Props> = ({
       options={options}
       isTool={isTool}
       text={text}
+      skipTracking={skipTracking}
     />
   );
 };
@@ -92,6 +95,7 @@ const FetchContent: React.FC<FetchContentProps> = ({
   options,
   isTool = false,
   text,
+  skipTracking = false,
 }) => {
   const { mutate: execute, isPending } = useSvmX402Fetch({
     account,
@@ -103,6 +107,7 @@ const FetchContent: React.FC<FetchContentProps> = ({
         : requestInit,
     options,
     isTool,
+    skipTracking,
   });
   const { isInitialized } = useIsInitialized();
 

--- a/apps/scan/src/app/_components/resource-fetch/index.tsx
+++ b/apps/scan/src/app/_components/resource-fetch/index.tsx
@@ -18,6 +18,7 @@ interface Props<TData = unknown> {
   options?: Omit<UseMutationOptions<X402FetchResponse<TData>>, 'mutationFn'>;
   isTool?: boolean;
   text?: string;
+  skipTracking?: boolean;
 }
 
 export const ResourceFetch: React.FC<Props> = ({
@@ -29,6 +30,7 @@ export const ResourceFetch: React.FC<Props> = ({
   options,
   isTool = false,
   text,
+  skipTracking = false,
 }) => {
   return (
     <div
@@ -48,6 +50,7 @@ export const ResourceFetch: React.FC<Props> = ({
             options={options}
             isTool={isTool}
             text={text}
+            skipTracking={skipTracking}
           />
         ) : (
           <FetchEvm
@@ -60,6 +63,7 @@ export const ResourceFetch: React.FC<Props> = ({
             options={options}
             isTool={isTool}
             text={text}
+            skipTracking={skipTracking}
           />
         )
       )}

--- a/apps/scan/src/app/_components/resources/executor/form/index.tsx
+++ b/apps/scan/src/app/_components/resources/executor/form/index.tsx
@@ -232,6 +232,7 @@ export function Form({
           onSuccess: data => setData(data),
           onError: error => setError(error),
         }}
+        skipTracking={skipTracking}
       />
 
       {error && (

--- a/apps/scan/src/app/_components/resources/executor/form/index.tsx
+++ b/apps/scan/src/app/_components/resources/executor/form/index.tsx
@@ -43,6 +43,7 @@ interface Props {
   maxAmountRequired: bigint;
   method: Methods;
   resource: string;
+  skipTracking?: boolean;
 }
 
 export function Form({
@@ -51,6 +52,7 @@ export function Form({
   maxAmountRequired,
   method,
   resource,
+  skipTracking = false,
 }: Props) {
   const queryFields = useMemo(
     () => getFields(inputSchema.queryParams),

--- a/apps/scan/src/app/_components/resources/executor/index.tsx
+++ b/apps/scan/src/app/_components/resources/executor/index.tsx
@@ -30,6 +30,7 @@ interface Props {
   hideOrigin?: boolean;
   defaultOpen?: boolean;
   isFlat?: boolean;
+  skipTracking?: boolean;
 }
 
 export const ResourceExecutor: React.FC<Props> = ({
@@ -40,6 +41,7 @@ export const ResourceExecutor: React.FC<Props> = ({
   className,
   hideOrigin = false,
   isFlat = false,
+  skipTracking = false,
 }) => {
   const { data: resourceMetrics } = api.public.resources.getMetrics.useQuery(
     {
@@ -95,6 +97,7 @@ export const ResourceExecutor: React.FC<Props> = ({
             maxAmountRequired={maxAmountRequired}
             method={bazaarMethod}
             resource={resource.resource}
+            skipTracking={skipTracking}
           />
         </AccordionContent>
       </Card>

--- a/apps/scan/src/app/_hooks/x402/evm.ts
+++ b/apps/scan/src/app/_hooks/x402/evm.ts
@@ -18,6 +18,7 @@ interface UseEvmX402FetchParams<TData = unknown> {
   init?: RequestInit;
   options?: Omit<UseMutationOptions<X402FetchResponse<TData>>, 'mutationFn'>;
   isTool?: boolean;
+  skipTracking?: boolean;
 }
 
 export const useEvmX402Fetch = <TData = unknown>({

--- a/apps/scan/src/app/_hooks/x402/svm.ts
+++ b/apps/scan/src/app/_hooks/x402/svm.ts
@@ -16,6 +16,7 @@ interface UseSvmX402FetchParams<TData = unknown> {
   init?: RequestInit;
   options?: Omit<UseMutationOptions<X402FetchResponse<TData>>, 'mutationFn'>;
   isTool?: boolean;
+  skipTracking?: boolean;
 }
 
 export const useSvmX402Fetch = <TData = unknown>({

--- a/apps/scan/src/app/_hooks/x402/use-fetch.ts
+++ b/apps/scan/src/app/_hooks/x402/use-fetch.ts
@@ -12,6 +12,7 @@ interface UseX402FetchParams<TData = unknown> {
   init?: RequestInit;
   options?: Omit<UseMutationOptions<X402FetchResponse<TData>>, 'mutationFn'>;
   isTool?: boolean;
+  skipTracking?: boolean;
 }
 
 export const useX402Fetch = <TData = unknown>({
@@ -21,11 +22,15 @@ export const useX402Fetch = <TData = unknown>({
   init,
   options,
   isTool = false,
+  skipTracking = false,
 }: UseX402FetchParams<TData>) => {
   return useMutation({
     mutationFn: async () => {
       const fetchWithPayment = wrapperFn(
-        isTool ? fetch : fetchWithProxy,
+        isTool
+          ? fetch
+          : (url: string | URL | Request, init?: RequestInit) =>
+              fetchWithProxy(url, init, { skipTracking }),
         value
       );
       const response = await fetchWithPayment(targetUrl, init);

--- a/apps/scan/src/app/developer/_components/form.tsx
+++ b/apps/scan/src/app/developer/_components/form.tsx
@@ -407,6 +407,7 @@ export const TestEndpointForm = () => {
                             }
                             hideOrigin
                             isFlat
+                            skipTracking={true}
                           />
                         ))}
                       </Accordion>

--- a/apps/scan/src/lib/x402/proxy-fetch.ts
+++ b/apps/scan/src/lib/x402/proxy-fetch.ts
@@ -4,7 +4,8 @@ const PROXY_ENDPOINT = '/api/proxy' as const;
 
 export const fetchWithProxy = async (
   input: URL | RequestInfo,
-  requestInit?: RequestInit
+  requestInit?: RequestInit,
+  options?: { skipTracking?: boolean }
 ) => {
   let url: string;
   if (input instanceof Request) {
@@ -15,6 +16,9 @@ export const fetchWithProxy = async (
   const proxyUrl = new URL(PROXY_ENDPOINT, env.NEXT_PUBLIC_PROXY_URL);
   proxyUrl.searchParams.set('url', encodeURIComponent(url));
   proxyUrl.searchParams.set('share_data', 'true');
+  if (options?.skipTracking) {
+    proxyUrl.searchParams.set('skip_tracking', 'true');
+  }
 
   const { method = 'GET', ...restInit } = requestInit ?? {};
   const normalizedMethod = method.toString().toUpperCase();

--- a/apps/scan/src/trpc/routers/developer.ts
+++ b/apps/scan/src/trpc/routers/developer.ts
@@ -4,6 +4,7 @@ import { createTRPCRouter, publicProcedure } from '../trpc';
 
 import { getOriginFromUrl } from '@/lib/url';
 import { parseX402Response } from '@/lib/x402/schema';
+import { fetchWithProxy } from '@/lib/x402/proxy-fetch';
 import { scrapeOriginData } from '@/services/scraper';
 
 export const developerRouter = createTRPCRouter({
@@ -56,15 +57,19 @@ export const developerRouter = createTRPCRouter({
     .query(async ({ input }) => {
       const { method, url, headers = {} } = input;
 
-      const response = await fetch(url, {
-        method,
-        headers:
-          method === 'POST'
-            ? { ...headers, 'Content-Type': 'application/json' }
-            : headers,
-        body: method === 'POST' ? '{}' : undefined,
-        redirect: 'follow',
-      });
+      const response = await fetchWithProxy(
+        url,
+        {
+          method,
+          headers:
+            method === 'POST'
+              ? { ...headers, 'Content-Type': 'application/json' }
+              : headers,
+          body: method === 'POST' ? '{}' : undefined,
+          redirect: 'follow',
+        },
+        { skipTracking: true }
+      );
 
       const text = await response.text();
       let body: unknown = null;


### PR DESCRIPTION
This PR adds `skip_tracking` parameter to prevent developer page endpoint tests from being recorded in analytics, ensuring they don't affect resource health status calculations.