### PR TITLE
Add predev script to auto-build internal deps before dev

### DIFF
--- a/apps/scan/package.json
+++ b/apps/scan/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "postinstall": "cp -f ../facilitators/images/* public/ 2>/dev/null || true",
-    "predev": "pnpm --filter @x402scan/neverthrow --filter @x402scan/partners-db build",
+    "predev": "pnpm --filter @x402scan/neverthrow --filter @x402scan/partners-db --filter @x402scan/analytics-db build",
     "dev": "next dev",
     "build": "next build",
     "build:deploy": "pnpm build",


### PR DESCRIPTION
Adds a `predev` script to `apps/scan/package.json` that builds `@x402scan/neverthrow`, `@x402scan/partners-db`, and `@x402scan/analytics-db` before starting Next.js dev. pnpm runs `predev` automatically before `dev`.