### PR TITLE
Bump @agentcash/discovery to 1.5.0, adopt structured x-payment-info

### DIFF
--- a/apps/scan/package.json
+++ b/apps/scan/package.json
@@ -21,7 +21,7 @@
     "format:check": "pnpm -w format:check:dir ./apps/scan"
   },
   "dependencies": {
-    "@agentcash/discovery": "1.4.5",
+    "@agentcash/discovery": "1.5.0",
     "@agentcash/router": "1.1.9",
     "@ai-sdk/openai": "^2.0.52",
     "@ai-sdk/react": "^2.0.68",

--- a/apps/scan/src/app/(app)/(home)/integration-spec/discovery-strategy-panel.tsx
+++ b/apps/scan/src/app/(app)/(home)/integration-spec/discovery-strategy-panel.tsx
@@ -31,7 +31,7 @@ const strategies: Strategy[] = [
     requirements: [
       'Top-level fields: openapi, info.title, info.x-guidance, info.version, paths.',
       'For paid operations: responses.402 and x-payment-info.',
-      'Set x-payment-info.protocols and one pricing mode (fixed, range, quote).',
+      'Set x-payment-info.protocols and one pricing mode (fixed or dynamic).',
       'Use OpenAPI security + components.securitySchemes for auth declaration.',
       'Add high-level guidance in info.x-guidance for user-friendly discovery.',
     ],
@@ -44,8 +44,7 @@ const strategies: Strategy[] = [
         "responses": { "402": { "description": "Payment Required" } },
         "x-payment-info": {
           "protocols": ["x402"],
-          "pricingMode": "fixed",
-          "price": "0.05"
+          "price": { "mode": "fixed", "currency": "USD", "value": "0.05" }
         }
       }
     }

--- a/apps/scan/src/app/(app)/(home)/integration-spec/discovery-strategy-panel.tsx
+++ b/apps/scan/src/app/(app)/(home)/integration-spec/discovery-strategy-panel.tsx
@@ -44,7 +44,7 @@ const strategies: Strategy[] = [
         "responses": { "402": { "description": "Payment Required" } },
         "x-payment-info": {
           "protocols": ["x402"],
-          "price": { "mode": "fixed", "currency": "USD", "value": "0.05" }
+          "price": { "mode": "fixed", "currency": "USD", "amount": "0.05" }
         }
       }
     }

--- a/apps/scan/src/app/(app)/(home)/integration-spec/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/integration-spec/page.tsx
@@ -42,10 +42,8 @@ OpenAPI payable operation must include ALL:
 - x-payment-info with:
   - protocols: ["x402"]
   - price (structured object):
-    - fixed: { mode: "fixed", currency: "USD", value: "<amount>" }
+    - fixed: { mode: "fixed", currency: "USD", amount: "<amount>" }
     - dynamic: { mode: "dynamic", currency: "USD", min: "<min>", max: "<max>" }
-  - Legacy flat format also accepted: { pricingMode: "fixed", price: "<amount>" } or { pricingMode: "dynamic", minPrice: "<min>", maxPrice: "<max>" }
-  - IMPORTANT: for fixed pricing use "price" or "value" (not "amount")
 - responses: { "402": { description: "Payment Required" } }
 
 /.well-known/x402 must be exactly:
@@ -57,7 +55,7 @@ OpenAPI payable operation must include ALL:
 
 Rules:
 - Runtime 402 behavior is authoritative over static metadata.
-- "amount" is for runtime accepts; "price" is for x-payment-info fixed pricing.
+- "amount" is for both runtime accepts and x-payment-info fixed pricing.
 
 Workflow:
 0) Install the agentcash MCP server:

--- a/apps/scan/src/app/(app)/(home)/integration-spec/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/integration-spec/page.tsx
@@ -41,11 +41,11 @@ Schema guidance (important):
 OpenAPI payable operation must include ALL:
 - x-payment-info with:
   - protocols: ["x402"]
-  - pricingMode + fields:
-    - fixed: { pricingMode: "fixed", price: "<amount>" }
-    - range: { pricingMode: "range", minPrice: "<min>", maxPrice: "<max>" }
-    - quote: { pricingMode: "quote" }
-  - IMPORTANT: for fixed pricing use "price" (not "amount")
+  - price (structured object):
+    - fixed: { mode: "fixed", currency: "USD", value: "<amount>" }
+    - dynamic: { mode: "dynamic", currency: "USD", min: "<min>", max: "<max>" }
+  - Legacy flat format also accepted: { pricingMode: "fixed", price: "<amount>" } or { pricingMode: "dynamic", minPrice: "<min>", maxPrice: "<max>" }
+  - IMPORTANT: for fixed pricing use "price" or "value" (not "amount")
 - responses: { "402": { description: "Payment Required" } }
 
 /.well-known/x402 must be exactly:

--- a/docs/DISCOVERY.md
+++ b/docs/DISCOVERY.md
@@ -39,9 +39,8 @@ For each paid operation:
 - include a `402` response in `responses`
 - include `x-payment-info.protocols` (for example `"x402"`)
 - include valid pricing metadata via `x-payment-info.price`:
-  - fixed: `{ mode: "fixed", currency: "USD", value: "0.05" }`
+  - fixed: `{ mode: "fixed", currency: "USD", amount: "0.05" }`
   - dynamic: `{ mode: "dynamic", currency: "USD", min: "0.01", max: "1.00" }`
-  - Legacy flat format (`pricingMode` + `price`/`minPrice`/`maxPrice`) is still accepted but the structured `price` object is canonical
 
 ### Auth requirements
 

--- a/docs/DISCOVERY.md
+++ b/docs/DISCOVERY.md
@@ -38,10 +38,10 @@ For each paid operation:
 - declare `x-payment-info`
 - include a `402` response in `responses`
 - include `x-payment-info.protocols` (for example `"x402"`)
-- include valid pricing metadata:
-  - `pricingMode: "fixed"` + `price`
-  - or `pricingMode: "range"` + `minPrice` + `maxPrice`
-  - or `pricingMode: "quote"`
+- include valid pricing metadata via `x-payment-info.price`:
+  - fixed: `{ mode: "fixed", currency: "USD", value: "0.05" }`
+  - dynamic: `{ mode: "dynamic", currency: "USD", min: "0.01", max: "1.00" }`
+  - Legacy flat format (`pricingMode` + `price`/`minPrice`/`maxPrice`) is still accepted but the structured `price` object is canonical
 
 ### Auth requirements
 

--- a/evals/prompts/copy-for-agents-v3.txt
+++ b/evals/prompts/copy-for-agents-v3.txt
@@ -14,11 +14,11 @@ Schema guidance (important):
 OpenAPI payable operation must include ALL:
 - x-payment-info with:
   - protocols: ["x402"]
-  - pricingMode + fields:
-    - fixed: { pricingMode: "fixed", price: "<amount>" }
-    - range: { pricingMode: "range", minPrice: "<min>", maxPrice: "<max>" }
-    - quote: { pricingMode: "quote" }
-  - IMPORTANT: for fixed pricing use "price" (not "amount")
+  - price (structured object, canonical format):
+    - fixed: { mode: "fixed", currency: "USD", value: "<amount>" }
+    - dynamic: { mode: "dynamic", currency: "USD", min: "<min>", max: "<max>" }
+  - Legacy flat format also accepted: { pricingMode: "fixed", price: "<amount>" } or { pricingMode: "dynamic", minPrice: "<min>", maxPrice: "<max>" }
+  - IMPORTANT: for fixed pricing use "price" or "value" (not "amount")
 - responses: { "402": { description: "Payment Required" } }
 
 /.well-known/x402 must be exactly:

--- a/evals/prompts/copy-for-agents-v3.txt
+++ b/evals/prompts/copy-for-agents-v3.txt
@@ -15,10 +15,8 @@ OpenAPI payable operation must include ALL:
 - x-payment-info with:
   - protocols: ["x402"]
   - price (structured object, canonical format):
-    - fixed: { mode: "fixed", currency: "USD", value: "<amount>" }
+    - fixed: { mode: "fixed", currency: "USD", amount: "<amount>" }
     - dynamic: { mode: "dynamic", currency: "USD", min: "<min>", max: "<max>" }
-  - Legacy flat format also accepted: { pricingMode: "fixed", price: "<amount>" } or { pricingMode: "dynamic", minPrice: "<min>", maxPrice: "<max>" }
-  - IMPORTANT: for fixed pricing use "price" or "value" (not "amount")
 - responses: { "402": { description: "Payment Required" } }
 
 /.well-known/x402 must be exactly:
@@ -30,7 +28,7 @@ OpenAPI payable operation must include ALL:
 
 Rules:
 - Runtime 402 behavior is authoritative over static metadata.
-- "amount" is for runtime accepts; "price" is for x-payment-info fixed pricing.
+- "amount" is for both runtime accepts and x-payment-info fixed pricing.
 
 Workflow:
 1) Audit discovery and probe failures.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,8 +295,8 @@ importers:
   apps/scan:
     dependencies:
       '@agentcash/discovery':
-        specifier: 1.4.5
-        version: 1.4.5
+        specifier: 1.5.0
+        version: 1.5.0
       '@agentcash/router':
         specifier: 1.2.5
         version: 1.2.5(6eacb81bb22aa1ce566e8ab228700749)
@@ -1001,6 +1001,8 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
+  packages/internal/databases/scan/generated/client: {}
+
   packages/internal/databases/transfers:
     dependencies:
       '@neondatabase/serverless':
@@ -1046,6 +1048,8 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+
+  packages/internal/databases/transfers/generated/client: {}
 
   packages/internal/neverthrow:
     dependencies:
@@ -1197,8 +1201,8 @@ packages:
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
 
-  '@agentcash/discovery@1.4.5':
-    resolution: {integrity: sha512-CY/tmB5tnAMS8AQjvzKtWFSTyoM/5nO7ESd4HJL9MEVLAEPQiOrYQu3IxL736I8ieySIHqY/cWWQZXQifMTVTQ==}
+  '@agentcash/discovery@1.5.0':
+    resolution: {integrity: sha512-Ne5UQX3R9x+t4ZcftBeh/5ZmWcC+oy7JrtL7eMtjJMZ+cyXxktSvKSQ1bE27Wb8LIM0/vOsECe3HmQga+GcHqw==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -12317,7 +12321,7 @@ snapshots:
 
   '@adraffy/ens-normalize@1.11.1': {}
 
-  '@agentcash/discovery@1.4.5':
+  '@agentcash/discovery@1.5.0':
     dependencies:
       dereference-json-schema: 0.2.2
       neverthrow: 8.2.0


### PR DESCRIPTION
## Summary
- Bumps `@agentcash/discovery` from `1.4.5` to `1.5.0`
- Bumps `@agentcash/router` to `1.2.5` (merged from main)
- Renames `"value"` to `"amount"` in all structured `price` objects to match the new canonical format
- Removes legacy flat format references (`pricingMode` + `price`/`minPrice`/`maxPrice`) from docs, agent prompts, and UI examples

## What changed upstream
- `PricingMode` type: `'fixed' | 'range' | 'quote'` → `'fixed' | 'dynamic'`
- `x-payment-info.price` uses `"amount"` (not `"value"`) for fixed pricing: `{ mode: "fixed", currency: "USD", amount: "0.05" }`
- Legacy flat format is no longer documented

## Files changed
- `apps/scan/package.json` — version bumps (discovery 1.5.0, router 1.2.5)
- `pnpm-lock.yaml` — lockfile update
- `docs/DISCOVERY.md` — pricing metadata docs
- `apps/scan/src/app/(app)/(home)/integration-spec/page.tsx` — agent prompt copy
- `apps/scan/src/app/(app)/(home)/integration-spec/discovery-strategy-panel.tsx` — UI example JSON
- `evals/prompts/copy-for-agents-v3.txt` — eval agent prompt

## Test plan
- [ ] `pnpm install --frozen-lockfile` passes
- [ ] Vercel build succeeds
- [ ] Integration-spec page renders correctly with updated example JSON
- [ ] Discovery evals pass with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)