### PR TITLE
Add REST API for programmatic resource registration

### DIFF
--- a/apps/scan/src/app/api/resources/register/origin/route.ts
+++ b/apps/scan/src/app/api/resources/register/origin/route.ts
@@ -1,0 +1,210 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { z } from 'zod';
+
+import { registerResource } from '@/lib/resources';
+import { extractX402Data } from '@/lib/x402';
+import { fetchDiscoveryDocument } from '@/services/discovery';
+import { deprecateStaleResources } from '@/services/db/resources/resource';
+
+import { Methods } from '@/types/x402';
+
+const originSchema = z.object({
+  origin: z.string().url(),
+});
+
+/**
+ * POST /api/resources/register/origin
+ *
+ * Register all x402 resources discovered from an origin.
+ * Uses DNS TXT records (_x402.{hostname}) or /.well-known/x402 for discovery.
+ *
+ * Request body:
+ *   { "origin": "https://example.com" }
+ *
+ * Response:
+ *   - 200: Registration results with counts of registered/failed resources
+ *   - 400: Invalid request body or no discovery document found
+ *   - 500: Internal server error
+ */
+export const POST = async (request: NextRequest) => {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Invalid JSON body' },
+      { status: 400 }
+    );
+  }
+
+  const parsed = originSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Invalid request body',
+        details: parsed.error.issues,
+      },
+      { status: 400 }
+    );
+  }
+
+  const { origin } = parsed.data;
+
+  try {
+    const discoveryResult = await fetchDiscoveryDocument(origin);
+
+    if (!discoveryResult.success) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            type: 'noDiscovery',
+            message: discoveryResult.error ?? 'No discovery document found',
+          },
+        },
+        { status: 400 }
+      );
+    }
+
+    function getErrorMessage(err: unknown): string {
+      if (typeof err === 'string') return err;
+      if (!err || typeof err !== 'object') return 'Unknown error';
+      if ('type' in err && typeof err.type === 'string') {
+        const details: string[] = [];
+        if ('parseErrors' in err && Array.isArray(err.parseErrors)) {
+          details.push(...(err.parseErrors as string[]));
+        } else if ('upsertErrors' in err && Array.isArray(err.upsertErrors)) {
+          details.push(...(err.upsertErrors as string[]));
+        }
+        return details.length > 0
+          ? `${err.type}: ${details.join(', ')}`
+          : err.type;
+      }
+      return 'Unknown error';
+    }
+
+    const results = await Promise.allSettled(
+      discoveryResult.resources.map(async resource => {
+        const resourceUrl = resource.url;
+        const methodsToTry = [Methods.POST, Methods.GET];
+
+        let lastError = 'No 402 response';
+        let lastStatus: number | undefined;
+        const errors: string[] = [];
+
+        for (const method of methodsToTry) {
+          try {
+            const response = await fetch(resourceUrl, {
+              method,
+              headers:
+                method === Methods.POST
+                  ? {
+                      'Content-Type': 'application/json',
+                      'Cache-Control': 'no-cache',
+                    }
+                  : { 'Cache-Control': 'no-cache' },
+              body: method === Methods.POST ? '{}' : undefined,
+              signal: AbortSignal.timeout(15000),
+              cache: 'no-store',
+            });
+
+            lastStatus = response.status;
+
+            if (response.status === 402) {
+              const x402Data = await extractX402Data(response);
+              const result = await registerResource(resourceUrl, x402Data);
+
+              if (result.success) {
+                return result;
+              }
+
+              const errorMsg =
+                getErrorMessage(result.error) || 'Registration failed';
+              errors.push(`${method}: ${errorMsg}`);
+              lastError = errors.join('; ');
+            } else {
+              const errorMsg = `Expected 402, got ${response.status}`;
+              errors.push(`${method}: ${errorMsg}`);
+              lastError = errors.join('; ');
+            }
+          } catch (err) {
+            const errorMsg =
+              err instanceof Error ? err.message : 'Request failed';
+            errors.push(`${method}: ${errorMsg}`);
+            lastError = errors.join('; ');
+          }
+        }
+
+        return {
+          success: false as const,
+          url: resourceUrl,
+          error: lastError,
+          status: lastStatus,
+        };
+      })
+    );
+
+    const successfulResults: { url: string }[] = [];
+    const failedResults: { url: string; error: string; status?: number }[] = [];
+    let originId: string | undefined;
+
+    for (let i = 0; i < results.length; i++) {
+      const result = results[i];
+      const resourceUrl = discoveryResult.resources[i]?.url ?? 'unknown';
+
+      if (!result) continue;
+
+      if (result.status === 'fulfilled' && result.value) {
+        const value = result.value;
+        if ('success' in value && value.success) {
+          successfulResults.push({ url: resourceUrl });
+          if (!originId && 'resource' in value && value.resource?.origin?.id) {
+            originId = value.resource.origin.id;
+          }
+        } else if ('success' in value && !value.success) {
+          failedResults.push({
+            url: resourceUrl,
+            error: value.error,
+            status: 'status' in value ? value.status : undefined,
+          });
+        }
+      } else if (result.status === 'rejected') {
+        failedResults.push({
+          url: resourceUrl,
+          error:
+            result.reason instanceof Error
+              ? result.reason.message
+              : 'Promise rejected',
+        });
+      }
+    }
+
+    // Deprecate resources that are no longer in the discovery document
+    let deprecated = 0;
+    if (originId) {
+      const activeResourceUrls = discoveryResult.resources.map(r => r.url);
+      deprecated = await deprecateStaleResources(originId, activeResourceUrls);
+    }
+
+    return NextResponse.json({
+      success: true,
+      registered: successfulResults.length,
+      failed: failedResults.length,
+      deprecated,
+      total: results.length,
+      source: discoveryResult.source,
+      failedDetails: failedResults,
+      originId,
+    });
+  } catch (error) {
+    console.error('Origin registration failed:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Internal server error',
+      },
+      { status: 500 }
+    );
+  }
+};

--- a/apps/scan/src/app/api/resources/register/route.ts
+++ b/apps/scan/src/app/api/resources/register/route.ts
@@ -1,0 +1,179 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { z } from 'zod';
+
+import { registerResource } from '@/lib/resources';
+import { extractX402Data } from '@/lib/x402';
+import { getOriginFromUrl, normalizeUrl } from '@/lib/url';
+import { fetchDiscoveryDocument } from '@/services/discovery';
+
+import { Methods } from '@/types/x402';
+
+import type { DiscoveryInfo } from '@/types/discovery';
+
+const registerSchema = z.object({
+  url: z.string().url(),
+  headers: z.record(z.string(), z.string()).optional(),
+});
+
+/**
+ * POST /api/resources/register
+ *
+ * Register a single x402 resource by URL.
+ * The endpoint will probe the URL with POST and GET to find a 402 response,
+ * parse the x402 payment requirements, and register the resource.
+ *
+ * Request body:
+ *   { "url": "https://example.com/api/resource", "headers": { "X-Custom": "value" } }
+ *
+ * Response:
+ *   - 200: Resource registered (or error details from the x402 response)
+ *   - 400: Invalid request body
+ *   - 500: Internal server error
+ */
+export const POST = async (request: NextRequest) => {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Invalid JSON body' },
+      { status: 400 }
+    );
+  }
+
+  const parsed = registerSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Invalid request body',
+        details: parsed.error.issues,
+      },
+      { status: 400 }
+    );
+  }
+
+  const { url, headers: customHeaders } = parsed.data;
+
+  try {
+    let parseErrorData: {
+      parseErrors: string[];
+      data: unknown;
+    } | null = null;
+
+    for (const method of [Methods.POST, Methods.GET]) {
+      const response = await fetch(url.replace('{', '').replace('}', ''), {
+        method,
+        headers:
+          method === Methods.POST
+            ? {
+                ...customHeaders,
+                'Content-Type': 'application/json',
+                'Cache-Control': 'no-cache',
+              }
+            : { ...customHeaders, 'Cache-Control': 'no-cache' },
+        body: method === Methods.POST ? '{}' : undefined,
+        cache: 'no-store',
+      });
+
+      if (response.status !== 402) {
+        continue;
+      }
+
+      const x402Data = await extractX402Data(response);
+      const result = await registerResource(url, x402Data);
+
+      if (result.success === false) {
+        if (result.error.type === 'parseResponse') {
+          parseErrorData = {
+            data: result.data,
+            parseErrors: result.error.parseErrors,
+          };
+          continue;
+        } else {
+          parseErrorData = {
+            data: result.data ?? null,
+            parseErrors:
+              'parseErrors' in result.error &&
+              Array.isArray(result.error.parseErrors)
+                ? result.error.parseErrors
+                : [JSON.stringify(result.error)],
+          };
+          continue;
+        }
+      }
+
+      // Check for discovery document
+      const origin = getOriginFromUrl(url);
+      let discovery: DiscoveryInfo = {
+        found: false,
+        otherResourceCount: 0,
+        origin,
+      };
+
+      try {
+        const discoveryResult = await fetchDiscoveryDocument(origin);
+        if (
+          discoveryResult.success &&
+          Array.isArray(discoveryResult.resources)
+        ) {
+          const normalizedInputUrl = normalizeUrl(url);
+          const otherResources = discoveryResult.resources.filter(r => {
+            if (
+              !r ||
+              typeof r !== 'object' ||
+              !('url' in r) ||
+              typeof r.url !== 'string'
+            ) {
+              return false;
+            }
+            return normalizeUrl(String(r.url)) !== normalizedInputUrl;
+          });
+          discovery = {
+            found: true,
+            source: discoveryResult.source,
+            otherResourceCount: otherResources.length,
+            origin,
+            resources: otherResources.map(r => r.url),
+          };
+        }
+      } catch {
+        // Discovery check failed silently
+      }
+
+      return NextResponse.json({
+        ...result,
+        methodUsed: method,
+        discovery,
+      });
+    }
+
+    if (parseErrorData) {
+      return NextResponse.json({
+        success: false,
+        data: parseErrorData.data,
+        error: {
+          type: 'parseErrors',
+          parseErrors: parseErrorData.parseErrors,
+        },
+      });
+    }
+
+    return NextResponse.json({
+      success: false,
+      error: {
+        type: 'no402',
+        message: 'The URL did not respond with HTTP 402 for any method (POST, GET)',
+      },
+    });
+  } catch (error) {
+    console.error('Resource registration failed:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Internal server error',
+      },
+      { status: 500 }
+    );
+  }
+};

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,161 @@
+# x402scan API - Programmatic Resource Management
+
+x402scan exposes REST API endpoints that let you register and manage x402 resources programmatically. This is useful for resource providers who want to automatically update their listings after deploying new endpoints, or for CI/CD pipelines that keep x402scan in sync with your services.
+
+## Endpoints
+
+### Register a Single Resource
+
+```
+POST /api/resources/register
+```
+
+Probes the given URL with both POST and GET requests looking for a `402 Payment Required` response. If found, the x402 payment requirements are parsed and the resource is registered.
+
+**Request Body**
+
+| Field     | Type                        | Required | Description                                  |
+|-----------|-----------------------------|----------|----------------------------------------------|
+| `url`     | `string` (valid URL)        | Yes      | The URL of the x402 resource to register.    |
+| `headers` | `Record<string, string>`    | No       | Custom headers to include when probing.      |
+
+**Example**
+
+```bash
+curl -X POST https://x402scan.com/api/resources/register \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://my-api.com/api/paid-endpoint"}'
+```
+
+**Response (success)**
+
+```json
+{
+  "success": true,
+  "resource": {
+    "resource": { "id": "...", "resource": "https://my-api.com/api/paid-endpoint", ... },
+    "origin": { "id": "...", "origin": "https://my-api.com", ... },
+    "accepts": [...]
+  },
+  "accepts": [...],
+  "response": { ... },
+  "methodUsed": "POST",
+  "discovery": {
+    "found": true,
+    "source": "well-known",
+    "otherResourceCount": 3,
+    "origin": "https://my-api.com",
+    "resources": ["https://my-api.com/api/other-endpoint", ...]
+  }
+}
+```
+
+**Response (no 402 detected)**
+
+```json
+{
+  "success": false,
+  "error": {
+    "type": "no402",
+    "message": "The URL did not respond with HTTP 402 for any method (POST, GET)"
+  }
+}
+```
+
+---
+
+### Register All Resources from an Origin
+
+```
+POST /api/resources/register/origin
+```
+
+Discovers all x402 resources at an origin using the [discovery protocol](./DISCOVERY.md) (DNS TXT records or `/.well-known/x402`), then registers each one. Resources that are no longer listed in the discovery document are automatically deprecated.
+
+**Request Body**
+
+| Field    | Type                  | Required | Description                              |
+|----------|-----------------------|----------|------------------------------------------|
+| `origin` | `string` (valid URL)  | Yes      | The origin URL (e.g. `https://my-api.com`). |
+
+**Example**
+
+```bash
+curl -X POST https://x402scan.com/api/resources/register/origin \
+  -H "Content-Type: application/json" \
+  -d '{"origin": "https://my-api.com"}'
+```
+
+**Response (success)**
+
+```json
+{
+  "success": true,
+  "registered": 5,
+  "failed": 1,
+  "deprecated": 0,
+  "total": 6,
+  "source": "well-known",
+  "failedDetails": [
+    {
+      "url": "https://my-api.com/api/broken-endpoint",
+      "error": "POST: Expected 402, got 500; GET: Expected 402, got 500",
+      "status": 500
+    }
+  ],
+  "originId": "uuid-of-origin"
+}
+```
+
+**Response (no discovery document)**
+
+```json
+{
+  "success": false,
+  "error": {
+    "type": "noDiscovery",
+    "message": "No discovery document found"
+  }
+}
+```
+
+---
+
+## Typical Workflows
+
+### After deploying a new endpoint
+
+If you add a new x402-protected route, register it immediately:
+
+```bash
+curl -X POST https://x402scan.com/api/resources/register \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://my-api.com/api/new-endpoint"}'
+```
+
+### Refreshing all resources from your origin
+
+If you maintain a `/.well-known/x402` discovery document, you can refresh everything in one call. This also deprecates resources you've removed:
+
+```bash
+curl -X POST https://x402scan.com/api/resources/register/origin \
+  -H "Content-Type: application/json" \
+  -d '{"origin": "https://my-api.com"}'
+```
+
+### CI/CD integration
+
+Add a step to your deployment pipeline:
+
+```yaml
+# GitHub Actions example
+- name: Update x402scan listing
+  run: |
+    curl -X POST https://x402scan.com/api/resources/register/origin \
+      -H "Content-Type: application/json" \
+      -d '{"origin": "https://my-api.com"}'
+```
+
+## Discovery Protocol
+
+For the origin registration endpoint to work, your server needs to implement the x402 discovery protocol. See [DISCOVERY.md](./DISCOVERY.md) for details on setting up DNS TXT records or a `/.well-known/x402` document.


### PR DESCRIPTION
Closes #104

Adds two new REST API endpoints that expose the existing TRPC resource registration logic to the open internet:

- **`POST /api/resources/register`** — register a single resource by URL. Probes with POST and GET to find a 402 response, parses the x402 data, and registers it. Also checks for a discovery document and returns info about other resources at the same origin.

- **`POST /api/resources/register/origin`** — register all resources from an origin using the discovery protocol (DNS TXT or `/.well-known/x402`). Automatically deprecates resources no longer in the discovery document.

Both endpoints mirror the existing `public.resources.register` and `public.resources.registerFromOrigin` TRPC mutations, just exposed as plain REST so they can be called from scripts, CI/CD pipelines, or external tools without needing a TRPC client.

Also added `docs/API.md` with usage examples including curl commands and a GitHub Actions snippet for CI/CD integration.