### PR TITLE
chore: bump @agentcash/discovery to 1.1.1

### DIFF
--- a/apps/scan/package.json
+++ b/apps/scan/package.json
@@ -21,7 +21,7 @@
     "format:check": "pnpm -w format:check:dir ./apps/scan"
   },
   "dependencies": {
-    "@agentcash/discovery": "0.0.0-pr-31-20260312214624",
+    "@agentcash/discovery": "1.1.1",
     "@agentcash/router": "^1.0.1",
     "@ai-sdk/openai": "^2.0.52",
     "@ai-sdk/react": "^2.0.68",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,8 +295,8 @@ importers:
   apps/scan:
     dependencies:
       '@agentcash/discovery':
-        specifier: 0.0.0-pr-31-20260312214624
-        version: 0.0.0-pr-31-20260312214624
+        specifier: 1.1.1
+        version: 1.1.1
       '@agentcash/router':
         specifier: ^1.0.1
         version: 1.0.1(2d34d474b384d21849900b1f6a2db476)
@@ -1198,8 +1198,8 @@ packages:
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
 
-  '@agentcash/discovery@0.0.0-pr-31-20260312214624':
-    resolution: {integrity: sha512-eSRduUzoecfWt45gOmu0QPqoojnJTMZi3RN6cRUMYmUrKnBSjEEq3jnL2bA3M+0mLIyHp0BirT+19dW/uMXApw==}
+  '@agentcash/discovery@1.1.1':
+    resolution: {integrity: sha512-VDt7PnhZRskWtJf3gkRHSgIT3bdBqeht5Zl3MzMtABwtcr5F13quGGC1s3nvORtQnWjfrbd9H/voEcCBpTJ/0Q==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -12258,7 +12258,7 @@ snapshots:
 
   '@adraffy/ens-normalize@1.11.1': {}
 
-  '@agentcash/discovery@0.0.0-pr-31-20260312214624':
+  '@agentcash/discovery@1.1.1':
     dependencies:
       dereference-json-schema: 0.2.2
       neverthrow: 8.2.0


### PR DESCRIPTION
## Summary

- Bumps `@agentcash/discovery` in `apps/scan/package.json` from `1.0.0` to `1.1.1`. Align warnings surfaced to match the warnings surfaced by @agentcash/discovery package. All warnings should continue to work as previously defined.