### PR TITLE
Fix toast description text color

### DIFF
--- a/apps/scan/src/components/ui/sonner.tsx
+++ b/apps/scan/src/components/ui/sonner.tsx
@@ -11,6 +11,11 @@ const Toaster = ({ ...props }: ToasterProps) => {
     <Sonner
       theme={theme as ToasterProps['theme']}
       className="toaster group"
+      toastOptions={{
+        classNames: {
+          description: '!text-popover-foreground',
+        },
+      }}
       style={
         {
           '--normal-bg': 'var(--popover)',


### PR DESCRIPTION
## Summary
- Add `!text-popover-foreground` class to toast description text so it matches the popover theme instead of using the default color