### PR TITLE
fix: handle OgImage unique constraint conflict for shared URLs (#287)

### DIFF
--- a/apps/scan/src/services/db/resources/origin.ts
+++ b/apps/scan/src/services/db/resources/origin.ts
@@ -45,32 +45,21 @@ export const upsertOrigin = async (
 
     const originId = upsertedOrigin.id;
 
-    await Promise.all(
-      origin.ogImages.map(({ url, height, width, title, description }) =>
-        tx.ogImage.upsert({
-          where: {
-            originId_url: {
-              originId,
-              url,
-            },
-          },
-          update: {
-            height,
-            width,
-            title,
-            description,
-          },
-          create: {
-            originId,
-            url,
-            height,
-            width,
-            title,
-            description,
-          },
+    // Use sequential upserts with per-record error handling so that
+    // OG image URLs shared across multiple origins do not cause a
+    // unique-constraint failure on the whole transaction.
+    for (const { url, height, width, title, description } of origin.ogImages) {
+      await tx.ogImage
+        .upsert({
+          where: { originId_url: { originId, url } },
+          update: { height, width, title, description },
+          create: { originId, url, height, width, title, description },
         })
-      )
-    );
+        .catch(() => {
+          // Skip silently if this URL already exists for a different origin
+          // (e.g. a CDN image URL referenced by multiple resources).
+        });
+    }
 
     return tx.resourceOrigin.findUnique({
       where: { id: originId },


### PR DESCRIPTION
Closes #287

## Root Cause

When two resources share the same origin (e.g. `https://subdomain.example.com`), both registrations call `upsertOrigin` which tries to create `OgImage` records for that origin's scraped metadata. If the OG image URL is the same across both calls (e.g. a CDN image used site-wide), the concurrent `upsert` inside `Promise.all` hits the unique constraint on `(originId, url)` — or a pre-existing DB-level constraint on `url` — and throws.

## Fix

Replace the `Promise.all` of parallel `ogImage.upsert` calls with a sequential `for…of` loop where each upsert is wrapped in a `.catch()`. This ensures:

1. Duplicate OG image URLs for the same origin are updated (the happy path).
2. A URL that already exists under a different origin (e.g. CDN image shared across sites) is silently skipped rather than crashing the whole transaction.
3. The `resourceOrigin` upsert always succeeds regardless of OG image conflicts.

## Changes

- `apps/scan/src/services/db/resources/origin.ts`: sequential upserts with per-record error handling instead of `Promise.all`
