### PR TITLE
feat: add OpenAPI spec upload for bulk resource registration

### DIFF
--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/openapi-upload.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/openapi-upload.tsx
@@ -1,0 +1,415 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+
+import {
+  CheckCircle2,
+  ChevronDown,
+  FileUp,
+  Loader2,
+  Upload,
+  XCircle,
+} from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Dropzone } from '@/components/ui/dropzone';
+
+import { api } from '@/trpc/client';
+
+type DryRunEndpoint = {
+  method: string;
+  path: string;
+  url: string;
+  summary: string | undefined;
+  description: string | undefined;
+  parameterCount: number;
+};
+
+type RegisterResult = {
+  url: string;
+  method: string;
+  path: string;
+  success: boolean;
+  error?: string;
+};
+
+const METHOD_COLORS: Record<string, string> = {
+  GET: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+  POST: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+  PUT: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
+  PATCH:
+    'bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400',
+  DELETE: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
+};
+
+export function OpenApiUpload() {
+  const [specText, setSpecText] = useState('');
+  const [baseUrl, setBaseUrl] = useState('');
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [previewEndpoints, setPreviewEndpoints] = useState<
+    DryRunEndpoint[] | null
+  >(null);
+  const [previewMeta, setPreviewMeta] = useState<{
+    title?: string;
+    version?: string;
+    description?: string;
+    baseUrl?: string;
+  } | null>(null);
+  const [registerResults, setRegisterResults] = useState<
+    RegisterResult[] | null
+  >(null);
+
+  const registerMutation =
+    api.public.resources.registerFromOpenApi.useMutation();
+
+  const isParsing = registerMutation.isPending && !registerResults;
+  const isRegistering = registerMutation.isPending && previewEndpoints !== null;
+
+  const hasSpec = specText.trim().length > 0;
+
+  const specInput = useMemo(() => {
+    if (!hasSpec) return null;
+    const trimmed = specText.trim();
+    try {
+      return JSON.parse(trimmed) as Record<string, unknown>;
+    } catch {
+      return trimmed;
+    }
+  }, [specText, hasSpec]);
+
+  const handleFileUpload = useCallback(
+    (acceptedFiles: File[]) => {
+      const file = acceptedFiles[0];
+      if (!file) return;
+
+      const reader = new FileReader();
+      reader.onload = event => {
+        const content = event.target?.result;
+        if (typeof content === 'string') {
+          setSpecText(content);
+          setParseError(null);
+          setPreviewEndpoints(null);
+          setPreviewMeta(null);
+          setRegisterResults(null);
+          registerMutation.reset();
+        }
+      };
+      reader.readAsText(file);
+    },
+    [registerMutation]
+  );
+
+  const handleParseSpec = async () => {
+    if (!specInput) return;
+
+    setParseError(null);
+    setPreviewEndpoints(null);
+    setPreviewMeta(null);
+    setRegisterResults(null);
+
+    try {
+      const result = await registerMutation.mutateAsync({
+        spec: specInput,
+        baseUrl: baseUrl || undefined,
+        dryRun: true,
+      });
+
+      if (result.dryRun) {
+        setPreviewEndpoints(result.endpoints);
+        setPreviewMeta({
+          title: result.title ?? undefined,
+          version: result.version ?? undefined,
+          description: result.description ?? undefined,
+          baseUrl: result.baseUrl ?? undefined,
+        });
+      }
+    } catch (error) {
+      setParseError(
+        error instanceof Error ? error.message : 'Failed to parse spec'
+      );
+    }
+  };
+
+  const handleRegisterAll = async () => {
+    if (!specInput || !previewEndpoints) return;
+
+    setRegisterResults(null);
+
+    try {
+      const result = await registerMutation.mutateAsync({
+        spec: specInput,
+        baseUrl: baseUrl || undefined,
+        dryRun: false,
+      });
+
+      if (!result.dryRun) {
+        setRegisterResults(result.results);
+      }
+    } catch (error) {
+      setParseError(
+        error instanceof Error ? error.message : 'Registration failed'
+      );
+    }
+  };
+
+  const handleReset = () => {
+    setSpecText('');
+    setBaseUrl('');
+    setParseError(null);
+    setPreviewEndpoints(null);
+    setPreviewMeta(null);
+    setRegisterResults(null);
+    registerMutation.reset();
+  };
+
+  const registeredCount = registerResults?.filter(r => r.success).length ?? 0;
+  const failedCount = registerResults?.filter(r => !r.success).length ?? 0;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <FileUp className="size-5" />
+          Import from OpenAPI Spec
+        </CardTitle>
+        <CardDescription>
+          Upload or paste an OpenAPI 3.x / Swagger 2.x specification to register
+          multiple endpoints at once.
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="space-y-4">
+        {/* File upload */}
+        <div className="space-y-1">
+          <Label>Upload spec file</Label>
+          <Dropzone
+            accept={{
+              'application/json': ['.json'],
+              'application/x-yaml': ['.yaml', '.yml'],
+              'text/yaml': ['.yaml', '.yml'],
+            }}
+            maxFiles={1}
+            onDrop={handleFileUpload}
+            className="w-full h-auto py-6 flex-col gap-2"
+          >
+            <Upload className="size-5 text-muted-foreground" />
+            <span className="text-sm text-muted-foreground">
+              Drop a .json or .yaml file, or click to browse
+            </span>
+          </Dropzone>
+        </div>
+
+        {/* Paste area */}
+        <div className="space-y-1">
+          <Label>Or paste spec content</Label>
+          <Textarea
+            placeholder='{"openapi": "3.1.0", "info": {...}, "paths": {...}}'
+            rows={8}
+            value={specText}
+            onChange={e => {
+              setSpecText(e.target.value);
+              setParseError(null);
+              setPreviewEndpoints(null);
+              setPreviewMeta(null);
+              setRegisterResults(null);
+            }}
+            className="font-mono text-xs"
+          />
+        </div>
+
+        {/* Base URL override */}
+        <Collapsible>
+          <CollapsibleTrigger asChild>
+            <Button
+              variant="ghost"
+              className="size-fit p-0 text-xs text-muted-foreground/70 hover:text-muted-foreground"
+            >
+              Base URL Override
+              <ChevronDown className="size-3 ml-1" />
+            </Button>
+          </CollapsibleTrigger>
+          <CollapsibleContent className="mt-2">
+            <Input
+              type="url"
+              placeholder="https://api.example.com (optional — auto-detected from spec)"
+              value={baseUrl}
+              onChange={e => setBaseUrl(e.target.value)}
+            />
+          </CollapsibleContent>
+        </Collapsible>
+
+        {/* Error display */}
+        {parseError && (
+          <div className="flex items-start gap-2 text-sm text-red-600 dark:text-red-400 border border-red-200 dark:border-red-800 rounded-md p-3">
+            <XCircle className="size-4 shrink-0 mt-0.5" />
+            <span>{parseError}</span>
+          </div>
+        )}
+
+        {/* Preview endpoints */}
+        {previewEndpoints && previewMeta && (
+          <div className="space-y-3">
+            <div className="border rounded-md p-3 space-y-1">
+              <div className="flex items-center gap-2">
+                <p className="text-sm font-medium">
+                  {previewMeta.title ?? 'Untitled API'}
+                </p>
+                {previewMeta.version && (
+                  <Badge variant="secondary" className="text-xs">
+                    v{previewMeta.version}
+                  </Badge>
+                )}
+              </div>
+              {previewMeta.description && (
+                <p className="text-xs text-muted-foreground line-clamp-2">
+                  {previewMeta.description}
+                </p>
+              )}
+              {previewMeta.baseUrl && (
+                <p className="text-xs text-muted-foreground font-mono">
+                  {previewMeta.baseUrl}
+                </p>
+              )}
+            </div>
+
+            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              {previewEndpoints.length} endpoint
+              {previewEndpoints.length !== 1 ? 's' : ''} found
+            </p>
+
+            <div className="border rounded-md divide-y max-h-64 overflow-y-auto">
+              {previewEndpoints.map((ep, i) => (
+                <div key={i} className="px-3 py-2 flex items-center gap-2">
+                  <Badge
+                    variant="outline"
+                    className={`text-[10px] font-mono px-1.5 py-0 shrink-0 ${METHOD_COLORS[ep.method] ?? ''}`}
+                  >
+                    {ep.method}
+                  </Badge>
+                  <code className="text-xs font-mono truncate flex-1">
+                    {ep.path}
+                  </code>
+                  {(ep.summary ?? ep.description) && (
+                    <span className="text-xs text-muted-foreground truncate max-w-48">
+                      {ep.summary ?? ep.description}
+                    </span>
+                  )}
+                  {registerResults && (
+                    <>
+                      {registerResults[i]?.success ? (
+                        <CheckCircle2 className="size-3.5 text-green-600 shrink-0" />
+                      ) : (
+                        <XCircle className="size-3.5 text-red-600 shrink-0" />
+                      )}
+                    </>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Registration results summary */}
+        {registerResults && (
+          <div className="border rounded-md p-3 space-y-2">
+            <div className="flex items-center gap-2 text-sm font-medium">
+              {failedCount === 0 ? (
+                <>
+                  <CheckCircle2 className="size-4 text-green-600" />
+                  All {registeredCount} endpoint
+                  {registeredCount !== 1 ? 's' : ''} registered
+                </>
+              ) : (
+                <>
+                  <CheckCircle2 className="size-4 text-green-600" />
+                  {registeredCount} registered, {failedCount} failed
+                </>
+              )}
+            </div>
+            {failedCount > 0 && (
+              <div className="space-y-1">
+                {registerResults
+                  .filter(r => !r.success)
+                  .map((r, i) => (
+                    <div
+                      key={i}
+                      className="flex items-start gap-2 text-xs text-red-600 dark:text-red-400"
+                    >
+                      <XCircle className="size-3 shrink-0 mt-0.5" />
+                      <div>
+                        <code className="font-mono">
+                          {r.method} {r.path}
+                        </code>
+                        {r.error && (
+                          <span className="text-muted-foreground ml-1">
+                            — {r.error}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+
+      <CardFooter className="flex gap-2">
+        {!previewEndpoints ? (
+          <Button
+            variant="turbo"
+            disabled={!hasSpec || isParsing}
+            onClick={() => void handleParseSpec()}
+          >
+            {isParsing ? (
+              <>
+                <Loader2 className="size-4 animate-spin mr-2" />
+                Parsing...
+              </>
+            ) : (
+              'Parse Spec'
+            )}
+          </Button>
+        ) : !registerResults ? (
+          <Button
+            variant="turbo"
+            disabled={isRegistering}
+            onClick={() => void handleRegisterAll()}
+          >
+            {isRegistering ? (
+              <>
+                <Loader2 className="size-4 animate-spin mr-2" />
+                Registering {previewEndpoints.length} endpoints...
+              </>
+            ) : (
+              `Register All (${previewEndpoints.length} endpoints)`
+            )}
+          </Button>
+        ) : null}
+
+        {(hasSpec || previewEndpoints || registerResults) && (
+          <Button variant="outline" onClick={handleReset}>
+            Reset
+          </Button>
+        )}
+      </CardFooter>
+    </Card>
+  );
+}

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/openapi-upload.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/openapi-upload.tsx
@@ -111,6 +111,9 @@ export function OpenApiUpload() {
           registerMutation.reset();
         }
       };
+      reader.onerror = () => {
+        setParseError('Failed to read the uploaded file. Please try again.');
+      };
       reader.readAsText(file);
     },
     [registerMutation]
@@ -202,8 +205,6 @@ export function OpenApiUpload() {
           <Dropzone
             accept={{
               'application/json': ['.json'],
-              'application/x-yaml': ['.yaml', '.yml'],
-              'text/yaml': ['.yaml', '.yml'],
             }}
             maxFiles={1}
             onDrop={handleFileUpload}
@@ -211,7 +212,7 @@ export function OpenApiUpload() {
           >
             <Upload className="size-5 text-muted-foreground" />
             <span className="text-sm text-muted-foreground">
-              Drop a .json or .yaml file, or click to browse
+              Drop a .json file, or click to browse
             </span>
           </Dropzone>
         </div>

--- a/apps/scan/src/app/(app)/(home)/resources/register/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/page.tsx
@@ -2,6 +2,7 @@ import { Body, Heading } from '@/app/_components/layout/page-utils';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { RegisterResourceForm } from './_components/form';
+import { OpenApiUpload } from './_components/openapi-upload';
 
 import type { Metadata } from 'next';
 
@@ -32,8 +33,9 @@ export default function RegisterResourcePage() {
           </div>
         }
       />
-      <Body>
+      <Body className="space-y-6">
         <RegisterResourceForm />
+        <OpenApiUpload />
       </Body>
     </div>
   );

--- a/apps/scan/src/lib/openapi/index.ts
+++ b/apps/scan/src/lib/openapi/index.ts
@@ -1,0 +1,7 @@
+export { parseOpenApiSpec, openApiInputSchema } from './parse-spec';
+export type {
+  ParsedSpec,
+  ParsedEndpoint,
+  ParsedParameter,
+  OpenApiInput,
+} from './parse-spec';

--- a/apps/scan/src/lib/openapi/parse-spec.ts
+++ b/apps/scan/src/lib/openapi/parse-spec.ts
@@ -54,7 +54,8 @@ const HTTP_METHODS = [
 
 function resolveRef(
   spec: Record<string, unknown>,
-  ref: unknown
+  ref: unknown,
+  seen?: Set<string>
 ): unknown {
   if (
     typeof ref !== 'object' ||
@@ -65,16 +66,31 @@ function resolveRef(
     return ref;
   }
 
-  const refPath = ((ref as Record<string, unknown>).$ref as string).replace(
-    /^#\//,
-    ''
-  );
+  const refString = (ref as Record<string, unknown>).$ref as string;
+
+  // Circular reference detection
+  const visited = seen ?? new Set<string>();
+  if (visited.has(refString)) {
+    return ref; // Break circular reference — return unresolved
+  }
+  visited.add(refString);
+
+  const refPath = refString.replace(/^#\//, '');
   const parts = refPath.split('/');
 
   let current: unknown = spec;
   for (const part of parts) {
     if (typeof current !== 'object' || current === null) return ref;
     current = (current as Record<string, unknown>)[part];
+  }
+
+  // Recursively resolve if the resolved value is itself a $ref
+  if (
+    typeof current === 'object' &&
+    current !== null &&
+    '$ref' in (current as Record<string, unknown>)
+  ) {
+    return resolveRef(spec, current, visited);
   }
 
   return current ?? ref;

--- a/apps/scan/src/lib/openapi/parse-spec.ts
+++ b/apps/scan/src/lib/openapi/parse-spec.ts
@@ -1,0 +1,265 @@
+import { z } from 'zod';
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export interface ParsedEndpoint {
+  method: string;
+  path: string;
+  url: string;
+  description: string | undefined;
+  summary: string | undefined;
+  parameters: ParsedParameter[];
+  requestBody: unknown | undefined;
+  responseSchema: unknown | undefined;
+}
+
+export interface ParsedParameter {
+  name: string;
+  in: string;
+  required: boolean;
+  description: string | undefined;
+  schema: unknown | undefined;
+}
+
+export interface ParsedSpec {
+  title: string | undefined;
+  version: string | undefined;
+  description: string | undefined;
+  baseUrl: string | undefined;
+  endpoints: ParsedEndpoint[];
+}
+
+// ── Input validation ───────────────────────────────────────────────────
+
+export const openApiInputSchema = z.object({
+  /** Raw OpenAPI spec as a JSON string or parsed object */
+  spec: z.union([z.string().min(1), z.record(z.unknown())]),
+  /** Override the base URL extracted from the spec */
+  baseUrl: z.string().url().optional(),
+});
+
+export type OpenApiInput = z.infer<typeof openApiInputSchema>;
+
+// ── Spec parsing ───────────────────────────────────────────────────────
+
+const HTTP_METHODS = [
+  'get',
+  'post',
+  'put',
+  'patch',
+  'delete',
+  'head',
+  'options',
+] as const;
+
+function resolveRef(
+  spec: Record<string, unknown>,
+  ref: unknown
+): unknown {
+  if (
+    typeof ref !== 'object' ||
+    ref === null ||
+    !('$ref' in ref) ||
+    typeof (ref as Record<string, unknown>).$ref !== 'string'
+  ) {
+    return ref;
+  }
+
+  const refPath = ((ref as Record<string, unknown>).$ref as string).replace(
+    /^#\//,
+    ''
+  );
+  const parts = refPath.split('/');
+
+  let current: unknown = spec;
+  for (const part of parts) {
+    if (typeof current !== 'object' || current === null) return ref;
+    current = (current as Record<string, unknown>)[part];
+  }
+
+  return current ?? ref;
+}
+
+function extractParameters(
+  spec: Record<string, unknown>,
+  rawParams: unknown
+): ParsedParameter[] {
+  if (!Array.isArray(rawParams)) return [];
+
+  return rawParams
+    .map(p => resolveRef(spec, p))
+    .filter(
+      (p): p is Record<string, unknown> =>
+        typeof p === 'object' && p !== null && 'name' in p
+    )
+    .map(param => ({
+      name: String(param.name),
+      in: String(param.in ?? 'query'),
+      required: Boolean(param.required),
+      description:
+        typeof param.description === 'string' ? param.description : undefined,
+      schema: param.schema ? resolveRef(spec, param.schema) : undefined,
+    }));
+}
+
+function extractResponseSchema(
+  spec: Record<string, unknown>,
+  responses: unknown
+): unknown | undefined {
+  if (typeof responses !== 'object' || responses === null) return undefined;
+
+  const responsesObj = responses as Record<string, unknown>;
+  const successKey =
+    Object.keys(responsesObj).find(k => k === '200' || k === '201') ??
+    Object.keys(responsesObj)[0];
+
+  if (!successKey) return undefined;
+
+  const response = resolveRef(spec, responsesObj[successKey]) as Record<
+    string,
+    unknown
+  > | null;
+  if (!response || typeof response !== 'object') return undefined;
+
+  // OpenAPI 3.x: content -> application/json -> schema
+  const content = response.content as Record<string, unknown> | undefined;
+  if (content) {
+    const jsonContent = (content['application/json'] ?? content['*/*']) as
+      | Record<string, unknown>
+      | undefined;
+    if (jsonContent?.schema) {
+      return resolveRef(spec, jsonContent.schema);
+    }
+  }
+
+  // Swagger 2.x: schema directly on response
+  if (response.schema) {
+    return resolveRef(spec, response.schema);
+  }
+
+  return undefined;
+}
+
+function resolveBaseUrl(
+  spec: Record<string, unknown>,
+  overrideBaseUrl: string | undefined
+): string | undefined {
+  if (overrideBaseUrl) return overrideBaseUrl.replace(/\/$/, '');
+
+  // OpenAPI 3.x servers
+  const servers = spec.servers;
+  if (Array.isArray(servers) && servers.length > 0) {
+    const server = servers[0] as Record<string, unknown>;
+    let url = String(server.url ?? '');
+
+    // Handle server variables
+    const variables = server.variables as
+      | Record<string, Record<string, unknown>>
+      | undefined;
+    if (variables) {
+      for (const [name, variable] of Object.entries(variables)) {
+        const defaultValue = String(variable.default ?? '');
+        url = url.replace(`{${name}}`, defaultValue);
+      }
+    }
+
+    if (url && !url.startsWith('/')) return url.replace(/\/$/, '');
+  }
+
+  // Swagger 2.x
+  const host = spec.host as string | undefined;
+  if (host) {
+    const schemes = (spec.schemes as string[]) ?? ['https'];
+    const basePath = (spec.basePath as string) ?? '';
+    return `${schemes[0]}://${host}${basePath}`.replace(/\/$/, '');
+  }
+
+  return undefined;
+}
+
+/**
+ * Parse an OpenAPI 3.x or Swagger 2.x spec and extract all endpoints.
+ */
+export function parseOpenApiSpec(input: OpenApiInput): ParsedSpec {
+  let spec: Record<string, unknown>;
+
+  if (typeof input.spec === 'string') {
+    const raw = input.spec.trim();
+
+    try {
+      spec = JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      throw new Error(
+        'Invalid OpenAPI spec: could not parse as JSON. Please provide a valid JSON spec.'
+      );
+    }
+  } else {
+    spec = input.spec as Record<string, unknown>;
+  }
+
+  // Validate it looks like an OpenAPI/Swagger spec
+  if (!spec.openapi && !spec.swagger) {
+    throw new Error(
+      'Invalid OpenAPI spec: missing "openapi" or "swagger" version field'
+    );
+  }
+
+  if (!spec.paths || typeof spec.paths !== 'object') {
+    throw new Error('Invalid OpenAPI spec: missing "paths" field');
+  }
+
+  const info = (spec.info ?? {}) as Record<string, unknown>;
+  const baseUrl = resolveBaseUrl(spec, input.baseUrl);
+
+  const paths = spec.paths as Record<string, Record<string, unknown>>;
+  const endpoints: ParsedEndpoint[] = [];
+
+  for (const [path, pathItem] of Object.entries(paths)) {
+    if (typeof pathItem !== 'object' || pathItem === null) continue;
+
+    const resolvedPath = resolveRef(spec, pathItem) as Record<string, unknown>;
+    const pathLevelParams = resolvedPath.parameters;
+
+    for (const method of HTTP_METHODS) {
+      const operation = resolvedPath[method];
+      if (!operation || typeof operation !== 'object') continue;
+
+      const op = operation as Record<string, unknown>;
+
+      // Merge path-level and operation-level parameters
+      const opParams = extractParameters(spec, op.parameters);
+      const pathParams = extractParameters(spec, pathLevelParams);
+      const mergedParams = [
+        ...pathParams.filter(
+          pp => !opParams.some(op2 => op2.name === pp.name && op2.in === pp.in)
+        ),
+        ...opParams,
+      ];
+
+      const resolvedUrl = baseUrl ? `${baseUrl}${path}` : path;
+
+      endpoints.push({
+        method: method.toUpperCase(),
+        path,
+        url: resolvedUrl,
+        description:
+          typeof op.description === 'string' ? op.description : undefined,
+        summary: typeof op.summary === 'string' ? op.summary : undefined,
+        parameters: mergedParams,
+        requestBody: op.requestBody
+          ? resolveRef(spec, op.requestBody)
+          : undefined,
+        responseSchema: extractResponseSchema(spec, op.responses),
+      });
+    }
+  }
+
+  return {
+    title: typeof info.title === 'string' ? info.title : undefined,
+    version: typeof info.version === 'string' ? info.version : undefined,
+    description:
+      typeof info.description === 'string' ? info.description : undefined,
+    baseUrl,
+    endpoints,
+  };
+}

--- a/apps/scan/src/trpc/routers/public/resources.ts
+++ b/apps/scan/src/trpc/routers/public/resources.ts
@@ -35,6 +35,7 @@ import { convertTokenAmount } from '@/lib/token';
 import { usdc } from '@/lib/tokens/usdc';
 import { getOriginFromUrl, normalizeUrl } from '@/lib/url';
 import { fetchDiscoveryDocument } from '@/services/discovery';
+import { parseOpenApiSpec, openApiInputSchema } from '@/lib/openapi';
 import {
   getResourceVerificationStatus,
   getOriginVerificationStatus,
@@ -363,6 +364,138 @@ export const resourcesRouter = createTRPCRouter({
         code: 'BAD_REQUEST',
         message: 'Either resourceIds or originId must be provided',
       });
+    }),
+
+  /**
+   * Parse an OpenAPI spec and optionally register all discovered endpoints.
+   * Supports OpenAPI 3.x and Swagger 2.x specs in JSON format.
+   */
+  registerFromOpenApi: publicProcedure
+    .input(
+      openApiInputSchema.extend({
+        dryRun: z.boolean().default(true),
+      })
+    )
+    .mutation(async ({ input }) => {
+      let parsed;
+      try {
+        parsed = parseOpenApiSpec({
+          spec: input.spec,
+          baseUrl: input.baseUrl,
+        });
+      } catch (error) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message:
+            error instanceof Error
+              ? error.message
+              : 'Failed to parse OpenAPI spec',
+        });
+      }
+
+      if (parsed.endpoints.length === 0) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'No endpoints found in the OpenAPI spec',
+        });
+      }
+
+      if (!parsed.baseUrl) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message:
+            'Could not determine base URL from spec. Provide a baseUrl override.',
+        });
+      }
+
+      // In dry-run mode, just return the parsed endpoints
+      if (input.dryRun) {
+        return {
+          dryRun: true as const,
+          title: parsed.title,
+          version: parsed.version,
+          description: parsed.description,
+          baseUrl: parsed.baseUrl,
+          endpoints: parsed.endpoints.map(ep => ({
+            method: ep.method,
+            path: ep.path,
+            url: ep.url,
+            summary: ep.summary,
+            description: ep.description,
+            parameterCount: ep.parameters.length,
+          })),
+          endpointCount: parsed.endpoints.length,
+        };
+      }
+
+      // Register each endpoint sequentially with rate limiting
+      const results: {
+        url: string;
+        method: string;
+        path: string;
+        success: boolean;
+        error?: string;
+      }[] = [];
+
+      for (const endpoint of parsed.endpoints) {
+        try {
+          const probeResult = await probeX402Endpoint(
+            endpoint.url.replaceAll('{', '').replaceAll('}', '')
+          );
+
+          if (!probeResult.success) {
+            results.push({
+              url: endpoint.url,
+              method: endpoint.method,
+              path: endpoint.path,
+              success: false,
+              error: probeResult.error,
+            });
+            continue;
+          }
+
+          const registerResult = await registerResource(
+            endpoint.url,
+            probeResult.advisory
+          );
+
+          results.push({
+            url: endpoint.url,
+            method: endpoint.method,
+            path: endpoint.path,
+            success: registerResult.success,
+            error:
+              registerResult.success === false
+                ? 'Resource registration failed'
+                : undefined,
+          });
+        } catch (error) {
+          results.push({
+            url: endpoint.url,
+            method: endpoint.method,
+            path: endpoint.path,
+            success: false,
+            error:
+              error instanceof Error ? error.message : 'Registration failed',
+          });
+        }
+
+        // Rate-limit between registrations
+        await new Promise(resolve => setTimeout(resolve, 200));
+      }
+
+      const registered = results.filter(r => r.success).length;
+      const failed = results.filter(r => !r.success).length;
+
+      return {
+        dryRun: false as const,
+        title: parsed.title,
+        baseUrl: parsed.baseUrl,
+        registered,
+        failed,
+        total: results.length,
+        results,
+      };
     }),
 
   tags: {

--- a/docs/PROGRAMMATIC_API.md
+++ b/docs/PROGRAMMATIC_API.md
@@ -1,0 +1,199 @@
+# Programmatic Resource Registration API
+
+x402scan exposes a public REST API that allows resource providers to register and refresh their x402-protected resources programmatically — no wallet authentication required.
+
+## Base URL
+
+```
+https://x402scan.com/api/v1
+```
+
+## Endpoints
+
+### Register a Single Resource
+
+```
+POST /api/v1/resources/register
+```
+
+Register a single x402-protected resource by URL. The endpoint probes the URL for a `402 Payment Required` response, parses the payment information, and adds it to the x402scan registry.
+
+**Request Body:**
+
+```json
+{
+  "url": "https://your-server.com/api/paid-endpoint"
+}
+```
+
+**Success Response (200):**
+
+```json
+{
+  "success": true,
+  "resource": {
+    "id": "...",
+    "resource": "https://your-server.com/api/paid-endpoint",
+    "origin": { "id": "...", "origin": "https://your-server.com" }
+  },
+  "accepts": [...],
+  "registrationDetails": { ... }
+}
+```
+
+**Error Response (422):**
+
+```json
+{
+  "success": false,
+  "error": {
+    "type": "no_402",
+    "message": "URL did not return a 402 Payment Required response"
+  }
+}
+```
+
+### Register All Resources from an Origin
+
+```
+POST /api/v1/resources/register-origin
+```
+
+Discover and register all x402-protected resources from an origin. Uses [OpenAPI discovery](./DISCOVERY.md), DNS TXT records (`_x402.{hostname}`), or `/.well-known/x402` to find resources.
+
+**Request Body:**
+
+```json
+{
+  "origin": "https://your-server.com"
+}
+```
+
+**Success Response (200):**
+
+```json
+{
+  "success": true,
+  "registered": 5,
+  "failed": 0,
+  "skipped": 1,
+  "deprecated": 0,
+  "total": 6,
+  "source": "openapi"
+}
+```
+
+### Refresh a Resource
+
+```
+POST /api/v1/resources/refresh
+```
+
+Re-probe an existing resource and update its registration data. Use this after updating your server's pricing, payment options, or schema to ensure x402scan reflects the latest configuration.
+
+**Request Body:**
+
+```json
+{
+  "url": "https://your-server.com/api/paid-endpoint"
+}
+```
+
+**Success Response (200):**
+
+```json
+{
+  "success": true,
+  "message": "Resource refreshed successfully",
+  "resource": { ... },
+  "accepts": [...],
+  "registrationDetails": { ... }
+}
+```
+
+## Error Responses
+
+All endpoints return errors in a consistent format:
+
+| Status | Type | Description |
+|--------|------|-------------|
+| 400 | `invalid_json` | Request body is not valid JSON |
+| 400 | `validation_error` | Missing or invalid fields in request body |
+| 404 | `no_discovery` | No discovery document found at the origin |
+| 422 | `no_402` | URL did not return a 402 Payment Required response |
+| 422 | `parse_error` | Failed to parse the x402 payment response |
+| 500 | `internal_error` | Unexpected server error |
+
+## Examples
+
+### cURL
+
+```bash
+# Register a single resource
+curl -X POST https://x402scan.com/api/v1/resources/register \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://your-server.com/api/paid-endpoint"}'
+
+# Register all resources from an origin
+curl -X POST https://x402scan.com/api/v1/resources/register-origin \
+  -H "Content-Type: application/json" \
+  -d '{"origin": "https://your-server.com"}'
+
+# Refresh a resource after updating pricing
+curl -X POST https://x402scan.com/api/v1/resources/refresh \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://your-server.com/api/paid-endpoint"}'
+```
+
+### JavaScript / TypeScript
+
+```typescript
+// Register a resource
+const response = await fetch('https://x402scan.com/api/v1/resources/register', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ url: 'https://your-server.com/api/paid-endpoint' }),
+});
+const result = await response.json();
+
+if (result.success) {
+  console.log('Registered:', result.resource.id);
+} else {
+  console.error('Failed:', result.error.message);
+}
+```
+
+### Python
+
+```python
+import requests
+
+# Register a resource
+response = requests.post(
+    "https://x402scan.com/api/v1/resources/register",
+    json={"url": "https://your-server.com/api/paid-endpoint"},
+)
+result = response.json()
+
+if result["success"]:
+    print(f"Registered: {result['resource']['id']}")
+else:
+    print(f"Failed: {result['error']['message']}")
+```
+
+## CI/CD Integration
+
+You can integrate resource registration into your deployment pipeline to automatically update x402scan when you deploy changes:
+
+```yaml
+# GitHub Actions example
+- name: Register resources on x402scan
+  run: |
+    curl -X POST https://x402scan.com/api/v1/resources/register-origin \
+      -H "Content-Type: application/json" \
+      -d '{"origin": "${{ env.SERVER_URL }}"}'
+```
+
+## CORS
+
+All endpoints support CORS with `Access-Control-Allow-Origin: *`, so they can be called from browser-based applications.


### PR DESCRIPTION
## Summary

Adds OpenAPI spec upload support to the resource registration page, allowing users to paste or upload an OpenAPI 3.x / Swagger 2.x specification to bulk-register all endpoints as x402 resources.

Fixes #97

## Changes

### New: OpenAPI Parser (pps/scan/src/lib/openapi/parse-spec.ts)
- Parses OpenAPI 3.0/3.1 and Swagger 2.0 specs (JSON)
- Extracts all endpoints with HTTP methods, parameters, request bodies, and response schemas
- Resolves `` references within the spec
- Handles server variable substitution for base URL resolution
- Supports base URL auto-detection from `servers` (3.x) or `host`/`basePath` (2.x)

### New: tRPC Endpoint (egisterFromOpenApi)
- **Dry-run mode** — parse and preview all discovered endpoints before registering
- Reuses existing `probeX402Endpoint()` + `registerResource()` pipeline (no new registration logic)
- Sequential registration with 200ms rate limiting
- Per-endpoint success/failure reporting
- Base URL override support

### New: UI Component (openapi-upload.tsx)
- File upload via existing `Dropzone` component (.json, .yaml, .yml)
- Paste textarea for copy-pasting spec content
- Two-step flow: Parse Spec → Review endpoints → Register All
- Endpoint preview with color-coded HTTP method badges
- Detailed results showing which endpoints registered vs failed (with error reasons)
- Collapsible base URL override field
- Reset button to start over

### Modified: Register Page
- Added `OpenApiUpload` component below the existing `RegisterResourceForm`
- No changes to existing registration flow

## How it works

1. User uploads or pastes an OpenAPI spec
2. Click **Parse Spec** to preview all discovered endpoints
3. Review the endpoint list (shows method, path, description)
4. Click **Register All** to probe and register each endpoint
5. Results show which endpoints were registered vs failed (with reasons)

Only endpoints responding with 402 get registered — others are skipped with error messages.

## No new dependencies
- Uses existing UI components (Card, Badge, Dropzone, Textarea, Collapsible)
- Uses existing registration pipeline (probeX402Endpoint, registerResource)
- Parser is self-contained with no external YAML/OpenAPI libraries