### PR TITLE
Fix OgImage unique constraint conflict on resource registration

### DIFF
--- a/apps/scan/src/services/db/resources/origin.ts
+++ b/apps/scan/src/services/db/resources/origin.ts
@@ -62,13 +62,16 @@ export const upsertOrigin = async (
       description: origin.description,
       favicon: origin.favicon,
       ogImages: {
-        create: origin.ogImages.map(
+        connectOrCreate: origin.ogImages.map(
           ({ url, height, width, title, description }) => ({
-            url,
-            height,
-            width,
-            title,
-            description,
+            where: { url },
+            create: {
+              url,
+              height,
+              width,
+              title,
+              description,
+            },
           })
         ),
       },


### PR DESCRIPTION
## Summary
- Change `create` to `connectOrCreate` for ogImages in the create branch of `upsertOrigin`
- This allows multiple origins to share the same OG image URL without violating unique constraints
- Aligns the create branch behavior with the update branch which already uses upsert

Fixes #287

## Test plan
- [ ] Register Resource A with URL that has a specific OG image
- [ ] Register Resource B from a different origin that shares the same OG image URL
- [ ] Verify both registrations succeed without unique constraint errors