### PR TITLE
Point invite code URL to agentcash.dev

### DIFF
--- a/apps/scan/src/app/(app)/admin/invite-codes/_components/columns.tsx
+++ b/apps/scan/src/app/(app)/admin/invite-codes/_components/columns.tsx
@@ -275,7 +275,7 @@ export const createColumns = (
             <DropdownMenuItem
               onClick={() =>
                 void navigator.clipboard.writeText(
-                  `${window.location.origin}/mcp?invite=${encodeURIComponent(row.original.code)}`
+                  `https://agentcash.dev?invite=${encodeURIComponent(row.original.code)}`
                 )
               }
             >


### PR DESCRIPTION
## Summary
- Changes the "Copy Full URL" button on the invite codes admin page to generate `agentcash.dev?invite=CODE` instead of `x402scan.com/mcp?invite=CODE`
- This sends users to the agentcash install walkthrough where they can pick their client and redeem the invite code