### PR TITLE
Make search case-insensitive

### DIFF
--- a/apps/scan/src/services/db/resources/origin.ts
+++ b/apps/scan/src/services/db/resources/origin.ts
@@ -194,6 +194,7 @@ export const searchOrigins = async (
     where: {
       origin: {
         contains: search,
+        mode: 'insensitive',
       },
       resources: {
         some: {

--- a/apps/scan/src/services/db/resources/resource.ts
+++ b/apps/scan/src/services/db/resources/resource.ts
@@ -350,6 +350,7 @@ const searchResourcesUncached = async (
               {
                 resource: {
                   contains: search,
+                  mode: 'insensitive',
                 },
               },
               {


### PR DESCRIPTION
## Summary
- Add `mode: 'insensitive'` to Prisma `contains` filters on resource URL and origin URL search queries
- JSON metadata search (`string_contains`) left as-is since Prisma doesn't support case-insensitive mode on JSON fields