### PR TITLE
fix: favicon fallback when origin returns no HTML

### DIFF
--- a/apps/scan/src/services/scraper/index.ts
+++ b/apps/scan/src/services/scraper/index.ts
@@ -1,5 +1,5 @@
 import type { OgObject } from 'open-graph-scraper/types';
-import { fetchHtml } from './html';
+import { checkUrlExists, fetchHtml } from './html';
 import { parseMetadataFromHtml } from './metadata';
 import { parseOgFromHtml } from './og';
 import { parseFaviconFromHtml } from './favicon';
@@ -51,6 +51,14 @@ export const scrapeOriginData = async (inputOrigin: string) => {
   let { og, metadata, favicon } = html
     ? await parseAllFromHtml(html, origin)
     : { og: null, metadata: null, favicon: null };
+
+  // If no favicon found (e.g. origin returned non-HTML or had no icon tags), try /favicon.ico directly
+  if (!favicon) {
+    const fallbackUrl = new URL('/favicon.ico', origin).toString();
+    if (await checkUrlExists(fallbackUrl)) {
+      favicon = fallbackUrl;
+    }
+  }
 
   // Handle API subdomain fallback
   if (origin.startsWith('https://api.')) {


### PR DESCRIPTION
## Summary

- Try `/favicon.ico` directly when an origin's root page returns a non-200 (or has no icon link tags)

Previously, the favicon.ico fallback only ran inside `parseFaviconFromHtml`, which requires HTML. If the origin root 404s (like `https://x402.quicknode.com/` does), we never attempted the fallback — even though `/favicon.ico` exists and works fine at that origin.