### PR TITLE
Fix Cursor MCP deep link encoding on landing page

### DIFF
--- a/apps/scan/src/app/mcp/(landing-page)/_components/lib/client-select/client-install/cursor.tsx
+++ b/apps/scan/src/app/mcp/(landing-page)/_components/lib/client-select/client-install/cursor.tsx
@@ -2,17 +2,29 @@ import { Button } from '@/components/ui/button';
 
 import type { ClientInstallComponent } from '.';
 
-const cursorDeepLink = (invite?: string) => {
-  const config = {
-    command: 'npx',
-    args: ['-y', '@x402scan/mcp@latest'],
-  };
+const encodeConfig = (config: Record<string, unknown>) => {
+  const payload = JSON.stringify(config);
 
-  if (invite) {
-    config.args.push('--invite', invite);
+  if (typeof globalThis.btoa === 'function') {
+    return globalThis.btoa(payload);
   }
 
-  return `cursor://anysphere.cursor-deeplink/mcp/install?name=x402&config=${encodeURIComponent(JSON.stringify(config))}`;
+  return Buffer.from(payload, 'utf-8').toString('base64');
+};
+
+const cursorDeepLink = (invite?: string) => {
+  const command = invite
+    ? `source $HOME/.nvm/nvm.sh 2>/dev/null; exec npx -y @x402scan/mcp@latest --invite ${invite}`
+    : 'source $HOME/.nvm/nvm.sh 2>/dev/null; exec npx -y @x402scan/mcp@latest';
+
+  const config = {
+    command: '/bin/bash',
+    args: ['-c', command],
+  };
+
+  const encodedConfig = encodeConfig(config);
+
+  return `cursor://anysphere.cursor-deeplink/mcp/install?name=x402&config=${encodeURIComponent(encodedConfig)}`;
 };
 
 export const CursorInstall: ClientInstallComponent = ({ invite }) => {


### PR DESCRIPTION
### Motivation
- The Cursor one-click install link was passing a raw JSON object instead of a base64 payload and used a plain `npx` command, which caused Cursor to report invalid JSON and fail installation.
- The intent is to ensure Cursor receives a properly encoded `config` and to launch the MCP with the documented shell wrapper so the `nvm` environment is sourced before `npx` runs.

### Description
- Added `encodeConfig` helper to base64-encode the MCP `config` payload using `btoa` when available or `Buffer` fallback. 
- Changed the deep link `config` to use `"command":"/bin/bash"` with `args: ['-c', <shell-wrapper command>]` so the link runs `source $HOME/.nvm/nvm.sh 2>/dev/null; exec npx -y @x402scan/mcp@latest` (and includes `--invite` when present).
- Updated the returned Cursor deep link to embed the base64-encoded config and apply `encodeURIComponent` to the encoded string.
- Implemented the change in `apps/scan/src/app/mcp/(landing-page)/_components/lib/client-select/client-install/cursor.tsx` and committed with message `Fix Cursor MCP deep link encoding`.

### Testing
- Ran a Python decode/encode check that constructed the old and new deep links and confirmed the old decoded JSON was `{"command":"npx","args":["-y","@x402scan/mcp@latest"]}` and the new decoded JSON is `{"command":"/bin/bash","args":["-c","source $HOME/.nvm/nvm.sh 2>/dev/null; exec npx -y @x402scan/mcp@latest"]}`, and this check succeeded.
- Verified the produced new deep link matches the expected base64-encoded config string via an automated script, and the verification succeeded.
- Attempted to `curl` the Cursor badge SVG as an automated connectivity check but the request returned `403 Forbidden`, so remote badge fetch could not be validated.
- No unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6974eb79e7f083239be3b4b30b7297a8)