### PR TITLE
Harden register-from-origin: method fallback + concurrency limit

### DIFF
--- a/apps/scan/src/trpc/routers/public/resources.ts
+++ b/apps/scan/src/trpc/routers/public/resources.ts
@@ -43,7 +43,92 @@ import {
 
 import type { Prisma } from '@x402scan/scan-db';
 import type { SupportedChain } from '@/types/chain';
-import type { DiscoveryInfo } from '@/types/discovery';
+import type { DiscoveryInfo, DiscoveredResource } from '@/types/discovery';
+
+const BULK_REGISTER_CONCURRENCY = 6;
+const METHOD_FALLBACKS = [Methods.DELETE, Methods.PUT, Methods.PATCH] as const;
+
+function uniqueMethods(methods: Methods[]): Methods[] {
+  return Array.from(new Set(methods));
+}
+
+function primaryMethodsToTry(resource: DiscoveredResource): Methods[] {
+  if (resource.method) {
+    return uniqueMethods([resource.method as Methods, Methods.POST, Methods.GET]);
+  }
+  return [Methods.POST, Methods.GET];
+}
+
+function probeInitForMethod(method: Methods): {
+  headers: Record<string, string>;
+  body?: string;
+} {
+  if (
+    method === Methods.POST ||
+    method === Methods.PUT ||
+    method === Methods.PATCH
+  ) {
+    return {
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-cache',
+      },
+      body: '{}',
+    };
+  }
+
+  return {
+    headers: { 'Cache-Control': 'no-cache' },
+  };
+}
+
+async function mapSettledWithConcurrency<T, R>(
+  items: T[],
+  mapper: (item: T, index: number) => Promise<R>,
+  concurrency = BULK_REGISTER_CONCURRENCY
+): Promise<PromiseSettledResult<R>[]> {
+  const results: (PromiseSettledResult<R> | undefined)[] = Array.from({
+    length: items.length,
+  });
+  let nextIndex = 0;
+
+  async function worker() {
+    while (true) {
+      const current = nextIndex;
+      nextIndex += 1;
+
+      if (current >= items.length) return;
+      const item = items[current] as T;
+
+      try {
+        const value = await mapper(item, current);
+        results[current] = {
+          status: 'fulfilled',
+          value,
+        };
+      } catch (reason) {
+        results[current] = {
+          status: 'rejected',
+          reason,
+        };
+      }
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, items.length) }, () => worker())
+  );
+
+  return results.map((result, index) => {
+    if (!result) {
+      return {
+        status: 'rejected',
+        reason: new Error(`Missing result at index ${index}`),
+      };
+    }
+    return result;
+  });
+}
 
 export const resourcesRouter = createTRPCRouter({
   get: publicProcedure.input(z.string()).query(async ({ input }) => {
@@ -312,33 +397,30 @@ export const resourcesRouter = createTRPCRouter({
         return 'Unknown error';
       }
 
-      const results = await Promise.allSettled(
-        discoveryResult.resources.map(async resource => {
+      const results = await mapSettledWithConcurrency(
+        discoveryResult.resources,
+        async resource => {
           const resourceUrl = resource.url;
-          // Always try both POST and GET to find which method works
-          const methodsToTry = [Methods.POST, Methods.GET];
+          const methodsToTry = primaryMethodsToTry(resource);
 
           let lastError = 'No 402 response';
           let lastStatus: number | undefined;
           const errors: string[] = [];
+          const methodStatuses = new Map<Methods, number>();
 
-          for (const method of methodsToTry) {
+          const tryMethod = async (method: Methods) => {
             try {
+              const probeInit = probeInitForMethod(method);
               const response = await fetch(resourceUrl, {
                 method,
-                headers:
-                  method === Methods.POST
-                    ? {
-                        'Content-Type': 'application/json',
-                        'Cache-Control': 'no-cache',
-                      }
-                    : { 'Cache-Control': 'no-cache' },
-                body: method === Methods.POST ? '{}' : undefined,
+                headers: probeInit.headers,
+                body: probeInit.body,
                 signal: AbortSignal.timeout(15000),
                 cache: 'no-store',
               });
 
               lastStatus = response.status;
+              methodStatuses.set(method, response.status);
 
               if (response.status === 402) {
                 // Extract x402 data (handles v2 header and v1 body, with JSON parse fallback)
@@ -355,7 +437,6 @@ export const resourcesRouter = createTRPCRouter({
                   getErrorMessage(result.error) || 'Registration failed';
                 errors.push(`${method}: ${errorMsg}`);
                 lastError = errors.join('; ');
-                // Continue to try next method - don't break
               } else {
                 const errorMsg = `Expected 402, got ${response.status}`;
                 errors.push(`${method}: ${errorMsg}`);
@@ -367,6 +448,30 @@ export const resourcesRouter = createTRPCRouter({
               errors.push(`${method}: ${errorMsg}`);
               lastError = errors.join('; ');
             }
+
+            return null;
+          };
+
+          for (const method of methodsToTry) {
+            const successfulResult = await tryMethod(method);
+            if (successfulResult) {
+              return successfulResult;
+            }
+          }
+
+          // Legacy fallback: if discovery did not specify method and both
+          // default probe methods are method-not-allowed, try uncommon methods.
+          if (
+            !resource.method &&
+            methodStatuses.get(Methods.POST) === 405 &&
+            methodStatuses.get(Methods.GET) === 405
+          ) {
+            for (const fallbackMethod of METHOD_FALLBACKS) {
+              const successfulResult = await tryMethod(fallbackMethod);
+              if (successfulResult) {
+                return successfulResult;
+              }
+            }
           }
 
           return {
@@ -375,7 +480,7 @@ export const resourcesRouter = createTRPCRouter({
             error: lastError,
             status: lastStatus,
           };
-        })
+        }
       );
 
       // Separate successful and failed results with details


### PR DESCRIPTION
## Summary
- add method-aware probe planning in `registerFromOrigin`
  - uses discovery method hint when present
  - keeps POST/GET probes for compatibility
  - if no hint and POST+GET both return 405, falls back to DELETE/PUT/PATCH
- add per-method probe request init (JSON body for POST/PUT/PATCH)
- throttle bulk registration concurrency to reduce DB transaction contention (`BULK_REGISTER_CONCURRENCY = 6`)
- add internal bounded-concurrency settled mapper

## Why
Recent stabletravel registration failures were a mix of:
1) DELETE-only endpoints (e.g. `flights/orders/cancel`) not reachable via POST/GET-only probing
2) bursty transaction contention during parallel bulk upserts (`Unable to start a transaction in the given time`)

This change addresses both without breaking existing legacy probing behavior.

## Validation
- `pnpm --filter @x402scan/app types:check`
- `pnpm --filter @x402scan/app exec eslint src/trpc/routers/public/resources.ts --max-warnings 0`
