### PR TITLE
Improve resource UX with collapsible optional params

### DIFF
--- a/apps/scan/src/app/(app)/_components/resources/executor/form/field-section.tsx
+++ b/apps/scan/src/app/(app)/_components/resources/executor/form/field-section.tsx
@@ -1,6 +1,18 @@
+'use client';
+
+import { useState } from 'react';
+import { ChevronRight } from 'lucide-react';
+
 import { Label } from '@/components/ui/label';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
 
 import { FieldInput } from './field-input';
+
+import { cn } from '@/lib/utils';
 
 import type { FieldDefinition, FieldValue } from '@/types/x402';
 
@@ -12,6 +24,42 @@ interface FieldSectionProps {
   title?: string;
 }
 
+function FieldRow({
+  field,
+  value,
+  onChange,
+  prefix,
+}: {
+  field: FieldDefinition;
+  value: FieldValue;
+  onChange: (name: string, value: FieldValue) => void;
+  prefix: string;
+}) {
+  return (
+    <div className="space-y-1">
+      <Label htmlFor={`${prefix}-${field.name}`}>
+        {field.name}
+        {field.required ? (
+          <span className="text-destructive ml-0.5">*</span>
+        ) : (
+          <span className="text-muted-foreground/60 text-xs ml-1.5 font-normal">
+            optional
+          </span>
+        )}
+      </Label>
+      <FieldInput
+        field={field}
+        value={value}
+        onChange={v => onChange(field.name, v)}
+        prefix={prefix}
+      />
+      {field.description && (
+        <p className="text-xs text-muted-foreground">{field.description}</p>
+      )}
+    </div>
+  );
+}
+
 export function FieldSection({
   fields,
   values,
@@ -19,34 +67,67 @@ export function FieldSection({
   prefix,
   title,
 }: FieldSectionProps) {
+  const [optionalOpen, setOptionalOpen] = useState(false);
+
   if (fields.length === 0) {
     return null;
   }
+
+  const requiredFields = fields.filter(f => f.required);
+  const optionalFields = fields.filter(f => !f.required);
 
   return (
     <div className="space-y-3">
       {title && (
         <h3 className="text-sm font-medium text-muted-foreground">{title}</h3>
       )}
-      {fields.map(field => (
-        <div key={`${prefix}-${field.name}`} className="space-y-1">
-          <Label htmlFor={`${prefix}-${field.name}`}>
-            {field.name}
-            {field.required ? (
-              <span className="text-destructive">*</span>
-            ) : null}
-          </Label>
-          <FieldInput
-            field={field}
-            value={values[field.name] ?? field.default ?? ''}
-            onChange={value => onChange(field.name, value)}
-            prefix={prefix}
-          />
-          {field.description && (
-            <p className="text-xs text-muted-foreground">{field.description}</p>
-          )}
+
+      {/* Required fields always visible at top */}
+      {requiredFields.length > 0 && (
+        <div className="space-y-3">
+          {requiredFields.map(field => (
+            <FieldRow
+              key={`${prefix}-${field.name}`}
+              field={field}
+              value={values[field.name] ?? field.default ?? ''}
+              onChange={onChange}
+              prefix={prefix}
+            />
+          ))}
         </div>
-      ))}
+      )}
+
+      {/* Optional fields in a collapsible section */}
+      {optionalFields.length > 0 && (
+        <Collapsible open={optionalOpen} onOpenChange={setOptionalOpen}>
+          <CollapsibleTrigger className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors py-1 group cursor-pointer w-full">
+            <ChevronRight
+              className={cn(
+                'size-3.5 transition-transform duration-200',
+                optionalOpen && 'rotate-90'
+              )}
+            />
+            <span>
+              {optionalFields.length} optional parameter
+              {optionalFields.length !== 1 ? 's' : ''}
+            </span>
+            <div className="flex-1 h-px bg-border ml-1" />
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <div className="space-y-3 pt-2">
+              {optionalFields.map(field => (
+                <FieldRow
+                  key={`${prefix}-${field.name}`}
+                  field={field}
+                  value={values[field.name] ?? field.default ?? ''}
+                  onChange={onChange}
+                  prefix={prefix}
+                />
+              ))}
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
+      )}
     </div>
   );
 }

--- a/apps/scan/src/app/(app)/_components/resources/executor/form/index.tsx
+++ b/apps/scan/src/app/(app)/_components/resources/executor/form/index.tsx
@@ -207,10 +207,44 @@ export function Form({
   const hasFields =
     headerFields.length > 0 || queryFields.length > 0 || bodyFields.length > 0;
 
+  const totalRequired = useMemo(() => {
+    return [headerFields, queryFields, bodyFields].reduce(
+      (sum, fields) => sum + fields.filter(f => f.required).length,
+      0
+    );
+  }, [headerFields, queryFields, bodyFields]);
+
+  const totalOptional = useMemo(() => {
+    return [headerFields, queryFields, bodyFields].reduce(
+      (sum, fields) => sum + fields.filter(f => !f.required).length,
+      0
+    );
+  }, [headerFields, queryFields, bodyFields]);
+
   return (
     <CardContent className="flex flex-col gap-4 p-4 border-t">
       {hasFields && (
         <div className="space-y-4">
+          {/* Summary of parameter counts */}
+          <div className="flex items-center gap-3 text-xs text-muted-foreground">
+            {totalRequired > 0 && (
+              <span>
+                <span className="font-medium text-foreground">
+                  {totalRequired}
+                </span>{' '}
+                required
+              </span>
+            )}
+            {totalRequired > 0 && totalOptional > 0 && (
+              <span className="text-border">|</span>
+            )}
+            {totalOptional > 0 && (
+              <span>
+                <span className="font-medium">{totalOptional}</span> optional
+              </span>
+            )}
+          </div>
+
           <FieldSection
             fields={headerFields}
             values={headerValues}
@@ -223,6 +257,7 @@ export function Form({
             values={queryValues}
             onChange={handleQueryChange}
             prefix="query"
+            title="Query Parameters"
           />
           <FieldSection
             fields={bodyFields}


### PR DESCRIPTION
Fixes #107

The resource parameter forms were showing all fields in a flat list which made it hard to see what's actually required vs optional. This was especially noisy for resources with many optional params.

Changes:
- Required fields are now shown at the top of each section, always visible
- Optional fields are collapsed by default behind a clickable "N optional parameters" toggle
- Added a small summary at the top of the form showing the count of required vs optional params
- Query parameters section now has a proper title (was missing before)
- Added "optional" label next to non-required field names for clarity

Used the existing `Collapsible` component from radix so no new dependencies needed.