### PR TITLE
fix(scan): prevent OgImage unique constraint conflict on registration (#287)

### DIFF
--- a/apps/scan/src/services/db/resources/origin.ts
+++ b/apps/scan/src/services/db/resources/origin.ts
@@ -45,32 +45,34 @@ export const upsertOrigin = async (
 
     const originId = upsertedOrigin.id;
 
-    await Promise.all(
-      origin.ogImages.map(({ url, height, width, title, description }) =>
-        tx.ogImage.upsert({
-          where: {
-            originId_url: {
-              originId,
-              url,
-            },
-          },
-          update: {
-            height,
-            width,
-            title,
-            description,
-          },
-          create: {
+    const uniqueOgImages = new Map(
+      origin.ogImages.map(img => [img.url, img])
+    );
+
+    for (const { url, height, width, title, description } of uniqueOgImages.values()) {
+      await tx.ogImage.upsert({
+        where: {
+          originId_url: {
             originId,
             url,
-            height,
-            width,
-            title,
-            description,
           },
-        })
-      )
-    );
+        },
+        update: {
+          height,
+          width,
+          title,
+          description,
+        },
+        create: {
+          originId,
+          url,
+          height,
+          width,
+          title,
+          description,
+        },
+      });
+    }
 
     return tx.resourceOrigin.findUnique({
       where: { id: originId },


### PR DESCRIPTION
## Summary

Fixes #287 — OgImage unique constraint conflict when registering resources that share OG image URLs.

**Root cause**: When `origin.ogImages` contains duplicate URLs (e.g. from redirects or shared CDN), `Promise.all` fires concurrent `upsert` calls with the same `(originId, url)` composite key. Both check `where` simultaneously, find no match, and both attempt `create` — one fails with a unique constraint violation.

**Fix**:
- **Deduplicate** OG images by URL before processing (last occurrence wins via `Map`)
- **Serialize** upserts with `for...of` instead of `Promise.all` to eliminate the race window on the `@@unique([originId, url])` constraint

Note: The global `@unique` on `OgImage.url` was already removed in migration `20260115100000_remove_ogimage_url_unique_constraint`, so different origins can share the same OG image URL. This fix addresses the remaining race condition within a single origin's ogImages array.

## Test plan
- [ ] Register Resource A with origin `https://subdomain.example.com` that has OG image `https://cdn.example.com/og.png`
- [ ] Register Resource B with origin `https://example.com` that shares the same OG image URL
- [ ] Verify both registrations succeed without constraint errors
- [ ] Verify OG images with duplicate URLs in a single page's meta tags don't cause failures