### PR TITLE
fix(cache): prevent Redis key too long error from bazaar address lists

### DIFF
--- a/apps/scan/src/app/api/cron/warm-cache/route.ts
+++ b/apps/scan/src/app/api/cron/warm-cache/route.ts
@@ -114,8 +114,10 @@ function getHomePageTasks(
       }),
 
     // Top Servers (Bazaar) - overall stats
+    // Uses origin-based MV (pre-joined), not stats.bazaar.overall which
+    // passes 1000+ addresses into the cache key and blows the Redis key limit.
     () =>
-      api.public.stats.bazaar.overall({
+      api.public.sellers.bazaar.stats.overall({
         timeframe,
         chain,
       }),

--- a/apps/scan/src/lib/cache.ts
+++ b/apps/scan/src/lib/cache.ts
@@ -1,7 +1,14 @@
+import { createHash } from 'crypto';
 import superjson from 'superjson';
 import type { PaginatedQueryParams } from './pagination';
 import { getRedisClient } from './redis';
 import { CACHE_DURATION_MINUTES } from './cache-constants';
+
+/**
+ * Maximum Redis key length in bytes. Keys exceeding this are hashed to prevent
+ * "ERR key too long" errors (e.g. when address lists are serialized into keys).
+ */
+const MAX_KEY_LENGTH = 1024;
 
 /**
  * Cache context that can be passed from tRPC to control cache behavior
@@ -193,7 +200,13 @@ const createCachedQueryBase = <TInput extends unknown[], TOutput>(config: {
       : (allArgs as unknown as TInput);
 
     const cacheKey = config.createCacheKey(...args);
-    const fullCacheKey = `${config.cacheKeyPrefix}:${cacheKey}`;
+    const rawKey = `${config.cacheKeyPrefix}:${cacheKey}`;
+    // Hash oversized keys to prevent Redis "ERR key too long" errors.
+    // Preserves the prefix for debuggability.
+    const fullCacheKey =
+      rawKey.length > MAX_KEY_LENGTH
+        ? `${config.cacheKeyPrefix}:hash:${createHash('sha256').update(rawKey).digest('hex')}`
+        : rawKey;
     const ttl = config.revalidate ?? CACHE_TTL_SECONDS;
 
     return await withRedisCache(

--- a/apps/scan/src/trpc/routers/public/stats.ts
+++ b/apps/scan/src/trpc/routers/public/stats.ts
@@ -4,8 +4,6 @@ import {
 } from '@/services/transfers/stats/first-transfer';
 
 import { createTRPCRouter, publicProcedure } from '../../trpc';
-import { getAcceptsAddresses } from '@/services/db/resources/accepts';
-import { mixedAddressSchema } from '@/lib/schemas';
 import {
   getOverallStatisticsMV,
   overallStatisticsMVInputSchema,
@@ -31,43 +29,4 @@ export const statsRouter = createTRPCRouter({
     .query(async ({ input }) => {
       return await getFirstTransferTimestamp(input);
     }),
-
-  bazaar: {
-    overall: publicProcedure
-      .input(overallStatisticsMVInputSchema)
-      .query(async ({ input, ctx }) => {
-        const originsByAddress = await getAcceptsAddresses({
-          chain: input.chain,
-        });
-        return await getOverallStatisticsMV(
-          {
-            ...input,
-            recipients: {
-              include: Object.keys(originsByAddress).map(addr =>
-                mixedAddressSchema.parse(addr)
-              ),
-            },
-          },
-          ctx
-        );
-      }),
-    bucketed: publicProcedure
-      .input(bucketedStatisticsMVInputSchema)
-      .query(async ({ input, ctx }) => {
-        const originsByAddress = await getAcceptsAddresses({
-          chain: input.chain,
-        });
-        return await getBucketedStatisticsMV(
-          {
-            ...input,
-            recipients: {
-              include: Object.keys(originsByAddress).map(addr =>
-                mixedAddressSchema.parse(addr)
-              ),
-            },
-          },
-          ctx
-        );
-      }),
-  },
 });


### PR DESCRIPTION
## Summary
- Cache warming called `stats.bazaar.overall` which fetched 1000+ origin addresses and serialized them into a 66KB Redis cache key, causing `ERR key too long 66608`
- Switched to `sellers.bazaar.stats.overall` which uses pre-joined origin MVs (no address list in key), matching what the frontend already uses
- Removed dead `stats.bazaar` routes from stats.ts (only caller was cache warming)
- Added safety net: cache keys exceeding 1KB are automatically SHA-256 hashed to prevent this class of bug

## Test plan
- [ ] Verify cache warming completes without `ERR key too long` errors
- [ ] Verify homepage bazaar stats still load correctly
- [ ] Verify resources page charts still display bazaar stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)