### PR TITLE
feat(scan): add register-origin step to agent integration prompt

### DIFF
--- a/apps/scan/src/app/(app)/(home)/integration-spec/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/integration-spec/page.tsx
@@ -38,8 +38,7 @@ Schema guidance (important):
 - This is required for reliable agent invocation and robust listing behavior.
 - TypeScript recommendation (optional): Zod v4 is a good source of truth, but any valid schema pipeline is fine.
 
-OpenAPI payable operation must include ALL:
-- x-agentcash-auth: { mode: "paid" }
+OpenAPI payable operation must include:
 - x-payment-info with:
   - protocols: ["x402"]
   - pricingMode + fields:
@@ -48,12 +47,6 @@ OpenAPI payable operation must include ALL:
     - quote: { pricingMode: "quote" }
   - IMPORTANT: for fixed pricing use "price" (not "amount")
 - responses: { "402": { description: "Payment Required" } }
-
-Auth mode rules (x-agentcash-auth.mode):
-- allowed: "paid" | "siwx" | "apiKey"
-- payable route => mode must be "paid"
-- non-payable auth-only route can use "siwx" or "apiKey"
-- if a route is payable and also supports SIWX, keep mode as "paid"
 
 /.well-known/x402 must be exactly:
 {
@@ -70,6 +63,12 @@ Workflow:
 1) Audit discovery and probe failures.
 2) Fix discovery metadata and 402 behavior.
 3) Re-run audits until clean.
+4) Register on x402scan:
+   curl -X POST https://x402scan.com/api/data/registry/register-origin \\
+     -H "Content-Type: application/json" \\
+     -d '{ "origin": "$TARGET_URL" }'
+   Returns: { registered, failed, deprecated, total, source, failedDetails? }
+   If failedDetails has entries, fix those endpoints and re-register.
 
 Validation commands:
 npx -y @agentcash/discovery "$TARGET_URL" --json
@@ -78,7 +77,8 @@ npx -y @agentcash/discovery "$TARGET_URL" -v
 Done when:
 - resources are discovered
 - OpenAPI is selected when present (otherwise well-known is acceptable fallback)
-- no critical parser/probe errors remain`;
+- no critical parser/probe errors remain
+- server is registered on x402scan with no failed resources`;
 
 function CodeBlock({ code }: { code: string }) {
   return (


### PR DESCRIPTION
## Summary

- Add step 4 to `agentPrompt`: register on x402scan via `POST /api/data/registry/register-origin`
- Add "registered on x402scan with no failed resources" to done-when criteria