### PR TITLE
proxy body fix

### DIFF
--- a/apps/proxy/src/routes/proxy.ts
+++ b/apps/proxy/src/routes/proxy.ts
@@ -260,8 +260,8 @@ async function proxyHandler(c: Context) {
           originalBodyUsed: upstreamResponse.bodyUsed,
           originalBody: upstreamResponse.body ? 'present' : 'null',
         });
-        // If clone fails, use original for both
-        clonedUpstreamResponse = upstreamResponse;
+        // If clone fails, don't run async handler to avoid consuming the body twice
+        clonedUpstreamResponse = null;
         returnResponse = upstreamResponse;
       }
     } else {


### PR DESCRIPTION
## PR Description

### Fix: Response body stream consumed before returning to x402scan

**Problem:**
The proxy was cloning the upstream response and consuming the body stream in the async analytics handler before it could be properly returned to x402scan. This caused intermittent failures where clients received empty or corrupted responses.

**Root Cause:**
The previous implementation always cloned the response and ran async body extraction regardless of whether analytics data was needed, leading to race conditions where the stream could be consumed by the async handler before the response was sent to the client.

**Solution:**
- **Conditional cloning**: Only clone the response when `share_data=true` query param is present
- **Separate response paths**: 
  - `returnResponse` - always the original response, used for returning to client
  - `clonedUpstreamResponse` - only created when analytics are needed, used by async handler
- **Gated async handling**: Analytics extraction only runs when `shareData && clonedUpstreamResponse`

**Additional Improvements:**
- Enhanced logging throughout the request/response lifecycle for debugging stream state
- Individual try/catch blocks around each body extraction step to prevent cascading failures
- Detailed error categorization (DNS, connection, timeout, SSL, fetch errors)
- Added `.catch()` handler on ClickHouse insert to prevent unhandled rejection crashes