### PR TITLE
fix: deduplicate OG images by URL to prevent unique constraint violation

### DIFF
--- a/apps/scan/src/services/db/resources/origin.ts
+++ b/apps/scan/src/services/db/resources/origin.ts
@@ -45,8 +45,14 @@ export const upsertOrigin = async (
 
     const originId = upsertedOrigin.id;
 
+    // Deduplicate OG images by URL to prevent unique constraint violations
+    // when the scraped page returns duplicate OG image entries.
+    const uniqueOgImages = [
+      ...new Map(origin.ogImages.map(img => [img.url, img])).values(),
+    ];
+
     await Promise.all(
-      origin.ogImages.map(({ url, height, width, title, description }) =>
+      uniqueOgImages.map(({ url, height, width, title, description }) =>
         tx.ogImage.upsert({
           where: {
             originId_url: {


### PR DESCRIPTION
## Summary

Fixes #287 — resource registration fails when scraped pages return duplicate OG image URLs.

### Problem
When a page returns multiple OG image entries with the same URL, the concurrent `Promise.all` upserts race against each other on the `(originId, url)` composite unique constraint, causing a unique constraint violation.

### Fix
Deduplicate OG images by URL using a Map before passing them to `Promise.all`. This ensures each URL is upserted exactly once per origin, eliminating the race condition.

### Changes
- `apps/scan/src/services/db/resources/origin.ts`: +5 lines — deduplicate `ogImages` array by URL before upserting

Minimal, surgical fix — no other behavior changed.