### PR TITLE
feat: strip ownershipProofs from discovery by default

### DIFF
--- a/packages/external/mcp/src/server/tools/discover-resources.ts
+++ b/packages/external/mcp/src/server/tools/discover-resources.ts
@@ -11,6 +11,7 @@ import { Origin } from '@/shared/origins';
 import { mcpErrorJson, mcpSuccessJson } from './response';
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { JsonObject } from '@/shared/neverthrow/json/types';
 
 const discoveryDocumentSchema = z
   .object({
@@ -83,7 +84,7 @@ export function registerDiscoveryTools(server: McpServer): void {
       );
 
       if (wellKnownResult.isOk()) {
-        const data = { ...wellKnownResult.value };
+        const data = { ...wellKnownResult.value } as JsonObject;
         if (!includeOwnershipProofs) delete data.ownershipProofs;
         return mcpSuccessJson({
           found: true,
@@ -134,7 +135,7 @@ export function registerDiscoveryTools(server: McpServer): void {
           );
 
           if (dnsDocResult.isOk()) {
-            const data = { ...dnsDocResult.value };
+            const data = { ...dnsDocResult.value } as JsonObject;
             if (!includeOwnershipProofs) delete data.ownershipProofs;
             return mcpSuccessJson({
               found: true,

--- a/packages/external/mcp/src/server/tools/discover-resources.ts
+++ b/packages/external/mcp/src/server/tools/discover-resources.ts
@@ -12,12 +12,16 @@ import { mcpErrorJson, mcpSuccessJson } from './response';
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
-const discoveryDocumentSchema = z.object({
-  version: z.number().refine(v => v === 1, { message: 'version must be 1' }),
-  resources: z.array(z.string()),
-  ownershipProofs: z.array(z.string()).optional(),
-  instructions: z.string().optional(),
-});
+const discoveryDocumentSchema = z
+  .object({
+    version: z
+      .number()
+      .refine(v => v === 1, { message: 'version must be 1' }),
+    resources: z.array(z.string()),
+    ownershipProofs: z.array(z.string()).optional(),
+    instructions: z.string().optional(),
+  })
+  .passthrough();
 
 const toolName = 'discover_api_endpoints';
 
@@ -47,7 +51,7 @@ export function registerDiscoveryTools(server: McpServer): void {
           .describe(
             'The origin URL or any URL on the origin to discover resources from'
           ),
-        includeOwnershipProof: z
+        includeOwnershipProofs: z
           .boolean()
           .default(false)
           .describe(
@@ -61,7 +65,7 @@ export function registerDiscoveryTools(server: McpServer): void {
         openWorldHint: true,
       },
     },
-    async ({ url, includeOwnershipProof }) => {
+    async ({ url, includeOwnershipProofs }) => {
       const origin = URL.canParse(url) ? new URL(url).origin : url;
       const hostname = URL.canParse(origin) ? new URL(origin).hostname : origin;
       log.info(`Discovering resources for origin: ${origin}`);
@@ -80,7 +84,7 @@ export function registerDiscoveryTools(server: McpServer): void {
 
       if (wellKnownResult.isOk()) {
         const data = { ...wellKnownResult.value };
-        if (!includeOwnershipProof) delete data.ownershipProofs;
+        if (!includeOwnershipProofs) delete data.ownershipProofs;
         return mcpSuccessJson({
           found: true,
           origin,
@@ -131,7 +135,7 @@ export function registerDiscoveryTools(server: McpServer): void {
 
           if (dnsDocResult.isOk()) {
             const data = { ...dnsDocResult.value };
-            if (!includeOwnershipProof) delete data.ownershipProofs;
+            if (!includeOwnershipProofs) delete data.ownershipProofs;
             return mcpSuccessJson({
               found: true,
               origin,


### PR DESCRIPTION
## Summary
- Add optional `includeOwnershipProofs` param (default: `false`) to `discover_api_endpoints`
- Ownership proofs from smart wallets (EIP-1271) are significantly larger than EOA signatures — they include the full validator calldata, webauthn assertions, and proof chains. These are easily 1KB+ hex blobs that waste agent context without benefiting most workflows.
- Add `.passthrough()` to the discovery document zod schema so future `.well-known/x402` fields are preserved rather than silently stripped by zod

## Related
- #631 — adds EIP-1271/EIP-6492 smart contract signature verification to ownership proofs

## Test plan
- [ ] `discover_api_endpoints({ url: "https://stablestudio.io" })` — should NOT include `ownershipProofs`
- [ ] `discover_api_endpoints({ url: "https://stablestudio.io", includeOwnershipProofs: true })` — should include `ownershipProofs`
- [ ] Discovery of origins without `ownershipProofs` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)