### PR TITLE
Downgrade trigger.dev machines from large-2x to medium-1x

### DIFF
--- a/sync/transfers/trigger/chains/evm/base/cdp/config.ts
+++ b/sync/transfers/trigger/chains/evm/base/cdp/config.ts
@@ -17,6 +17,6 @@ export const baseCdpConfig: SyncConfig = {
   buildQuery,
   transformResponse,
   enabled: true,
-  machine: 'large-2x',
+  machine: 'medium-1x',
   splitSyncByFacilitator: true,
 };

--- a/sync/transfers/trigger/chains/solana/bitquery/config.ts
+++ b/sync/transfers/trigger/chains/solana/bitquery/config.ts
@@ -16,5 +16,5 @@ export const solanaChainConfig: SyncConfig = {
   buildQuery,
   transformResponse,
   enabled: true,
-  machine: 'large-2x',
+  machine: 'medium-1x',
 };


### PR DESCRIPTION
## Summary
- Downgrades Base CDP and Solana Bitquery sync jobs from `large-2x` (8 vCPU, 16 GB) to `medium-1x` (1 vCPU, 2 GB)
- These jobs are HTTP requests + DB writes, don't need heavy compute
- Estimated savings: ~$290/month (~58% of current trigger.dev bill)