### PR TITLE
Fix HTML entity encoding in origin metadata display

### DIFF
--- a/apps/scan/src/app/(app)/(home)/resources/(overview)/_components/carousel/origin-card/index.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/(overview)/_components/carousel/origin-card/index.tsx
@@ -16,6 +16,7 @@ import { Favicon } from '@/app/(app)/_components/favicon';
 import { FooterStat, LoadingFooterStat } from './stat';
 
 import { convertTokenAmount } from '@/lib/token';
+import { decodeHtmlEntities } from '@/lib/utils';
 
 import type { RouterOutputs } from '@/trpc/client';
 
@@ -39,7 +40,7 @@ export const OriginCard: React.FC<Props> = ({ origin }) => {
               />
               <div className="flex-1 overflow-hidden">
                 <CardTitle className="font-bold text-sm md:text-base truncate group-hover:text-primary transition-colors">
-                  {originWithMetadata.title ?? 'No Title'}
+                  {originWithMetadata.title ? decodeHtmlEntities(originWithMetadata.title) : 'No Title'}
                 </CardTitle>
                 <p className="text-[10px] md:text-xs text-muted-foreground truncate font-mono">
                   {originWithMetadata.origin}
@@ -47,7 +48,7 @@ export const OriginCard: React.FC<Props> = ({ origin }) => {
               </div>
             </div>
             <CardDescription className="text-muted-foreground text-[10px] md:text-xs line-clamp-2">
-              {originWithMetadata?.description ?? 'No description'}
+              {originWithMetadata?.description ? decodeHtmlEntities(originWithMetadata.description) : 'No description'}
             </CardDescription>
           </CardHeader>
         </div>

--- a/apps/scan/src/app/(app)/@breadcrumbs/server/[id]/layout.tsx
+++ b/apps/scan/src/app/(app)/@breadcrumbs/server/[id]/layout.tsx
@@ -4,6 +4,7 @@ import { Breadcrumb } from '../../_components/breadcrumb';
 
 import { Separator } from '../../_components/separator';
 import { api } from '@/trpc/server';
+import { decodeHtmlEntities } from '@/lib/utils';
 import { notFound } from 'next/navigation';
 
 export default async function OriginLayout({
@@ -28,7 +29,7 @@ export default async function OriginLayout({
       <Breadcrumb
         href={`/server/${id}`}
         image={origin.favicon}
-        name={origin.title ?? new URL(origin.origin).hostname}
+        name={origin.title ? decodeHtmlEntities(origin.title) : new URL(origin.origin).hostname}
         Fallback={Wallet}
         mobileHideText
         className="hidden md:block min-w-0"

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
@@ -23,7 +23,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import { cn } from '@/lib/utils';
+import { cn, decodeHtmlEntities } from '@/lib/utils';
 
 import { Favicon } from '@/app/(app)/_components/favicon';
 import { ResourceExecutor } from '@/app/(app)/_components/resources/executor';
@@ -1504,7 +1504,7 @@ function OriginPreviewCard({
                     !origin.title && 'opacity-60'
                   )}
                 >
-                  {origin.title ?? 'No Title'}
+                  {origin.title ? decodeHtmlEntities(origin.title) : 'No Title'}
                 </h3>
                 <p
                   className={cn(
@@ -1512,7 +1512,7 @@ function OriginPreviewCard({
                     !origin.description && 'text-muted-foreground/60'
                   )}
                 >
-                  {origin.description ?? 'No Description'}
+                  {origin.description ? decodeHtmlEntities(origin.description) : 'No Description'}
                 </p>
               </div>
             </div>
@@ -1524,7 +1524,7 @@ function OriginPreviewCard({
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={origin.ogImages[0]!.url}
-            alt={origin.title ?? ''}
+            alt={origin.title ? decodeHtmlEntities(origin.title) : ''}
             className="rounded-md max-h-24"
           />
         </div>

--- a/apps/scan/src/app/(app)/_components/origins.tsx
+++ b/apps/scan/src/app/(app)/_components/origins.tsx
@@ -11,7 +11,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Address, Addresses } from '@/components/ui/address';
 
 import { Favicon } from '@/app/(app)/_components/favicon';
-import { cn } from '@/lib/utils';
+import { cn, decodeHtmlEntities } from '@/lib/utils';
 
 import type { ResourceOrigin } from '@x402scan/scan-db/types';
 import type { MixedAddress } from '@/types/address';
@@ -89,7 +89,7 @@ export const Origins: React.FC<Props> = ({
               <ul className="list-disc list-inside">
                 {origins.slice(1).map(origin => (
                   <li key={origin.id}>
-                    {origin.title ?? new URL(origin.origin).hostname}
+                    {origin.title ? decodeHtmlEntities(origin.title) : new URL(origin.origin).hostname}
                   </li>
                 ))}
               </ul>

--- a/apps/scan/src/app/(app)/_components/resources/origin.tsx
+++ b/apps/scan/src/app/(app)/_components/resources/origin.tsx
@@ -2,7 +2,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
 import { Favicon } from '@/app/(app)/_components/favicon';
 
-import { cn } from '@/lib/utils';
+import { cn, decodeHtmlEntities } from '@/lib/utils';
 
 import type { OgImage, ResourceOrigin } from '@x402scan/scan-db/types';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -55,7 +55,7 @@ export const OriginCard: React.FC<Props> = ({
                     !origin.title && 'opacity-60'
                   )}
                 >
-                  {origin.title ?? 'No Title'}
+                  {origin.title ? decodeHtmlEntities(origin.title) : 'No Title'}
                 </h3>
                 <p
                   className={cn(
@@ -63,7 +63,7 @@ export const OriginCard: React.FC<Props> = ({
                     !origin.description && 'text-muted-foreground/60'
                   )}
                 >
-                  {origin.description ?? 'No Description'}
+                  {origin.description ? decodeHtmlEntities(origin.description) : 'No Description'}
                 </p>
               </div>
             </div>
@@ -75,7 +75,7 @@ export const OriginCard: React.FC<Props> = ({
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={origin.ogImages[0]!.url}
-            alt={origin.ogImages[0]!.title ?? ''}
+            alt={origin.ogImages[0]!.title ? decodeHtmlEntities(origin.ogImages[0]!.title) : ''}
             className="rounded-md max-h-24"
           />
         </div>

--- a/apps/scan/src/app/(app)/admin/resource-search/_components/table/columns.tsx
+++ b/apps/scan/src/app/(app)/admin/resource-search/_components/table/columns.tsx
@@ -3,6 +3,7 @@ import { Badge } from '@/components/ui/badge';
 import { Avatar } from '@/components/ui/avatar';
 import { Globe, TrendingUp, Zap, CheckCircle, Filter } from 'lucide-react';
 import type { FilteredSearchResult } from '@/services/resource-search/types';
+import { decodeHtmlEntities } from '@/lib/utils';
 import { HeaderCell } from '@/components/ui/data-table/header-cell';
 import { ResourceSearchSortingContext } from '@/app/(app)/_contexts/sorting/resource-search/context';
 
@@ -94,7 +95,7 @@ export const createColumns = (): ExtendedColumnDef<FilteredSearchResult>[] => [
     cell: ({ row }) => {
       const origin = row.original.origin;
       const favicon = origin.favicon;
-      const title = origin.title ?? origin.origin;
+      const title = origin.title ? decodeHtmlEntities(origin.title) : origin.origin;
 
       return (
         <div className="flex items-center gap-3">

--- a/apps/scan/src/app/(app)/server/[id]/(overview)/_components/header/index.tsx
+++ b/apps/scan/src/app/(app)/server/[id]/(overview)/_components/header/index.tsx
@@ -9,7 +9,7 @@ import { Avatar } from '@/components/ui/avatar';
 
 import { OriginStats, LoadingOriginStats } from './stats';
 
-import { cn } from '@/lib/utils';
+import { cn, decodeHtmlEntities } from '@/lib/utils';
 
 import { HeaderButtons, LoadingHeaderButtons } from './buttons';
 
@@ -35,7 +35,7 @@ export const HeaderCard: React.FC<Props> = ({ origin }) => {
           <div className="">
             <div className="flex items-center gap-2 min-w-0">
               <h1 className="text-xl md:text-3xl font-bold wrap-break-word line-clamp-2 min-w-0">
-                {origin.title ?? new URL(origin.origin).hostname}
+                {origin.title ? decodeHtmlEntities(origin.title) : new URL(origin.origin).hostname}
               </h1>
               {origin.hasX402V2Resource && (
                 <X402V2Badge className="mt-1 shrink-0" />
@@ -59,7 +59,7 @@ export const HeaderCard: React.FC<Props> = ({ origin }) => {
                   : 'text-muted-foreground'
               )}
             >
-              {origin.description ?? 'No Description'}
+              {origin.description ? decodeHtmlEntities(origin.description) : 'No Description'}
             </p>
           </div>
           <Suspense fallback={<LoadingHeaderButtons />}>

--- a/apps/scan/src/app/(app)/server/[id]/layout.tsx
+++ b/apps/scan/src/app/(app)/server/[id]/layout.tsx
@@ -1,5 +1,6 @@
 import { Nav } from '@/app/(app)/_components/layout/nav';
 import { env } from '@/env';
+import { decodeHtmlEntities } from '@/lib/utils';
 import { api } from '@/trpc/server';
 import type { Metadata } from 'next';
 
@@ -37,8 +38,8 @@ export async function generateMetadata({
     return { title: 'Server not found' };
   }
 
-  const title = origin.title ?? origin.origin;
-  const description = origin.description ?? `Explore ${title} on x402scan`;
+  const title = origin.title ? decodeHtmlEntities(origin.title) : origin.origin;
+  const description = origin.description ? decodeHtmlEntities(origin.description) : `Explore ${title} on x402scan`;
 
   const imageUrl = origin.ogImages?.[0]?.url
     ? new URL(origin.ogImages[0].url, env.NEXT_PUBLIC_APP_URL).toString()

--- a/apps/scan/src/lib/utils.ts
+++ b/apps/scan/src/lib/utils.ts
@@ -93,6 +93,20 @@ export const USDC_ADDRESS = {
   [Chain.OPTIMISM]: '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85' as const,
 } satisfies Record<Chain, MixedAddress>;
 
+const HTML_ENTITIES: Record<string, string> = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#39;': "'",
+  '&apos;': "'",
+};
+
+const ENTITY_PATTERN = /&(?:amp|lt|gt|quot|#39|apos);/g;
+
+export const decodeHtmlEntities = (str: string): string =>
+  str.replace(ENTITY_PATTERN, match => HTML_ENTITIES[match] ?? match);
+
 export const safeParseJson = <T>(
   value: string | null | undefined,
   fallback: T


### PR DESCRIPTION
## Summary
- Add `decodeHtmlEntities` utility to decode common HTML entities (`&amp;`, `&lt;`, `&gt;`, `&quot;`, `&#39;`, `&apos;`) at render time
- Apply decoding across all 8 frontend locations that display origin titles and descriptions: server detail header, SEO metadata, breadcrumbs, origin cards, carousel cards, origins list, admin search table, and discovery panel

<img width="851" height="331" alt="Screenshot 2026-03-09 at 12 23 13" src="https://github.com/user-attachments/assets/ea3b2588-8419-4b09-a123-7575ce901dde" />

<img width="1425" height="420" alt="Screenshot 2026-03-09 at 12 23 37" src="https://github.com/user-attachments/assets/ac2abc55-b07b-45fb-8945-455569f0fe7c" />
