### PR TITLE
fix: handle non-string query param types in resource registry

### DIFF
--- a/apps/scan/src/app/(app)/_components/resources/executor/form/index.tsx
+++ b/apps/scan/src/app/(app)/_components/resources/executor/form/index.tsx
@@ -264,15 +264,15 @@ export function Form({
       )}
 
       {data && (
-        <pre className="max-h-60 overflow-auto rounded-md bg-muted text-xs">
-          {data.type === 'json' ? (
+        data.type === 'json' ? (
+          <div className="max-h-60 overflow-auto rounded-md bg-muted text-xs">
             <JsonViewer data={data.data as JsonValue} />
-          ) : (
-            <pre className="max-h-60 overflow-auto rounded-md bg-muted p-3 text-xs">
-              {JSON.stringify(data.data, null, 2)}
-            </pre>
-          )}
-        </pre>
+          </div>
+        ) : (
+          <pre className="max-h-60 overflow-auto rounded-md bg-muted p-3 text-xs">
+            {JSON.stringify(data.data, null, 2)}
+          </pre>
+        )
       )}
     </CardContent>
   );

--- a/apps/scan/src/lib/x402/schema.test.ts
+++ b/apps/scan/src/lib/x402/schema.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { extractFieldsFromSchema } from './schema';
+import { Methods } from '@/types/x402';
+
+describe('extractFieldsFromSchema', () => {
+  it('should extract string-typed query params', () => {
+    const inputSchema = {
+      method: 'GET',
+      queryParams: {
+        duration: { type: 'string', description: 'Time window' },
+        include: { type: 'string' },
+      },
+    };
+
+    const fields = extractFieldsFromSchema(inputSchema, Methods.GET, 'query');
+    expect(fields).toHaveLength(2);
+    expect(fields.find(f => f.name === 'duration')?.type).toBe('string');
+    expect(fields.find(f => f.name === 'include')?.type).toBe('string');
+  });
+
+  it('should handle numeric example values in query params', () => {
+    const inputSchema = {
+      method: 'GET',
+      queryParams: {
+        page: 1,
+        duration: '5m',
+      },
+    };
+
+    const fields = extractFieldsFromSchema(inputSchema, Methods.GET, 'query');
+    expect(fields).toHaveLength(2);
+
+    const pageField = fields.find(f => f.name === 'page');
+    expect(pageField).toBeDefined();
+    expect(pageField?.type).toBe('integer');
+    expect(pageField?.default).toBe('1');
+
+    const durationField = fields.find(f => f.name === 'duration');
+    expect(durationField).toBeDefined();
+    expect(durationField?.type).toBe('5m');
+  });
+
+  it('should handle boolean example values in query params', () => {
+    const inputSchema = {
+      method: 'GET',
+      queryParams: {
+        include_gt_community_data: true,
+        verbose: false,
+      },
+    };
+
+    const fields = extractFieldsFromSchema(inputSchema, Methods.GET, 'query');
+    expect(fields).toHaveLength(2);
+
+    const boolField = fields.find(f => f.name === 'include_gt_community_data');
+    expect(boolField).toBeDefined();
+    expect(boolField?.type).toBe('boolean');
+    expect(boolField?.default).toBe('true');
+    expect(boolField?.enum).toEqual(['true', 'false']);
+
+    const verboseField = fields.find(f => f.name === 'verbose');
+    expect(verboseField?.default).toBe('false');
+  });
+
+  it('should handle float numeric values', () => {
+    const inputSchema = {
+      method: 'GET',
+      queryParams: {
+        threshold: 0.5,
+      },
+    };
+
+    const fields = extractFieldsFromSchema(inputSchema, Methods.GET, 'query');
+    const field = fields.find(f => f.name === 'threshold');
+    expect(field?.type).toBe('number');
+    expect(field?.default).toBe('0.5');
+  });
+
+  it('should handle mixed param types like CoinGecko trending pools', () => {
+    const inputSchema = {
+      method: 'GET',
+      queryParams: {
+        page: 1,
+        duration: '5m',
+        include_gt_community_data: true,
+        include: 'base_token,quote_tokens,dex',
+      },
+    };
+
+    const fields = extractFieldsFromSchema(inputSchema, Methods.GET, 'query');
+    expect(fields).toHaveLength(4);
+    expect(fields.map(f => f.name).sort()).toEqual([
+      'duration',
+      'include',
+      'include_gt_community_data',
+      'page',
+    ]);
+  });
+
+  it('should preserve non-string defaults in schema objects', () => {
+    const inputSchema = {
+      method: 'GET',
+      queryParams: {
+        limit: { type: 'integer', default: 10 },
+        active: { type: 'boolean', default: false },
+      },
+    };
+
+    const fields = extractFieldsFromSchema(inputSchema, Methods.GET, 'query');
+    expect(fields.find(f => f.name === 'limit')?.default).toBe('10');
+    expect(fields.find(f => f.name === 'active')?.default).toBe('false');
+  });
+});

--- a/apps/scan/src/lib/x402/schema.ts
+++ b/apps/scan/src/lib/x402/schema.ts
@@ -112,6 +112,30 @@ function expandFields(
       continue;
     }
 
+    // Handle numeric example values (e.g. queryParams: { page: 1 })
+    if (typeof raw === 'number') {
+      fields.push({
+        name: fullName,
+        type: Number.isInteger(raw) ? 'integer' : 'number',
+        required: parentRequired?.includes(name) ?? false,
+        enum: undefined,
+        default: String(raw),
+      } satisfies FieldDefinition);
+      continue;
+    }
+
+    // Handle boolean example values (e.g. queryParams: { verbose: true })
+    if (typeof raw === 'boolean') {
+      fields.push({
+        name: fullName,
+        type: 'boolean',
+        required: parentRequired?.includes(name) ?? false,
+        enum: ['true', 'false'],
+        default: String(raw),
+      } satisfies FieldDefinition);
+      continue;
+    }
+
     if (typeof raw !== 'object' || !raw) {
       continue;
     }
@@ -124,7 +148,7 @@ function expandFields(
       ? (field.enum as string[])
       : undefined;
     const fieldDefault =
-      typeof field.default === 'string' ? field.default : undefined;
+      field.default != null ? String(field.default) : undefined;
 
     const isFieldRequired =
       typeof field.required === 'boolean'


### PR DESCRIPTION
## Problem

Numeric and boolean example values in `queryParams` (like `page=1` or `include_gt_community_data=true`) get silently dropped from the Resource Registry display. Only string-typed values show up.

This happens because `expandFields` in `schema.ts` only handles `string` and `object` raw values -- raw `number` and `boolean` primitives fall through to the `typeof raw !== 'object'` guard and get skipped.

Reported in #623 with CoinGecko trending pools as an example: out of 4 query params (`page`, `duration`, `include_gt_community_data`, `include`), only `duration` and `include` were displayed.

## Changes

**`schema.ts`**
- Handle `typeof raw === 'number'` in `expandFields` -- infers `integer` vs `number` type, pre-fills default
- Handle `typeof raw === 'boolean'` -- sets type to `boolean` with `['true', 'false']` enum and pre-fills default
- Fix `fieldDefault` extraction to preserve non-string defaults (was `typeof field.default === 'string'`, now `field.default != null ? String(field.default)`)

**`form/index.tsx`**
- Fix nested `<pre>` inside `<pre>` in the response viewer -- JSON responses now use a `<div>` wrapper, plain text keeps `<pre>`

**`schema.test.ts`** (new)
- 6 tests covering numeric, boolean, float, mixed-type params, and non-string defaults

## Test plan

- [x] All 6 new tests pass via `pnpm test:run`
- [x] No new TypeScript errors (`tsc --noEmit` clean for changed files)
- [ ] View a resource with mixed query param types (e.g. CoinGecko trending pools) -- all params should appear

Closes #623