### PR TITLE
fix: remove gap between resource accordion items

### DIFF
--- a/apps/scan/src/app/_components/resources/origin-resources.tsx
+++ b/apps/scan/src/app/_components/resources/origin-resources.tsx
@@ -31,7 +31,7 @@ export const OriginResources: React.FC<Props> = ({
   return (
     <Accordion
       type="multiple"
-      className="border-b-0"
+      className="border-b-0 gap-0"
       defaultValue={
         defaultOpen ? resources.map(resource => resource.id) : undefined
       }

--- a/apps/scan/src/components/ui/accordion.tsx
+++ b/apps/scan/src/components/ui/accordion.tsx
@@ -6,9 +6,16 @@ import * as AccordionPrimitive from '@radix-ui/react-accordion';
 import { cn } from '@/lib/utils';
 
 function Accordion({
+  className,
   ...props
 }: React.ComponentProps<typeof AccordionPrimitive.Root>) {
-  return <AccordionPrimitive.Root data-slot="accordion" {...props} />;
+  return (
+    <AccordionPrimitive.Root
+      data-slot="accordion"
+      className={cn('flex flex-col', className)}
+      {...props}
+    />
+  );
 }
 
 function AccordionItem({


### PR DESCRIPTION
## Summary
- Update Accordion component to explicitly handle className prop with `cn()` 
- Remove default `gap-2` that was causing LHS alignment lines to not line up in the resources list
- Add `gap-0` to OriginResources accordion to ensure proper line alignment

## Test plan
- [ ] Verify resource list LHS lines align properly on /developer page
- [ ] Verify other accordions in the app still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)