### PR TITLE
fix(scan): avoid double-encoding proxy URL

### DIFF
--- a/apps/scan/src/lib/x402/proxy-fetch.ts
+++ b/apps/scan/src/lib/x402/proxy-fetch.ts
@@ -40,7 +40,7 @@ export const fetchWithProxy = async (
   }
 
   const proxyUrl = new URL(PROXY_ENDPOINT, env.NEXT_PUBLIC_PROXY_URL);
-  proxyUrl.searchParams.set('url', encodeURIComponent(url));
+  proxyUrl.searchParams.set('url', url);
   proxyUrl.searchParams.set('share_data', 'true');
 
   const { method = 'GET', ...restInit } = effectiveInit ?? {};


### PR DESCRIPTION
## Summary\n- remove redundant encodeURIComponent when setting proxy  query param\n- keep URL encoding to URLSearchParams only\n\n## Problem\nDeveloper payment execution requests could be malformed as  (double-encoded), causing fetch failures.\n\n## Validation\n- pnpm --filter @x402scan/app types:check