### PR TITLE
fix(solana): check ATA existence before querying token balance

### DIFF
--- a/apps/scan/src/services/solana/balance.ts
+++ b/apps/scan/src/services/solana/balance.ts
@@ -26,21 +26,33 @@ export const getSolanaTokenBalance = async (
   const { ownerAddress, tokenMint } = getSolanaTokenBalanceSchema.parse(input);
 
   try {
-    const [usdcTokenAccount] = await findAssociatedTokenPda({
+    const [tokenAccount] = await findAssociatedTokenPda({
       mint: address(tokenMint),
       owner: address(ownerAddress),
       tokenProgram: TOKEN_PROGRAM_ADDRESS,
     });
     const {
       value: { amount, decimals },
-    } = await solanaRpc.getTokenAccountBalance(usdcTokenAccount).send();
+    } = await solanaRpc.getTokenAccountBalance(tokenAccount).send();
 
     return convertTokenAmount(BigInt(amount), decimals);
   } catch (error) {
-    console.error('Error getting Solana token balance', error);
+    // Wallets that have never held this token won't have an ATA on-chain.
+    // getTokenAccountBalance throws RPC -32602 ("could not find account")
+    // which is expected — only log unexpected errors.
+    if (!isAccountNotFoundError(error)) {
+      console.error('Error getting Solana token balance', error);
+    }
     return 0;
   }
 };
+
+/** RPC -32602 "could not find account" — the ATA doesn't exist on-chain. */
+function isAccountNotFoundError(error: unknown): boolean {
+  if (!(error instanceof Error) || !('context' in error)) return false;
+  const ctx = (error as { context: Record<string, unknown> }).context;
+  return ctx?.__code === -32602;
+}
 
 export const getSolanaNativeBalance = async (
   ownerAddress: z.output<typeof solanaAddressSchema>


### PR DESCRIPTION
## Summary
- Fixes noisy `SolanaError #-32602: could not find account` errors in production on the `chainsWithBalances` tRPC route
- Wallets without an Associated Token Account (never held USDC) trigger this expected RPC error from `getTokenAccountBalance`
- Detects the specific `-32602` error code and suppresses logging for this case, while still logging unexpected errors

## Test plan
- [ ] Verify `chainsWithBalances` returns correctly for wallets with USDC
- [ ] Verify wallets without Solana USDC no longer produce error logs
- [ ] Check that the public Solana balance query also works correctly (shares same function)

🤖 Generated with [Claude Code](https://claude.com/claude-code)