### PR TITLE
Sort resources alphabetically to match x402 manifest order

### DIFF
--- a/apps/scan/src/services/db/resources/origin.ts
+++ b/apps/scan/src/services/db/resources/origin.ts
@@ -144,6 +144,9 @@ export const listOriginsWithResources = async (
             some: acceptsWhere,
           },
         },
+        orderBy: {
+          resource: 'asc',
+        },
         include: {
           accepts: {
             where: acceptsWhere,


### PR DESCRIPTION
## Summary
- Adds `orderBy: { resource: 'asc' }` to the `listOriginsWithResources` query so resources display in alphabetical URL order, matching the ordering in `.well-known/x402` manifests.