### PR TITLE
fix(scan): update send hooks to use JSON body instead of query params

### DIFF
--- a/apps/scan/src/app/(app)/_hooks/send/use-evm-send.ts
+++ b/apps/scan/src/app/(app)/_hooks/send/use-evm-send.ts
@@ -66,10 +66,12 @@ export const useEvmSend = (props?: Props) => {
   } = useEvmX402Fetch({
     chain,
     connection,
-    targetUrl: `${window.location.origin}/api/x402/send?address=${toAddress}&amount=${amount}&chain=${chain}`,
+    targetUrl: `${window.location.origin}/api/x402/send`,
     value: amount ? BigInt(amount * 10 ** token.decimals) : BigInt(0),
     init: {
       method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ address: toAddress, amount, chain }),
     },
     options: {
       onSuccess: data => {

--- a/apps/scan/src/app/(app)/_hooks/send/use-svm-send.ts
+++ b/apps/scan/src/app/(app)/_hooks/send/use-svm-send.ts
@@ -60,10 +60,12 @@ export const useSvmSend = ({
     reset,
   } = useSvmX402Fetch({
     account,
-    targetUrl: `${window.location.origin}/api/x402/send?address=${toAddress}&amount=${amount}&chain=${Chain.SOLANA}`,
+    targetUrl: `${window.location.origin}/api/x402/send`,
     value: amount ? BigInt(amount * 10 ** token.decimals) : BigInt(0),
     init: {
       method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ address: toAddress, amount, chain: Chain.SOLANA }),
     },
     options: {
       onSuccess: () => {

--- a/apps/scan/src/app/.well-known/x402/route.ts
+++ b/apps/scan/src/app/.well-known/x402/route.ts
@@ -8,7 +8,7 @@ export function GET() {
     instructions: `Data API: GET /api/x402/* endpoints return paginated x402 payment data.
 All data endpoints cost $0.01 except /api/x402/resources/search ($0.02).
 Common query params: page (0-indexed), page_size (1-100), chain (base|solana), timeframe (1|7|14|30 days).
-Send API: POST /api/x402/send with query params address, amount, chain.
+Send API: POST /api/x402/send with JSON body { address, amount, chain }.
 Registry API: Register x402 resources into the index.
   POST /api/x402/registry/register — JSON body { url } — probes URL for 402, registers resource.
   POST /api/x402/registry/register-origin — JSON body { origin } — discovers and registers all resources from origin.


### PR DESCRIPTION
## Summary
- `/api/x402/send` now expects `{ address, amount, chain }` as a JSON body after the agentcash-router migration — but the EVM and SVM send hooks were still passing these as query params
- Updated both `use-evm-send.ts` and `use-svm-send.ts` to POST a JSON body with `Content-Type: application/json`
- Fixed stale description in `/.well-known/x402` which still documented query params

## Affected screens
- Wallet drawer → Withdraw tab (EVM + SVM)
- `/mcp/deposit/[address]` deposit flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)