### PR TITLE
Add KAMIYO facilitator

### DIFF
--- a/packages/external/facilitators/src/facilitators/index.ts
+++ b/packages/external/facilitators/src/facilitators/index.ts
@@ -24,3 +24,4 @@ export { openmid, openmidFacilitator } from './openmid';
 export { primer, primerFacilitator } from './primer';
 export { x402jobs, x402jobsFacilitator } from './x402jobs';
 export { openfacilitator, openfacilitatorFacilitator } from './openfacilitator';
+export { kamiyo, kamiyoFacilitator } from './kamiyo';

--- a/packages/external/facilitators/src/facilitators/kamiyo.ts
+++ b/packages/external/facilitators/src/facilitators/kamiyo.ts
@@ -1,0 +1,40 @@
+import { Network } from '../types';
+import { USDC_BASE_TOKEN, USDC_SOLANA_TOKEN } from '../constants';
+
+import type { Facilitator, FacilitatorConfig } from '../types';
+
+export const kamiyo: FacilitatorConfig = {
+  url: 'https://x402.kamiyo.ai',
+};
+
+export const kamiyoDiscovery: FacilitatorConfig = {
+  url: 'https://x402.kamiyo.ai',
+};
+
+export const kamiyoFacilitator = {
+  id: 'kamiyo',
+  metadata: {
+    name: 'KAMIYO',
+    image: 'https://kamiyo.ai/logo.png',
+    docsUrl: 'https://kamiyo.ai',
+    color: '#6366F1',
+  },
+  config: kamiyo,
+  discoveryConfig: kamiyoDiscovery,
+  addresses: {
+    [Network.SOLANA]: [
+      {
+        address: 'Cti3TCvSX1gXxR9XUWszghwETYUKFEGnuLAvMV4hsMLD',
+        tokens: [USDC_SOLANA_TOKEN],
+        dateOfFirstTransaction: new Date('2026-02-07'),
+      },
+    ],
+    [Network.BASE]: [
+      {
+        address: '0x6448D7772CF9dBd6112AE14176eE5E447A040a45',
+        tokens: [USDC_BASE_TOKEN],
+        dateOfFirstTransaction: new Date('2026-02-07'),
+      },
+    ],
+  },
+} as const satisfies Facilitator;

--- a/packages/external/facilitators/src/lists/all.ts
+++ b/packages/external/facilitators/src/lists/all.ts
@@ -24,6 +24,7 @@ import {
   primerFacilitator,
   x402jobsFacilitator,
   openfacilitatorFacilitator,
+  kamiyoFacilitator,
 } from '../facilitators';
 
 import { validateUniqueFacilitators } from './validate';
@@ -56,6 +57,7 @@ const FACILITATORS = validateUniqueFacilitators([
   primerFacilitator,
   x402jobsFacilitator,
   openfacilitatorFacilitator,
+  kamiyoFacilitator,
 ]);
 
 export const allFacilitators: Facilitator[] =


### PR DESCRIPTION
## Summary

Adds KAMIYO as a facilitator supporting Base and Solana networks.

## Details

- **Facilitator URL**: https://x402.kamiyo.ai
- **Networks**: Base, Solana
- **Assets**: USDC (ERC-20 + SPL)

| Network | Address |
|---------|---------|
| Solana | `Cti3TCvSX1gXxR9XUWszghwETYUKFEGnuLAvMV4hsMLD` |
| Base | `0x6448D7772CF9dBd6112AE14176eE5E447A040a45` |

## Files Changed

- `packages/external/facilitators/src/facilitators/kamiyo.ts` (new)
- `packages/external/facilitators/src/facilitators/index.ts` (export added)
- `packages/external/facilitators/src/lists/all.ts` (registered in list)