### PR TITLE
fix: add escrow scheme to AcceptsScheme enum

### DIFF
--- a/apps/scan/src/lib/x402/index.ts
+++ b/apps/scan/src/lib/x402/index.ts
@@ -32,7 +32,7 @@ export type InputSchema = OutputSchema['input'];
  * the database in a common format for v1 and v2.
  */
 export const normalizedAcceptSchema = z3.object({
-  scheme: z3.literal('exact'),
+  scheme: z3.enum(['exact', 'escrow']),
   network: z3.string(),
   maxAmountRequired: z3.string(),
   payTo: z3.string(),
@@ -71,7 +71,7 @@ function normalizePaymentRequirement(
 ): NormalizedAccept {
   if (isV2PaymentRequirement(accept)) {
     return {
-      scheme: accept.scheme as 'exact',
+      scheme: accept.scheme as 'exact' | 'escrow',
       network: normalizeChainId(accept.network),
       maxAmountRequired: accept.amount,
       payTo: accept.payTo,

--- a/apps/scan/src/services/db/resources/resource.ts
+++ b/apps/scan/src/services/db/resources/resource.ts
@@ -28,7 +28,7 @@ export const upsertResourceSchema = z.object({
   metadata: z.record(z.string(), z.any()).optional(),
   accepts: z.array(
     z.object({
-      scheme: z.enum(['exact']),
+      scheme: z.enum(['exact', 'escrow']),
       network: z.union([
         z.enum([
           'base_sepolia',

--- a/packages/internal/databases/scan/prisma/schema.prisma
+++ b/packages/internal/databases/scan/prisma/schema.prisma
@@ -105,6 +105,7 @@ model Resources {
 }
 
 enum AcceptsScheme {
+  escrow
   exact
 }
 


### PR DESCRIPTION
## Summary
Adds the `escrow` scheme to `AcceptsScheme` enum and related Zod validation schemas to allow x402r escrow endpoints to be registered correctly.

## Problem
Closes #663

## Solution
- Added `escrow` to Prisma `AcceptsScheme`
- Updated `z.enum` schemas in `apps/scan/src/services/db/resources/resource.ts` and `apps/scan/src/lib/x402/index.ts`
- Updated typescript casts to include `'exact' | 'escrow'`

## Checklist
- [x] Code builds without errors
- [x] No new dependencies added