### PR TITLE
feat: add EIP-1271/EIP-6492 smart contract signature verification

### DIFF
--- a/apps/scan/src/lib/ownership-proof.ts
+++ b/apps/scan/src/lib/ownership-proof.ts
@@ -16,13 +16,13 @@ import { baseRpc } from '@/services/rpc/base';
 type ChainType = 'evm' | 'solana';
 
 /** Subset of viem's PublicClient used for on-chain signature verification */
-type EvmVerificationClient = {
+interface EvmVerificationClient {
   verifyMessage: (args: {
     address: `0x${string}`;
     message: string;
     signature: `0x${string}`;
   }) => Promise<boolean>;
-};
+}
 
 interface VerificationConfig {
   signature: string;


### PR DESCRIPTION
## Summary
- Add EIP-1271 (smart contract wallet) and EIP-6492 (counterfactual smart wallet) signature verification to ownership proof system
- EVMVerifier now tries ECDSA recovery first (fast, no RPC needed for EOA signatures), then falls back to on-chain `verifyMessage` for smart contract wallets
- Uses a structural type for the public client to avoid viem generic chain-type mismatches
- Injects `baseRpc` into the verifier registry at module level

## Details
Previously, ownership proof verification only worked for EOA (externally owned account) signatures via `recoverMessageAddress`. Smart contract wallet signatures (e.g. from Coinbase Smart Wallet, Safe, etc.) would silently fail verification.

Now the `EVMVerifier`:
1. Tries fast ECDSA recovery first (no RPC call needed)
2. If the recovered address doesn't match, falls back to `publicClient.verifyMessage()` which handles EIP-1271 and EIP-6492 natively via an on-chain `eth_call`

No changes to public API — `verifyOwnershipProofMultichain` and `verifyAnyOwnershipProof` signatures are unchanged.

## Test plan
- [ ] EOA ownership proof still verifies (fast ECDSA path, no RPC)
- [ ] Smart contract wallet ownership proof now verifies via on-chain fallback
- [ ] Malformed signatures return `false` without throwing
- [ ] No regressions in resource registration verification flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)