### PR TITLE
fix: tags were being included unnecessarily

### DIFF
--- a/apps/scan/src/services/db/resources/accepts.ts
+++ b/apps/scan/src/services/db/resources/accepts.ts
@@ -16,8 +16,6 @@ export const getAcceptsAddresses = async (input: GetAcceptsAddressesInput) => {
     include: {
       resourceRel: {
         select: {
-          _count: true,
-          tags: true,
           origin: true,
         },
       },

--- a/apps/scan/src/trpc/routers/public/resources.ts
+++ b/apps/scan/src/trpc/routers/public/resources.ts
@@ -202,23 +202,4 @@ export const resourcesRouter = createTRPCRouter({
       return await listResourceTags(input);
     }),
   },
-  getMetrics: publicProcedure
-    .input(z.object({ resourceId: z.string() }))
-    .query(async ({ input }) => {
-      return await scanDb.resourceMetrics.findFirst({
-        where: { resourceId: input.resourceId },
-        orderBy: { updatedAt: 'desc' },
-        select: {
-          uptime24hPct: true,
-          totalCount24h: true,
-          count_5xx_24h: true,
-          count_4xx_24h: true,
-          count_2xx_24h: true,
-          p50_24hMs: true,
-          p90_24hMs: true,
-          p99_24hMs: true,
-          updatedAt: true,
-        },
-      });
-    }),
 });


### PR DESCRIPTION
The WHERE clause generates SQL JOINs to filter results, regardless of whether you include that relation in the output. Here's how Prisma translates it:

**What Prisma generates for the WHERE filter:**
```sql
SELECT accepts.*, resources.origin_id, ...
FROM "Accepts" accepts
INNER JOIN "Resources" resources ON accepts."resourceId" = resources.id
WHERE EXISTS (
  SELECT 1 FROM "ResourcesTags" rt
  JOIN "Tag" t ON rt."tagId" = t.id
  WHERE rt."resourceId" = resources.id
  AND t.name IN ('tag1', 'tag2')
)
```

**The `select: { tags: true }` was additionally loading:**
```sql
-- Separate batch query triggered after main query
SELECT * FROM "ResourcesTags" WHERE "resourceId" IN ($1, $2, ..., $181)
```

The filtering (WHERE) and loading (SELECT/include) are two different operations:

| Operation | What it does | Still works? |
|-----------|--------------|--------------|
| `where: { tags: { some: ... } }` | Filters results using SQL JOINs | ✅ Yes |
| `select: { tags: true }` | Loads tag data into response | ❌ Removed (wasn't used) |