### PR TITLE
Allow uploading of OpenAPI spec for resources

### DIFF
--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/openapi-upload.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/openapi-upload.tsx
@@ -1,0 +1,561 @@
+'use client';
+
+import { useState, useCallback, useRef } from 'react';
+
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ChevronDown,
+  FileCode,
+  Loader2,
+  Upload,
+  XCircle,
+} from 'lucide-react';
+
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
+import { cn } from '@/lib/utils';
+
+import { api } from '@/trpc/client';
+
+type DryRunEndpoint = {
+  url: string;
+  method: string;
+  path: string;
+  description: string | null;
+  operationId: string | null;
+  hasQueryParams: boolean;
+  hasBodyFields: boolean;
+  hasResponseSchema: boolean;
+};
+
+type RegisteredEndpoint = {
+  url: string;
+  method: string;
+  path: string;
+  description: string | null;
+};
+
+type FailedEndpoint = {
+  url: string;
+  method: string;
+  path: string;
+  description: string | null;
+  error: string;
+};
+
+const METHOD_COLORS: Record<string, string> = {
+  GET: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+  POST: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
+  PUT: 'bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300',
+  PATCH: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300',
+  DELETE: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
+};
+
+export const OpenAPIUpload = () => {
+  const [specContent, setSpecContent] = useState('');
+  const [baseUrl, setBaseUrl] = useState('');
+  const [showBaseUrl, setShowBaseUrl] = useState(false);
+  const [dryRunResult, setDryRunResult] = useState<{
+    title: string | null;
+    description: string | null;
+    version: string | null;
+    baseUrl: string;
+    endpointCount: number;
+    endpoints: DryRunEndpoint[];
+  } | null>(null);
+  const [registerResult, setRegisterResult] = useState<{
+    registered: number;
+    failed: number;
+    total: number;
+    successfulEndpoints: RegisteredEndpoint[];
+    failedEndpoints: FailedEndpoint[];
+  } | null>(null);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const { mutate: parseSpec, isPending: isParsing } =
+    api.public.resources.registerFromOpenAPISpec.useMutation({
+      onSuccess: data => {
+        if (!data.success) {
+          toast.error(data.error ?? 'Failed to parse spec');
+          return;
+        }
+        if (data.dryRun) {
+          setDryRunResult({
+            title: data.title,
+            description: data.description,
+            version: data.version,
+            baseUrl: data.baseUrl,
+            endpointCount: data.endpointCount,
+            endpoints: data.endpoints,
+          });
+          toast.success(
+            `Found ${data.endpointCount} endpoint${data.endpointCount === 1 ? '' : 's'}`
+          );
+        }
+      },
+      onError: err => {
+        toast.error(err.message ?? 'Failed to parse spec');
+      },
+    });
+
+  const { mutate: registerAll, isPending: isRegistering } =
+    api.public.resources.registerFromOpenAPISpec.useMutation({
+      onSuccess: data => {
+        if (!data.success) {
+          toast.error(data.error ?? 'Registration failed');
+          return;
+        }
+        if (!data.dryRun) {
+          setRegisterResult({
+            registered: data.registered,
+            failed: data.failed,
+            total: data.total,
+            successfulEndpoints: data.successfulEndpoints,
+            failedEndpoints: data.failedEndpoints,
+          });
+          if (data.registered > 0) {
+            toast.success(
+              `Registered ${data.registered} of ${data.total} endpoint${data.total === 1 ? '' : 's'}`
+            );
+          } else {
+            toast.error(
+              'No endpoints could be registered. They may not return 402 responses.'
+            );
+          }
+        }
+      },
+      onError: err => {
+        toast.error(err.message ?? 'Registration failed');
+      },
+    });
+
+  const handleFileUpload = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+
+      const reader = new FileReader();
+      reader.onload = event => {
+        const content = event.target?.result as string;
+        setSpecContent(content);
+        setDryRunResult(null);
+        setRegisterResult(null);
+      };
+      reader.readAsText(file);
+    },
+    []
+  );
+
+  const handleParse = () => {
+    if (!specContent.trim()) {
+      toast.error('Please paste or upload an OpenAPI spec');
+      return;
+    }
+    setDryRunResult(null);
+    setRegisterResult(null);
+    parseSpec({
+      spec: specContent,
+      baseUrl: baseUrl || undefined,
+      dryRun: true,
+    });
+  };
+
+  const handleRegister = () => {
+    if (!specContent.trim()) return;
+    registerAll({
+      spec: specContent,
+      baseUrl: baseUrl || undefined,
+      dryRun: false,
+    });
+  };
+
+  const handleReset = () => {
+    setSpecContent('');
+    setBaseUrl('');
+    setDryRunResult(null);
+    setRegisterResult(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg md:text-xl flex items-center gap-2">
+          <FileCode className="size-5" />
+          {registerResult
+            ? 'Registration Complete'
+            : dryRunResult
+              ? 'Spec Preview'
+              : 'Import from OpenAPI Spec'}
+        </CardTitle>
+        <CardDescription className="text-sm md:text-base">
+          {registerResult
+            ? `Registered ${registerResult.registered} of ${registerResult.total} endpoints.`
+            : dryRunResult
+              ? `${dryRunResult.endpointCount} endpoint${dryRunResult.endpointCount === 1 ? '' : 's'} found. Review and register them below.`
+              : 'Upload or paste an OpenAPI specification file (JSON or YAML) to automatically register all your API endpoints as x402 resources.'}
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent>
+        {registerResult ? (
+          <div className="flex flex-col gap-4">
+            {/* Summary */}
+            <div className="grid grid-cols-3 gap-3">
+              <div className="border rounded-lg p-3 text-center">
+                <p className="text-2xl font-bold">{registerResult.total}</p>
+                <p className="text-xs text-muted-foreground">Total</p>
+              </div>
+              <div className="border rounded-lg p-3 text-center border-green-500/30 bg-green-500/5">
+                <p className="text-2xl font-bold text-green-600">
+                  {registerResult.registered}
+                </p>
+                <p className="text-xs text-muted-foreground">Registered</p>
+              </div>
+              <div className="border rounded-lg p-3 text-center border-red-500/30 bg-red-500/5">
+                <p className="text-2xl font-bold text-red-600">
+                  {registerResult.failed}
+                </p>
+                <p className="text-xs text-muted-foreground">Failed</p>
+              </div>
+            </div>
+
+            <Accordion type="multiple" className="w-full">
+              {registerResult.successfulEndpoints.length > 0 && (
+                <AccordionItem value="successful">
+                  <AccordionTrigger className="py-3">
+                    <div className="flex items-center gap-2">
+                      <CheckCircle2 className="size-4 text-green-600" />
+                      <span className="font-semibold">
+                        Registered Endpoints
+                      </span>
+                      <Badge variant="secondary">
+                        {registerResult.successfulEndpoints.length}
+                      </Badge>
+                    </div>
+                  </AccordionTrigger>
+                  <AccordionContent>
+                    <div className="space-y-1">
+                      {registerResult.successfulEndpoints.map((ep, i) => (
+                        <div
+                          key={i}
+                          className="flex items-center gap-2 p-2 rounded-md bg-muted/50 text-sm"
+                        >
+                          <Badge
+                            className={cn(
+                              'text-[10px] font-mono px-1.5 py-0',
+                              METHOD_COLORS[ep.method]
+                            )}
+                            variant="outline"
+                          >
+                            {ep.method}
+                          </Badge>
+                          <span className="font-mono text-xs truncate">
+                            {ep.path}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  </AccordionContent>
+                </AccordionItem>
+              )}
+
+              {registerResult.failedEndpoints.length > 0 && (
+                <AccordionItem value="failed">
+                  <AccordionTrigger className="py-3">
+                    <div className="flex items-center gap-2">
+                      <XCircle className="size-4 text-red-600" />
+                      <span className="font-semibold">Failed Endpoints</span>
+                      <Badge variant="secondary">
+                        {registerResult.failedEndpoints.length}
+                      </Badge>
+                    </div>
+                  </AccordionTrigger>
+                  <AccordionContent>
+                    <div className="space-y-2">
+                      {registerResult.failedEndpoints.map((ep, i) => (
+                        <div
+                          key={i}
+                          className="p-2 rounded-md bg-red-500/5 border border-red-500/20"
+                        >
+                          <div className="flex items-center gap-2 text-sm">
+                            <Badge
+                              className={cn(
+                                'text-[10px] font-mono px-1.5 py-0',
+                                METHOD_COLORS[ep.method]
+                              )}
+                              variant="outline"
+                            >
+                              {ep.method}
+                            </Badge>
+                            <span className="font-mono text-xs truncate">
+                              {ep.path}
+                            </span>
+                          </div>
+                          <p className="text-xs text-muted-foreground mt-1">
+                            {ep.error}
+                          </p>
+                        </div>
+                      ))}
+                    </div>
+                  </AccordionContent>
+                </AccordionItem>
+              )}
+            </Accordion>
+          </div>
+        ) : dryRunResult ? (
+          <div className="flex flex-col gap-4">
+            {/* Spec info */}
+            {(dryRunResult.title || dryRunResult.description) && (
+              <div className="border rounded-lg p-4 bg-muted/30">
+                {dryRunResult.title && (
+                  <h3 className="font-semibold">{dryRunResult.title}</h3>
+                )}
+                {dryRunResult.description && (
+                  <p className="text-sm text-muted-foreground mt-1">
+                    {dryRunResult.description}
+                  </p>
+                )}
+                {dryRunResult.version && (
+                  <Badge variant="outline" className="mt-2 text-xs">
+                    v{dryRunResult.version}
+                  </Badge>
+                )}
+                {dryRunResult.baseUrl && (
+                  <p className="text-xs text-muted-foreground mt-2 font-mono">
+                    Base: {dryRunResult.baseUrl}
+                  </p>
+                )}
+              </div>
+            )}
+
+            {/* Endpoint list */}
+            <div className="border rounded-lg overflow-hidden">
+              <div className="bg-muted/50 px-4 py-2 border-b">
+                <p className="text-sm font-medium">
+                  {dryRunResult.endpointCount} Endpoint
+                  {dryRunResult.endpointCount === 1 ? '' : 's'} Found
+                </p>
+              </div>
+              <div className="max-h-80 overflow-y-auto divide-y">
+                {dryRunResult.endpoints.map((ep, i) => (
+                  <div key={i} className="px-4 py-2.5 hover:bg-muted/30">
+                    <div className="flex items-center gap-2">
+                      <Badge
+                        className={cn(
+                          'text-[10px] font-mono px-1.5 py-0 shrink-0',
+                          METHOD_COLORS[ep.method]
+                        )}
+                        variant="outline"
+                      >
+                        {ep.method}
+                      </Badge>
+                      <span className="font-mono text-sm truncate">
+                        {ep.path}
+                      </span>
+                      <div className="flex items-center gap-1 ml-auto shrink-0">
+                        {ep.hasQueryParams && (
+                          <Badge
+                            variant="secondary"
+                            className="text-[10px] px-1.5 py-0"
+                          >
+                            query
+                          </Badge>
+                        )}
+                        {ep.hasBodyFields && (
+                          <Badge
+                            variant="secondary"
+                            className="text-[10px] px-1.5 py-0"
+                          >
+                            body
+                          </Badge>
+                        )}
+                      </div>
+                    </div>
+                    {ep.description && (
+                      <p className="text-xs text-muted-foreground mt-1 ml-14">
+                        {ep.description}
+                      </p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="flex items-start gap-3 p-3 bg-amber-500/10 border border-amber-500/30 rounded-md">
+              <AlertTriangle className="size-4 text-amber-600 shrink-0 mt-0.5" />
+              <p className="text-sm text-muted-foreground">
+                Only endpoints that respond with a 402 status code will be
+                registered. Endpoints without x402 payment requirements will be
+                skipped.
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-4">
+            {/* File upload */}
+            <div className="flex flex-col gap-2">
+              <Label>Upload spec file</Label>
+              <div className="flex gap-2">
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".json,.yaml,.yml"
+                  onChange={handleFileUpload}
+                  className="hidden"
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="w-full"
+                  onClick={() => fileInputRef.current?.click()}
+                >
+                  <Upload className="size-4 mr-2" />
+                  Choose File (.json, .yaml, .yml)
+                </Button>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-3">
+              <div className="h-px flex-1 bg-border" />
+              <span className="text-xs text-muted-foreground">or</span>
+              <div className="h-px flex-1 bg-border" />
+            </div>
+
+            {/* Paste spec */}
+            <div className="flex flex-col gap-2">
+              <Label>Paste spec content</Label>
+              <Textarea
+                placeholder='{"openapi": "3.0.0", "info": {...}, "paths": {...}}'
+                value={specContent}
+                onChange={e => {
+                  setSpecContent(e.target.value);
+                  setDryRunResult(null);
+                  setRegisterResult(null);
+                }}
+                className="min-h-40 font-mono text-xs"
+              />
+            </div>
+
+            {/* Base URL override */}
+            <Collapsible open={showBaseUrl} onOpenChange={setShowBaseUrl}>
+              <CollapsibleTrigger asChild>
+                <Button
+                  variant="ghost"
+                  className="size-fit p-0 w-full md:size-fit text-xs md:text-xs text-muted-foreground/60 hover:text-muted-foreground"
+                >
+                  Base URL Override
+                  <ChevronDown
+                    className={cn(
+                      'size-3 transition-transform',
+                      showBaseUrl && 'rotate-180'
+                    )}
+                  />
+                </Button>
+              </CollapsibleTrigger>
+              <CollapsibleContent className="border p-4 rounded-md mt-2">
+                <div className="flex flex-col gap-2">
+                  <Label className="text-xs">
+                    Base URL (overrides servers in spec)
+                  </Label>
+                  <Input
+                    type="text"
+                    placeholder="https://api.example.com"
+                    value={baseUrl}
+                    onChange={e => setBaseUrl(e.target.value)}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    If your spec&apos;s server URL is wrong or missing, provide
+                    the correct base URL here.
+                  </p>
+                </div>
+              </CollapsibleContent>
+            </Collapsible>
+          </div>
+        )}
+      </CardContent>
+
+      <CardFooter className="flex-col gap-2">
+        {registerResult ? (
+          <Button variant="outline" onClick={handleReset} className="w-full">
+            Import Another Spec
+          </Button>
+        ) : dryRunResult ? (
+          <div className="flex gap-2 w-full">
+            <Button
+              variant="outline"
+              onClick={() => {
+                setDryRunResult(null);
+              }}
+              className="flex-1"
+            >
+              Back to Edit
+            </Button>
+            <Button
+              variant="turbo"
+              disabled={isRegistering}
+              onClick={handleRegister}
+              className="flex-1"
+            >
+              {isRegistering ? (
+                <>
+                  <Loader2 className="size-4 animate-spin mr-2" />
+                  Registering...
+                </>
+              ) : (
+                `Register ${dryRunResult.endpointCount} Endpoint${dryRunResult.endpointCount === 1 ? '' : 's'}`
+              )}
+            </Button>
+          </div>
+        ) : (
+          <Button
+            variant="turbo"
+            disabled={isParsing || !specContent.trim()}
+            onClick={handleParse}
+            className="w-full"
+          >
+            {isParsing ? (
+              <>
+                <Loader2 className="size-4 animate-spin mr-2" />
+                Parsing...
+              </>
+            ) : (
+              <>
+                <FileCode className="size-4 mr-2" />
+                Parse Spec
+              </>
+            )}
+          </Button>
+        )}
+      </CardFooter>
+    </Card>
+  );
+};

--- a/apps/scan/src/app/(app)/(home)/resources/register/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/page.tsx
@@ -1,5 +1,6 @@
 import { Body, Heading } from '@/app/_components/layout/page-utils';
 import { RegisterResourceForm } from './_components/form';
+import { OpenAPIUpload } from './_components/openapi-upload';
 import { OutputSchema } from './_components/schema';
 import { DeveloperToolBanner } from './_components/developer-tool-banner';
 
@@ -20,6 +21,7 @@ export default function RegisterResourcePage() {
       <Body>
         <DeveloperToolBanner />
         <RegisterResourceForm />
+        <OpenAPIUpload />
         <OutputSchema />
       </Body>
     </div>

--- a/apps/scan/src/lib/openapi/index.ts
+++ b/apps/scan/src/lib/openapi/index.ts
@@ -1,0 +1,7 @@
+export { parseOpenAPISpec } from './parse-spec';
+export type {
+  ParsedEndpoint,
+  FieldDef,
+  ParseSpecResult,
+  ParseSpecError,
+} from './parse-spec';

--- a/apps/scan/src/lib/openapi/parse-spec.ts
+++ b/apps/scan/src/lib/openapi/parse-spec.ts
@@ -1,0 +1,553 @@
+/**
+ * OpenAPI spec parser for extracting resource endpoints.
+ *
+ * Parses OpenAPI 3.x specs (JSON or YAML) and extracts endpoints
+ * with their methods, parameters, and request/response schemas.
+ */
+
+export interface ParsedEndpoint {
+  /** Full URL for this endpoint (baseUrl + path) */
+  url: string;
+  /** HTTP method (GET, POST, PUT, PATCH, DELETE) */
+  method: string;
+  /** Path from the spec (e.g. /api/v1/generate) */
+  path: string;
+  /** Operation summary or description */
+  description: string | null;
+  /** Operation ID if available */
+  operationId: string | null;
+  /** Query parameters */
+  queryParams: Record<string, FieldDef>;
+  /** Request body fields (for POST/PUT/PATCH) */
+  bodyFields: Record<string, FieldDef>;
+  /** Response schema (if available) */
+  responseSchema: Record<string, unknown> | null;
+}
+
+export interface FieldDef {
+  type?: string;
+  required?: boolean;
+  description?: string;
+  enum?: string[];
+  properties?: Record<string, FieldDef>;
+  items?: FieldDef;
+}
+
+export interface ParseSpecResult {
+  success: true;
+  title: string | null;
+  description: string | null;
+  version: string | null;
+  baseUrl: string;
+  endpoints: ParsedEndpoint[];
+}
+
+export interface ParseSpecError {
+  success: false;
+  error: string;
+}
+
+/**
+ * Attempt to parse a string as JSON first.
+ * If that fails, do a basic YAML-like parse for common OpenAPI structures.
+ */
+function parseContent(content: string): unknown {
+  // Try JSON first
+  try {
+    return JSON.parse(content);
+  } catch {
+    // Not JSON, continue
+  }
+
+  // Try a minimal YAML parse for the subset used by OpenAPI specs
+  try {
+    return parseSimpleYaml(content);
+  } catch {
+    // Not parseable
+  }
+
+  throw new Error(
+    'Could not parse spec content. Please provide valid JSON or YAML.'
+  );
+}
+
+/**
+ * Minimal YAML parser that handles the subset commonly used by OpenAPI specs.
+ */
+function parseSimpleYaml(content: string): unknown {
+  const lines = content.split('\n');
+  return parseYamlLines(lines, 0, 0).value;
+}
+
+interface YamlResult {
+  value: unknown;
+  nextIndex: number;
+}
+
+function parseYamlLines(
+  lines: string[],
+  startIndex: number,
+  minIndent: number
+): YamlResult {
+  const result: Record<string, unknown> = {};
+  let i = startIndex;
+
+  while (i < lines.length) {
+    const line = lines[i]!;
+    const trimmed = line.trimStart();
+
+    if (trimmed === '' || trimmed.startsWith('#')) {
+      i++;
+      continue;
+    }
+
+    const indent = line.length - trimmed.length;
+    if (indent < minIndent) break;
+
+    // Handle list items
+    if (trimmed.startsWith('- ')) {
+      const arr: unknown[] = [];
+      while (i < lines.length) {
+        const arrLine = lines[i]!;
+        const arrTrimmed = arrLine.trimStart();
+        const arrIndent = arrLine.length - arrTrimmed.length;
+
+        if (arrTrimmed === '' || arrTrimmed.startsWith('#')) {
+          i++;
+          continue;
+        }
+        if (arrIndent < indent) break;
+        if (!arrTrimmed.startsWith('- ')) break;
+
+        const val = arrTrimmed.slice(2).trim();
+        arr.push(parseYamlValue(val));
+        i++;
+      }
+      return { value: arr, nextIndex: i };
+    }
+
+    const colonIdx = trimmed.indexOf(':');
+    if (colonIdx === -1) {
+      i++;
+      continue;
+    }
+
+    const key = trimmed.slice(0, colonIdx).trim();
+    const afterColon = trimmed.slice(colonIdx + 1).trim();
+
+    if (afterColon === '' || afterColon === '|' || afterColon === '>') {
+      const nextNonEmpty = findNextNonEmpty(lines, i + 1);
+      if (nextNonEmpty !== null) {
+        const nextLine = lines[nextNonEmpty]!;
+        const nextIndent = nextLine.length - nextLine.trimStart().length;
+        if (nextIndent > indent) {
+          const nested = parseYamlLines(lines, nextNonEmpty, nextIndent);
+          result[key] = nested.value;
+          i = nested.nextIndex;
+        } else {
+          result[key] = null;
+          i++;
+        }
+      } else {
+        result[key] = null;
+        i++;
+      }
+    } else {
+      result[key] = parseYamlValue(afterColon);
+      i++;
+    }
+  }
+
+  return { value: result, nextIndex: i };
+}
+
+function findNextNonEmpty(lines: string[], start: number): number | null {
+  for (let i = start; i < lines.length; i++) {
+    const trimmed = lines[i]!.trim();
+    if (trimmed !== '' && !trimmed.startsWith('#')) return i;
+  }
+  return null;
+}
+
+function parseYamlValue(val: string): unknown {
+  if (val === 'true') return true;
+  if (val === 'false') return false;
+  if (val === 'null' || val === '~') return null;
+
+  if (
+    (val.startsWith('"') && val.endsWith('"')) ||
+    (val.startsWith("'") && val.endsWith("'"))
+  ) {
+    return val.slice(1, -1);
+  }
+
+  if (val.startsWith('[') && val.endsWith(']')) {
+    return val
+      .slice(1, -1)
+      .split(',')
+      .map(s => parseYamlValue(s.trim()));
+  }
+
+  const num = Number(val);
+  if (!isNaN(num) && val !== '') return num;
+
+  return val;
+}
+
+/**
+ * Extract the base URL from the OpenAPI spec servers array.
+ */
+function extractBaseUrl(
+  spec: Record<string, unknown>,
+  fallbackBaseUrl?: string
+): string {
+  const servers = spec.servers;
+  if (Array.isArray(servers) && servers.length > 0) {
+    const first = servers[0] as Record<string, unknown>;
+    if (typeof first.url === 'string') {
+      let url = first.url;
+      const variables = first.variables as
+        | Record<string, { default?: string }>
+        | undefined;
+      if (variables) {
+        for (const [varName, varDef] of Object.entries(variables)) {
+          if (varDef.default) {
+            url = url.replace(`{${varName}}`, varDef.default);
+          }
+        }
+      }
+      if (url.startsWith('/') && fallbackBaseUrl) {
+        return fallbackBaseUrl.replace(/\/+$/, '') + url;
+      }
+      return url.replace(/\/+$/, '');
+    }
+  }
+  return fallbackBaseUrl?.replace(/\/+$/, '') ?? '';
+}
+
+/**
+ * Resolve a $ref path in the spec.
+ */
+function resolveRef(
+  spec: Record<string, unknown>,
+  ref: string
+): Record<string, unknown> | null {
+  if (!ref.startsWith('#/')) return null;
+  const parts = ref.slice(2).split('/');
+  let current: unknown = spec;
+  for (const part of parts) {
+    if (current && typeof current === 'object' && part in current) {
+      current = (current as Record<string, unknown>)[part];
+    } else {
+      return null;
+    }
+  }
+  return current as Record<string, unknown> | null;
+}
+
+/**
+ * Convert an OpenAPI schema object to our FieldDef format.
+ */
+function schemaToFieldDef(
+  spec: Record<string, unknown>,
+  schema: Record<string, unknown>,
+  requiredFields?: string[],
+  fieldName?: string,
+  depth = 0
+): FieldDef {
+  if (depth > 10) return { type: 'object' };
+
+  let resolved = schema;
+  if (typeof schema.$ref === 'string') {
+    const refResolved = resolveRef(spec, schema.$ref);
+    if (refResolved) resolved = refResolved;
+    else return { type: 'object', description: `Unresolved: ${schema.$ref}` };
+  }
+
+  const field: FieldDef = {};
+
+  if (typeof resolved.type === 'string') {
+    field.type = resolved.type;
+  }
+
+  if (typeof resolved.description === 'string') {
+    field.description = resolved.description;
+  }
+
+  if (Array.isArray(resolved.enum)) {
+    field.enum = resolved.enum.map(String);
+  }
+
+  if (fieldName && requiredFields?.includes(fieldName)) {
+    field.required = true;
+  }
+
+  if (resolved.properties && typeof resolved.properties === 'object') {
+    const props: Record<string, FieldDef> = {};
+    const nestedRequired = Array.isArray(resolved.required)
+      ? (resolved.required as string[])
+      : [];
+    for (const [propName, propSchema] of Object.entries(
+      resolved.properties as Record<string, Record<string, unknown>>
+    )) {
+      props[propName] = schemaToFieldDef(
+        spec,
+        propSchema,
+        nestedRequired,
+        propName,
+        depth + 1
+      );
+    }
+    field.properties = props;
+    if (!field.type) field.type = 'object';
+  }
+
+  if (resolved.items && typeof resolved.items === 'object') {
+    field.items = schemaToFieldDef(
+      spec,
+      resolved.items as Record<string, unknown>,
+      undefined,
+      undefined,
+      depth + 1
+    );
+    if (!field.type) field.type = 'array';
+  }
+
+  return field;
+}
+
+/**
+ * Extract parameters from an operation.
+ */
+function extractParams(
+  spec: Record<string, unknown>,
+  parameters: unknown[]
+): {
+  queryParams: Record<string, FieldDef>;
+} {
+  const queryParams: Record<string, FieldDef> = {};
+
+  for (const param of parameters) {
+    let resolved = param as Record<string, unknown>;
+
+    if (typeof resolved.$ref === 'string') {
+      const ref = resolveRef(spec, resolved.$ref);
+      if (ref) resolved = ref;
+      else continue;
+    }
+
+    const name = resolved.name as string;
+    const location = resolved.in as string;
+    const schema = (resolved.schema as Record<string, unknown>) ?? {};
+    const isRequired = resolved.required === true;
+
+    const fieldDef = schemaToFieldDef(spec, schema);
+    fieldDef.required = isRequired;
+    if (typeof resolved.description === 'string') {
+      fieldDef.description = resolved.description;
+    }
+
+    if (location === 'query') {
+      queryParams[name] = fieldDef;
+    }
+  }
+
+  return { queryParams };
+}
+
+/**
+ * Extract request body fields from an operation.
+ */
+function extractBodyFields(
+  spec: Record<string, unknown>,
+  requestBody: Record<string, unknown>
+): Record<string, FieldDef> {
+  let resolved = requestBody;
+  if (typeof resolved.$ref === 'string') {
+    const ref = resolveRef(spec, resolved.$ref);
+    if (ref) resolved = ref;
+    else return {};
+  }
+
+  const content = resolved.content as Record<string, unknown> | undefined;
+  if (!content) return {};
+
+  const jsonContent = (content['application/json'] ??
+    content['application/x-www-form-urlencoded'] ??
+    Object.values(content)[0]) as Record<string, unknown> | undefined;
+
+  if (!jsonContent?.schema) return {};
+
+  const schema = jsonContent.schema as Record<string, unknown>;
+
+  let resolvedSchema = schema;
+  if (typeof schema.$ref === 'string') {
+    const ref = resolveRef(spec, schema.$ref);
+    if (ref) resolvedSchema = ref;
+    else return {};
+  }
+
+  const properties = resolvedSchema.properties as
+    | Record<string, Record<string, unknown>>
+    | undefined;
+  if (!properties) return {};
+
+  const required = Array.isArray(resolvedSchema.required)
+    ? (resolvedSchema.required as string[])
+    : [];
+
+  const fields: Record<string, FieldDef> = {};
+  for (const [name, propSchema] of Object.entries(properties)) {
+    fields[name] = schemaToFieldDef(spec, propSchema, required, name);
+  }
+
+  return fields;
+}
+
+/**
+ * Extract response schema from an operation.
+ */
+function extractResponseSchema(
+  spec: Record<string, unknown>,
+  responses: Record<string, unknown>
+): Record<string, unknown> | null {
+  const response = (responses['200'] ??
+    responses['201'] ??
+    responses['default']) as Record<string, unknown> | undefined;
+  if (!response) return null;
+
+  let resolved = response;
+  if (typeof resolved.$ref === 'string') {
+    const ref = resolveRef(spec, resolved.$ref);
+    if (ref) resolved = ref;
+    else return null;
+  }
+
+  const content = resolved.content as Record<string, unknown> | undefined;
+  if (!content) return null;
+
+  const jsonContent = (content['application/json'] ??
+    Object.values(content)[0]) as Record<string, unknown> | undefined;
+  if (!jsonContent?.schema) return null;
+
+  const schema = jsonContent.schema as Record<string, unknown>;
+
+  if (typeof schema.$ref === 'string') {
+    return resolveRef(spec, schema.$ref);
+  }
+
+  return schema;
+}
+
+const SUPPORTED_METHODS = ['get', 'post', 'put', 'patch', 'delete'];
+
+/**
+ * Parse an OpenAPI spec string and extract endpoints.
+ */
+export function parseOpenAPISpec(
+  content: string,
+  baseUrl?: string
+): ParseSpecResult | ParseSpecError {
+  let spec: Record<string, unknown>;
+  try {
+    spec = parseContent(content) as Record<string, unknown>;
+  } catch (err) {
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : 'Failed to parse spec',
+    };
+  }
+
+  const openapi = spec.openapi ?? spec.swagger;
+  if (!openapi) {
+    return {
+      success: false,
+      error:
+        'Not a valid OpenAPI spec. Missing "openapi" or "swagger" version field.',
+    };
+  }
+
+  const info = spec.info as Record<string, unknown> | undefined;
+  const title = (info?.title as string) ?? null;
+  const description = (info?.description as string) ?? null;
+  const version = (info?.version as string) ?? null;
+
+  const specBaseUrl = extractBaseUrl(spec, baseUrl);
+
+  const paths = spec.paths as Record<
+    string,
+    Record<string, unknown>
+  > | null;
+  if (!paths) {
+    return {
+      success: false,
+      error: 'No paths found in the OpenAPI spec.',
+    };
+  }
+
+  const endpoints: ParsedEndpoint[] = [];
+
+  for (const [path, pathItem] of Object.entries(paths)) {
+    if (!pathItem || typeof pathItem !== 'object') continue;
+
+    const pathParams = Array.isArray(pathItem.parameters)
+      ? pathItem.parameters
+      : [];
+
+    for (const method of SUPPORTED_METHODS) {
+      const operation = pathItem[method] as Record<string, unknown> | undefined;
+      if (!operation) continue;
+
+      const operationParams = Array.isArray(operation.parameters)
+        ? operation.parameters
+        : [];
+      const allParams = [...pathParams, ...operationParams];
+
+      const { queryParams } = extractParams(spec, allParams);
+
+      const bodyFields = operation.requestBody
+        ? extractBodyFields(
+            spec,
+            operation.requestBody as Record<string, unknown>
+          )
+        : {};
+
+      const responseSchema = operation.responses
+        ? extractResponseSchema(
+            spec,
+            operation.responses as Record<string, unknown>
+          )
+        : null;
+
+      const summary = (operation.summary as string) ?? null;
+      const opDescription = (operation.description as string) ?? null;
+
+      endpoints.push({
+        url: specBaseUrl + path,
+        method: method.toUpperCase(),
+        path,
+        description: summary ?? opDescription,
+        operationId: (operation.operationId as string) ?? null,
+        queryParams,
+        bodyFields,
+        responseSchema,
+      });
+    }
+  }
+
+  if (endpoints.length === 0) {
+    return {
+      success: false,
+      error: 'No endpoints found in the OpenAPI spec.',
+    };
+  }
+
+  return {
+    success: true,
+    title,
+    description,
+    version,
+    baseUrl: specBaseUrl,
+    endpoints,
+  };
+}


### PR DESCRIPTION
Adds support for uploading/pasting OpenAPI specs to bulk-register x402 resource endpoints. Resolves #97.

## What this does

- New OpenAPI spec parser (`lib/openapi/parse-spec.ts`) that handles both JSON and YAML formats, extracts endpoints with their methods, query params, body schemas, and response schemas
- New `registerFromOpenAPISpec` tRPC endpoint with dry-run mode so users can preview what will be registered before committing
- UI component on the register page with file upload + paste textarea, base URL override, and detailed results showing which endpoints succeeded/failed
- Only endpoints responding with 402 get registered (others are skipped with clear error messages)

## How it works

1. User uploads or pastes an OpenAPI 3.x spec
2. Click "Parse Spec" to preview all discovered endpoints
3. Review the endpoint list (shows method, path, description, param types)
4. Click "Register All" to attempt registration of each endpoint
5. Results show which endpoints were registered vs failed (with reasons)

The parser handles `$ref` resolution, server variable substitution, and nested schema extraction. No new dependencies needed - the YAML parser is a lightweight built-in that covers the OpenAPI subset.