### PR TITLE
Fix early return preventing register GET iteration

### DIFF
--- a/apps/scan/src/trpc/routers/public/resources.ts
+++ b/apps/scan/src/trpc/routers/public/resources.ts
@@ -160,10 +160,8 @@ export const resourcesRouter = createTRPCRouter({
               data: result.data,
               parseErrors: result.error.parseErrors,
             };
-            continue;
-          } else {
-            return result;
           }
+          continue;
         }
 
         return {


### PR DESCRIPTION
## Summary
- Change the else branch to continue instead of return when a non-parseResponse error occurs
- This allows the loop to try the GET method after POST fails

Fixes #412

## Test plan
- [ ] Register a resource that responds with 402 on GET but not on POST
- [ ] Verify the resource is registered successfully using the GET method