### PR TITLE
Add Moltalyzer facilitator

### DIFF
--- a/packages/external/facilitators/README.md
+++ b/packages/external/facilitators/README.md
@@ -122,6 +122,7 @@ This package includes pre-configured integrations for the following X402 facilit
 | **Openmid**          | BASE          | No        | No                           |
 | **Primer**           | BASE          | No        | No                           |
 | **RelAI**            | BASE, SOLANA  | ✅ Yes    | No                           |
+| **Moltalyzer**       | BASE          | No        | No                           |
 
 ### Import Individual Facilitators
 

--- a/packages/external/facilitators/src/facilitators/index.ts
+++ b/packages/external/facilitators/src/facilitators/index.ts
@@ -25,3 +25,4 @@ export { primer, primerFacilitator } from './primer';
 export { x402jobs, x402jobsFacilitator } from './x402jobs';
 export { openfacilitator, openfacilitatorFacilitator } from './openfacilitator';
 export { relai, relaiFacilitator } from './relai';
+export { moltalyzer, moltalyzerFacilitator } from './moltalyzer';

--- a/packages/external/facilitators/src/facilitators/moltalyzer.ts
+++ b/packages/external/facilitators/src/facilitators/moltalyzer.ts
@@ -1,0 +1,28 @@
+import { Network } from '../types';
+import { USDC_BASE_TOKEN } from '../constants';
+
+import type { Facilitator, FacilitatorConfig } from '../types';
+
+export const moltalyzer: FacilitatorConfig = {
+  url: 'https://api.moltalyzer.xyz',
+};
+
+export const moltalyzerFacilitator = {
+  id: 'moltalyzer',
+  metadata: {
+    name: 'Moltalyzer',
+    image: 'https://moltalyzer.xyz/molty.png',
+    docsUrl: 'https://api.moltalyzer.xyz/api',
+    color: '#FF6B35',
+  },
+  config: moltalyzer,
+  addresses: {
+    [Network.BASE]: [
+      {
+        address: '0xef9aee373ae9efee085fc0e727399a4d96cdbdc6',
+        tokens: [USDC_BASE_TOKEN],
+        dateOfFirstTransaction: new Date('2026-02-04'),
+      },
+    ],
+  },
+} as const satisfies Facilitator;

--- a/packages/external/facilitators/src/lists/all.ts
+++ b/packages/external/facilitators/src/lists/all.ts
@@ -25,6 +25,7 @@ import {
   x402jobsFacilitator,
   openfacilitatorFacilitator,
   relaiFacilitator,
+  moltalyzerFacilitator,
 } from '../facilitators';
 
 import { validateUniqueFacilitators } from './validate';
@@ -58,6 +59,7 @@ const FACILITATORS = validateUniqueFacilitators([
   x402jobsFacilitator,
   openfacilitatorFacilitator,
   relaiFacilitator,
+  moltalyzerFacilitator,
 ]);
 
 export const allFacilitators: Facilitator[] =


### PR DESCRIPTION
# Add Facilitator

## Summary

- Facilitator Name: `Moltalyzer`
- URL: `https://api.moltalyzer.xyz`
- Website: `https://moltalyzer.xyz`
- Short description: Self-hosted x402 facilitator on Base (USDC) powering three AI intelligence feeds — Moltbook community digests, GitHub trending repos, and Polymarket insider detection. 7 pay-per-call endpoints from $0.005.

## Signer Address

- **Base**: `0xef9aee373ae9efee085fc0e727399a4d96cdbdc6`
- **Token**: USDC
- **First transaction**: 2026-02-04

## Files Changed

- `packages/external/facilitators/src/facilitators/moltalyzer.ts` — New facilitator definition
- `packages/external/facilitators/src/facilitators/index.ts` — Export
- `packages/external/facilitators/src/lists/all.ts` — Register in all facilitators list
- `packages/external/facilitators/README.md` — Add to table