### PR TITLE
Fix link color visibility in chat messages

### DIFF
--- a/apps/scan/src/components/ai-elements/response.tsx
+++ b/apps/scan/src/components/ai-elements/response.tsx
@@ -77,6 +77,18 @@ export const Response = memo(
             <li className="ml-2 space-y-2 text-xs md:text-sm">{children}</li>
           );
         },
+        a({ children, href }) {
+          return (
+            <a
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-foreground underline hover:opacity-80"
+            >
+              {children}
+            </a>
+          );
+        },
       }}
       {...props}
     />


### PR DESCRIPTION
## Summary
- Add custom anchor component to Streamdown markdown renderer
- Uses `text-foreground` with underline instead of default blue color
- Links are now visible against blue chat bubbles

Fixes #396

## Test plan
- [ ] Send a message with a link in the chat
- [ ] Verify the link is visible against the blue user message bubble
- [ ] Verify links still work and open in new tab