### PR TITLE
fix: update npx package name for Claude Code install

### DIFF
--- a/apps/scan/src/app/mcp/(home)/install/[client]/(walkthrough)/_components/client-install/claude-code.tsx
+++ b/apps/scan/src/app/mcp/(home)/install/[client]/(walkthrough)/_components/client-install/claude-code.tsx
@@ -6,7 +6,7 @@ export const ClaudeCodeInstall: ClientInstallComponent = ({ invite }) => {
   return (
     <CopyCommand
       title="Manual Install"
-      command={`claude mcp add x402scan --scope user -- npx -y x402scan-mcp@latest${invite ? ` -- invite ${invite}` : ''}`}
+      command={`claude mcp add x402scan --scope user -- npx -y @x402scan/mcp@latest${invite ? ` -- invite ${invite}` : ''}`}
     />
   );
 };


### PR DESCRIPTION
## Summary
- Updates the Claude Code install command to use `@x402scan/mcp` instead of the old `x402scan-mcp` package name

## Test plan
- [ ] Verify the install page shows the correct command

🤖 Generated with [Claude Code](https://claude.com/claude-code)