### PR TITLE
fix: deduplicate OG images to prevent unique constraint race (#287)

### DIFF
--- a/apps/scan/src/services/db/resources/origin.ts
+++ b/apps/scan/src/services/db/resources/origin.ts
@@ -45,8 +45,12 @@ export const upsertOrigin = async (
 
     const originId = upsertedOrigin.id;
 
+    const uniqueOgImages = [
+      ...new Map(origin.ogImages.map(img => [img.url, img])).values(),
+    ];
+
     await Promise.all(
-      origin.ogImages.map(({ url, height, width, title, description }) =>
+      uniqueOgImages.map(({ url, height, width, title, description }) =>
         tx.ogImage.upsert({
           where: {
             originId_url: {


### PR DESCRIPTION
## Summary

Fixes #287 — OgImage unique constraint conflict during resource registration.

- **Root cause**: When a scraped page contains duplicate `og:image` tags pointing to the same URL, `Promise.all` fires multiple `upsert` calls with the same compound key `(originId, url)` simultaneously, causing a race condition and unique constraint violation.
- **Fix**: Deduplicate OG images by URL before upserting, ensuring each URL is processed exactly once per batch. Uses a `Map` keyed by URL so the last occurrence wins (preserving the most recent metadata).

Note: The original `@unique` constraint on `url` alone was already removed in PR #472, which resolved the cross-origin conflict. This PR addresses the remaining within-batch race condition.

## Changes

- `apps/scan/src/services/db/resources/origin.ts`: Added URL-based deduplication of OG images before the `Promise.all` upsert loop.

## Test plan

- [x] Verified the fix is minimal (single file, 4 lines added)
- [ ] Registration with duplicate OG image URLs in metadata should succeed
- [ ] Registration with unique OG image URLs continues to work as before