### PR TITLE
Fix #104: [Feature Request] Add Resources Programmatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ We're actively seeking contributors to help build x402scan. We believe an ecosys
 
 If you know of a resource that is not yet listed, you can add it by visiting [https://www.x402scan.com/resources/register](https://www.x402scan.com/resources/register) and submitting the URL. If the URL returns a valid x402 schema, it will be added to the resources list automatically.
 
+You can also register or refresh resources programmatically via:
+- `POST https://www.x402scan.com/api/data/registry/register` for a single resource URL
+- `POST https://www.x402scan.com/api/data/registry/register-origin` for discovery-based origin refresh
+
+Request/response examples are documented in [docs/DISCOVERY.md](./docs/DISCOVERY.md#programmatic-registration-api).
+
 ### Add Facilitators
 
 If you know of another facilitator that is not listed, you can add it to [`facilitators/config.ts`](https://github.com/Merit-Systems/x402scan/blob/main/facilitators/config.ts) and the dashboard will automatically update.

--- a/apps/scan/src/app/api/data/_lib/schemas.ts
+++ b/apps/scan/src/app/api/data/_lib/schemas.ts
@@ -100,6 +100,14 @@ export const originResourcesQuerySchema = paginationSchema.extend({
 
 export const registryRegisterBodySchema = z.object({
   url: z.string().url().describe('URL of the x402-protected resource to register'),
+  headers: z
+    .record(z.string(), z.string())
+    .optional()
+    .describe('Optional headers to include when probing the resource URL'),
+  body: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe('Optional JSON body used when probing with POST'),
 });
 
 export const registryRegisterOriginBodySchema = z.object({

--- a/apps/scan/src/app/api/data/registry/register/route.ts
+++ b/apps/scan/src/app/api/data/registry/register/route.ts
@@ -15,7 +15,7 @@ export const POST = async (request: NextRequest) => {
   const parsed = await parseJsonBody(request, registryRegisterBodySchema);
   if (!parsed.success) return parsed.response;
 
-  const { url } = parsed.data;
+  const { url, headers, body } = parsed.data;
 
   let lastParseError: {
     parseErrors: string[];
@@ -30,9 +30,18 @@ export const POST = async (request: NextRequest) => {
         method,
         headers:
           method === Methods.POST
-            ? { 'Content-Type': 'application/json', 'Cache-Control': 'no-cache' }
-            : { 'Cache-Control': 'no-cache' },
-        body: method === Methods.POST ? '{}' : undefined,
+            ? {
+                ...headers,
+                'Content-Type': 'application/json',
+                'Cache-Control': 'no-cache',
+              }
+            : { ...headers, 'Cache-Control': 'no-cache' },
+        body:
+          method === Methods.POST
+            ? body
+              ? JSON.stringify(body)
+              : '{}'
+            : undefined,
         signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
         cache: 'no-store',
       });

--- a/apps/scan/src/app/api/data/registry/register/route.ts
+++ b/apps/scan/src/app/api/data/registry/register/route.ts
@@ -15,7 +15,7 @@ export const POST = async (request: NextRequest) => {
   const parsed = await parseJsonBody(request, registryRegisterBodySchema);
   if (!parsed.success) return parsed.response;
 
-  const { url, headers, body } = parsed.data;
+  const { url, headers = {}, body } = parsed.data;
 
   let lastParseError: {
     parseErrors: string[];

--- a/docs/DISCOVERY.md
+++ b/docs/DISCOVERY.md
@@ -166,6 +166,45 @@ When a user clicks **Register This URL Only**:
 - Register only that endpoint.
 - Useful for partial rollouts and rate-limited providers.
 
+## Programmatic Registration API
+
+You can add or refresh resources programmatically using public API endpoints.
+
+### Register or refresh a single resource
+
+```bash
+curl -X POST https://www.x402scan.com/api/data/registry/register \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://yourdomain.com/api/paid-endpoint",
+    "headers": {
+      "Authorization": "Bearer your-probe-token"
+    },
+    "body": {
+      "example": "probe"
+    }
+  }'
+```
+
+Notes:
+- `headers` and `body` are optional.
+- Re-submitting the same `url` triggers a refresh (metadata and challenge data are re-probed and upserted).
+
+### Register or refresh all resources discovered from an origin
+
+```bash
+curl -X POST https://www.x402scan.com/api/data/registry/register-origin \
+  -H "Content-Type: application/json" \
+  -d '{
+    "origin": "https://yourdomain.com"
+  }'
+```
+
+This endpoint:
+- discovers resources from OpenAPI / `/.well-known/x402` / DNS pointer precedence,
+- registers all valid `402` resources found, and
+- deprecates previously-registered resources no longer present in discovery.
+
 ---
 
 ## Common Failure Reasons


### PR DESCRIPTION
## Summary

This PR resolves #104.

### Changes

Exposed programmatic resource registration/refresh more completely by extending the public registry register API to accept optional probe headers/body (matching TRPC behavior) and added documentation for single-resource and origin-wide programmatic registration/refresh flows.

### Files Modified

- `apps/scan/src/app/api/data/_lib/schemas.ts`
- `apps/scan/src/app/api/data/registry/register/route.ts`
- `docs/DISCOVERY.md`
- `README.md`

Happy to address any feedback or make adjustments.

/claim #104