### PR TITLE
Add KAMIYO facilitator

### DIFF
--- a/packages/external/facilitators/src/facilitators/index.ts
+++ b/packages/external/facilitators/src/facilitators/index.ts
@@ -25,3 +25,4 @@ export { primer, primerFacilitator } from './primer';
 export { x402jobs, x402jobsFacilitator } from './x402jobs';
 export { openfacilitator, openfacilitatorFacilitator } from './openfacilitator';
 export { relai, relaiFacilitator } from './relai';
+export { kamiyo, kamiyoFacilitator } from './kamiyo';

--- a/packages/external/facilitators/src/facilitators/kamiyo.ts
+++ b/packages/external/facilitators/src/facilitators/kamiyo.ts
@@ -1,0 +1,41 @@
+import { Network } from '../types';
+import { USDC_BASE_TOKEN, USDC_SOLANA_TOKEN } from '../constants';
+
+import type { Facilitator, FacilitatorConfig } from '../types';
+
+export const kamiyo: FacilitatorConfig = {
+  url: 'https://x402.kamiyo.ai',
+};
+
+export const kamiyoDiscovery: FacilitatorConfig = {
+  url: 'https://x402.kamiyo.ai',
+};
+
+export const kamiyoFacilitator = {
+  id: 'kamiyo',
+  metadata: {
+    name: 'KAMIYO',
+    image: 'https://kamiyo.ai/logo.png',
+    docsUrl: 'https://kamiyo.ai',
+    color: '#6366F1',
+  },
+  config: kamiyo,
+  discoveryConfig: kamiyoDiscovery,
+  addresses: {
+    [Network.SOLANA]: [
+      {
+        address: 'Cti3TCvSX1gXxR9XUWszghwETYUKFEGnuLAvMV4hsMLD',
+        tokens: [USDC_SOLANA_TOKEN],
+        dateOfFirstTransaction: new Date('2026-02-07'),
+      },
+    ],
+    [Network.BASE]: [
+      {
+        address: '0x6448D7772CF9dBd6112AE14176eE5E447A040a45',
+        tokens: [USDC_BASE_TOKEN],
+        dateOfFirstTransaction: new Date('2026-02-07'),
+      },
+    ],
+  },
+} as const satisfies Facilitator;
+

--- a/packages/external/facilitators/src/lists/all.ts
+++ b/packages/external/facilitators/src/lists/all.ts
@@ -25,6 +25,7 @@ import {
   x402jobsFacilitator,
   openfacilitatorFacilitator,
   relaiFacilitator,
+  kamiyoFacilitator,
 } from '../facilitators';
 
 import { validateUniqueFacilitators } from './validate';
@@ -58,6 +59,7 @@ const FACILITATORS = validateUniqueFacilitators([
   x402jobsFacilitator,
   openfacilitatorFacilitator,
   relaiFacilitator,
+  kamiyoFacilitator,
 ]);
 
 export const allFacilitators: Facilitator[] =


### PR DESCRIPTION
Supersedes #625 (rebased on current main to remove merge conflicts). Adds KAMIYO facilitator definition + exports + inclusion in all facilitators list.