### PR TITLE
feat: update Dexter facilitator with Polygon support

### DIFF
--- a/packages/external/facilitators/src/facilitators/dexter.ts
+++ b/packages/external/facilitators/src/facilitators/dexter.ts
@@ -1,5 +1,5 @@
 import { Network } from '../types';
-import { USDC_BASE_TOKEN, USDC_SOLANA_TOKEN } from '../constants';
+import { USDC_BASE_TOKEN, USDC_POLYGON_TOKEN, USDC_SOLANA_TOKEN } from '../constants';
 
 import type { Facilitator, FacilitatorConfig } from '../types';
 
@@ -34,6 +34,13 @@ export const dexterFacilitator = {
         address: '0x40272E2eAc848Ea70db07Fd657D799bD309329C4',
         tokens: [USDC_BASE_TOKEN],
         dateOfFirstTransaction: new Date('2025-12-25'),
+      },
+    ],
+    [Network.POLYGON]: [
+      {
+        address: '0x40272E2eAc848Ea70db07Fd657D799bD309329C4',
+        tokens: [USDC_POLYGON_TOKEN],
+        dateOfFirstTransaction: new Date('2026-01-27'),
       },
     ],
   },


### PR DESCRIPTION
## Summary

- Add Polygon address to Dexter facilitator config
- Same EVM address (`0x40272E2eAc848Ea70db07Fd657D799bD309329C4`) used across all EVM chains
- Dexter facilitator now supports 7 mainnets: Solana, Base, Polygon, Arbitrum, Optimism, Avalanche, and SKALE Europa
- Only the 3 chains in the `Network` enum are listed (Solana, Base, Polygon)

## Notes

Dexter added Polygon support on Jan 27, 2026. Arbitrum, Optimism, and Avalanche followed shortly after. SKALE Europa (zero-gas) was added today (Feb 25, 2026).

Would be happy to add the remaining chains if/when the `Network` enum is expanded.

Made with [Cursor](https://cursor.com)