### PR TITLE
add first-class SIWX support to discovery and registration

### DIFF
--- a/apps/scan/.gitignore
+++ b/apps/scan/.gitignore
@@ -48,3 +48,4 @@ next-env.d.ts
 .trigger
 
 test-*
+.env*.local

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
@@ -38,7 +38,7 @@ import type {
   FailedResource as FailedResourceType,
   TestedResource as TestedResourceType,
 } from '@/types/batch-test';
-import type { DiscoverySource } from '@/types/discovery';
+import type { AuthMode, DiscoverySource } from '@/types/discovery';
 import type { Methods } from '@/types/x402';
 import type { OgImage, ResourceOrigin } from '@x402scan/scan-db/types';
 
@@ -74,17 +74,21 @@ export interface DiscoveryPanelProps {
   discoveryError?: string;
   /** Map of URL to invalid status for displaying badges */
   invalidResourcesMap?: Record<string, { invalid: boolean; reason?: string }>;
+  /** Map of URL to auth mode from discovery (e.g. 'siwx' for identity-gated). */
+  authModeMap?: Record<string, AuthMode>;
   /** Whether bulk registration is in progress */
   isRegisteringAll: boolean;
   /** Bulk registration result */
   bulkResult?: {
     success: boolean;
     registered: number;
+    siwx?: number;
     total: number;
     failed: number;
     skipped?: number;
     deprecated?: number;
     failedDetails?: { url: string; error: string; status?: number }[];
+    siwxDetails?: { url: string }[];
     skippedDetails?: { url: string; error: string; status?: number }[];
   } | null;
   /** Called when "Register All" is clicked (required in register mode) */
@@ -133,6 +137,7 @@ export function DiscoveryPanel({
   resourceCount,
   discoveryError,
   invalidResourcesMap = {},
+  authModeMap = {},
   isRegisteringAll,
   bulkResult,
   onRegisterAll,
@@ -162,15 +167,16 @@ export function DiscoveryPanel({
   if (!isTestMode && bulkResult?.success) {
     const skippedCount = bulkResult.skipped ?? 0;
     const skippedDetails = bulkResult.skippedDetails ?? [];
-    const siwxSkippedCount = skippedDetails.filter(item =>
-      item.error.includes('SIWX')
-    ).length;
-    const missingSchemaSkippedCount = skippedDetails.filter(item =>
-      item.error.includes('Missing input schema')
-    ).length;
+    const siwxCount = bulkResult.siwx ?? 0;
+    const siwxDetails = bulkResult.siwxDetails ?? [];
 
-    // Show error state if no resources were registered
-    if (bulkResult.registered === 0 && bulkResult.failed > 0) {
+    // Show error state only if nothing landed positively (no paid registers
+    // and no SIWX detections) and there were real failures.
+    if (
+      bulkResult.registered === 0 &&
+      siwxCount === 0 &&
+      bulkResult.failed > 0
+    ) {
       return (
         <div className="space-y-3">
           <div className="flex items-start gap-3 p-4 border rounded-md bg-red-500/10 border-red-500/30">
@@ -261,6 +267,22 @@ export function DiscoveryPanel({
           </div>
         </div>
 
+        {/* SIWX detected notice */}
+        {siwxCount > 0 && (
+          <div className="flex items-start gap-3 p-4 border border-primary bg-primary/5 rounded-md">
+            <ShieldCheck className="size-5 text-primary shrink-0 mt-0.5" />
+            <div>
+              <h3 className="font-medium text-primary">
+                {siwxCount} SIWX route{siwxCount === 1 ? '' : 's'} detected
+              </h3>
+              <p className="text-sm text-muted-foreground">
+                Identity-gated routes — agents with an agentcash wallet can
+                call these for free.
+              </p>
+            </div>
+          </div>
+        )}
+
         {/* Skipped resources notice */}
         {skippedCount > 0 && (
           <div className="flex items-start gap-3 p-4 border rounded-md bg-amber-600/10 border-amber-600/30">
@@ -271,24 +293,8 @@ export function DiscoveryPanel({
               </h3>
               <p className="text-sm text-muted-foreground">
                 Some resources were skipped by compatibility rules in strict
-                registration mode.
+                registration mode (e.g. missing input schema).
               </p>
-              <ul className="text-xs text-muted-foreground mt-2 space-y-1">
-                {siwxSkippedCount > 0 && (
-                  <li>
-                    - {siwxSkippedCount} SIWX auth-only endpoint
-                    {siwxSkippedCount === 1 ? '' : 's'} (no payment
-                    requirements)
-                  </li>
-                )}
-                {missingSchemaSkippedCount > 0 && (
-                  <li>
-                    - {missingSchemaSkippedCount} endpoint
-                    {missingSchemaSkippedCount === 1 ? '' : 's'} missing input
-                    schema
-                  </li>
-                )}
-              </ul>
             </div>
           </div>
         )}
@@ -353,6 +359,28 @@ export function DiscoveryPanel({
               </div>
             </details>
           )}
+
+        {siwxCount > 0 && siwxDetails.length > 0 && (
+          <details className="border rounded-md group">
+            <summary className="p-3 cursor-pointer hover:bg-muted/50 font-medium text-sm flex items-center gap-2">
+              <ChevronDown className="size-4 transition-transform group-open:rotate-180" />
+              SIWX Routes ({siwxDetails.length})
+            </summary>
+            <div className="p-4 pt-2 border-t space-y-2 max-h-[400px] overflow-y-auto">
+              {siwxDetails.map((entry, idx) => (
+                <div
+                  key={idx}
+                  className="p-3 bg-muted/50 rounded border text-xs space-y-1"
+                >
+                  <div className="flex items-start gap-2">
+                    <span className="text-muted-foreground shrink-0">URL:</span>
+                    <span className="font-mono break-all">{entry.url}</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </details>
+        )}
 
         {skippedCount > 0 && skippedDetails.length > 0 && (
           <details className="border rounded-md group">
@@ -514,6 +542,7 @@ export function DiscoveryPanel({
                 {paginatedResources.map((resourceUrl, idx) => {
                   const tested = testedResourceMap.get(resourceUrl);
                   const invalidInfo = invalidResourcesMap[resourceUrl];
+                  const authMode = authModeMap[resourceUrl];
 
                   if (tested) {
                     // Check if we have a valid schema for ResourceExecutor
@@ -541,6 +570,7 @@ export function DiscoveryPanel({
                         preview={preview}
                         testedResponse={tested}
                         invalidInfo={invalidInfo}
+                        authMode={authMode}
                         verifiedAddresses={verifiedAddresses}
                         onRetry={onRetryResource}
                       />
@@ -556,6 +586,7 @@ export function DiscoveryPanel({
                       preview={preview}
                       failedDetails={failedDetails}
                       invalidInfo={invalidInfo}
+                      authMode={authMode}
                       verifiedAddresses={verifiedAddresses}
                       onRetry={onRetryResource}
                     />
@@ -571,6 +602,7 @@ export function DiscoveryPanel({
               source={source}
               registeredUrls={registeredUrls}
               invalidResourcesMap={invalidResourcesMap}
+              authModeMap={authModeMap}
             />
           )}
 
@@ -750,6 +782,7 @@ function FailedResourceCard({
   failedDetails,
   testedResponse,
   invalidInfo,
+  authMode,
   verifiedAddresses = {},
   onRetry,
 }: {
@@ -759,6 +792,7 @@ function FailedResourceCard({
   /** If provided, x402 parsed successfully but is missing schema */
   testedResponse?: TestedResource;
   invalidInfo?: { invalid: boolean; reason?: string };
+  authMode?: AuthMode;
   verifiedAddresses?: Record<string, boolean>;
   onRetry?: () => Promise<void>;
 }) {
@@ -795,11 +829,14 @@ function FailedResourceCard({
   // Determine checklist status based on error details or tested response
   const returns402 = x402Parsed;
   const isInvalid = invalidInfo?.invalid ?? false;
-  const errorMessage = isInvalid
-    ? (invalidInfo?.reason ?? 'Invalid format')
-    : x402Parsed
-      ? 'Missing input schema'
-      : (failedDetails?.error ?? 'Unknown error');
+  const isSiwx = authMode === 'siwx';
+  const errorMessage = isSiwx
+    ? 'SIWX (identity-gated, no payment)'
+    : isInvalid
+      ? (invalidInfo?.reason ?? 'Invalid format')
+      : x402Parsed
+        ? 'Missing input schema'
+        : (failedDetails?.error ?? 'Unknown error');
 
   return (
     <div className="pl-4 border-l pt-4 relative">
@@ -807,7 +844,11 @@ function FailedResourceCard({
       <Card
         className={cn(
           'overflow-hidden',
-          isInvalid ? 'border-yellow-500/30' : 'border-red-500/30'
+          isSiwx
+            ? 'border-primary'
+            : isInvalid
+              ? 'border-yellow-500/30'
+              : 'border-red-500/30'
         )}
       >
         <button
@@ -821,12 +862,14 @@ function FailedResourceCard({
                 <div
                   className={cn(
                     'font-mono px-1 rounded-md text-xs shrink-0',
-                    isInvalid
-                      ? 'bg-yellow-600/10 border border-yellow-600 text-yellow-600'
-                      : 'bg-red-600/10 border border-red-600 text-red-600'
+                    isSiwx
+                      ? 'bg-primary/10 border border-primary text-primary'
+                      : isInvalid
+                        ? 'bg-yellow-600/10 border border-yellow-600 text-yellow-600'
+                        : 'bg-red-600/10 border border-red-600 text-red-600'
                   )}
                 >
-                  {isInvalid ? 'INVALID' : 'ERR'}
+                  {isSiwx ? 'SIWX' : isInvalid ? 'INVALID' : 'ERR'}
                 </div>
                 <span className="font-mono text-sm truncate">{pathname}</span>
               </div>
@@ -834,7 +877,11 @@ function FailedResourceCard({
                 <span
                   className={cn(
                     'text-xs truncate max-w-[200px]',
-                    isInvalid ? 'text-yellow-500' : 'text-red-500'
+                    isSiwx
+                      ? 'text-primary'
+                      : isInvalid
+                        ? 'text-yellow-500'
+                        : 'text-red-500'
                   )}
                 >
                   {errorMessage}
@@ -976,12 +1023,14 @@ function RegisterModeResourceList({
   source,
   registeredUrls,
   invalidResourcesMap = {},
+  authModeMap = {},
 }: {
   enteredUrl?: string;
   discoveredResources: string[];
   source?: DiscoverySource;
   registeredUrls: string[];
   invalidResourcesMap?: Record<string, { invalid: boolean; reason?: string }>;
+  authModeMap?: Record<string, AuthMode>;
 }) {
   const registeredSet = new Set(registeredUrls);
 
@@ -1064,6 +1113,22 @@ function RegisterModeResourceList({
                       </span>
                     ) : (
                       <span className="text-xs text-muted-foreground">New</span>
+                    )}
+                    {authModeMap[url] === 'siwx' && (
+                      <Tooltip>
+                        <TooltipTrigger>
+                          <span className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded bg-primary/10 border border-primary text-primary">
+                            <ShieldCheck className="size-3" />
+                            SIWX
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p className="text-xs">
+                            Identity-gated route (Sign-In With X). Requires a
+                            wallet proof; no payment.
+                          </p>
+                        </TooltipContent>
+                      </Tooltip>
                     )}
                     {invalidResourcesMap[url]?.invalid && (
                       <Tooltip>

--- a/apps/scan/src/app/(app)/_components/discovery/use-discovery.ts
+++ b/apps/scan/src/app/(app)/_components/discovery/use-discovery.ts
@@ -7,7 +7,11 @@ import { api } from '@/trpc/client';
 import { useRegisterFromOrigin } from '@/hooks/use-register-from-origin';
 
 import type { FailedResource, TestedResource } from '@/types/batch-test';
-import type { DiscoveredResource, DiscoverySource } from '@/types/discovery';
+import type {
+  AuthMode,
+  DiscoveredResource,
+  DiscoverySource,
+} from '@/types/discovery';
 import type { OriginPreview } from './discovery-panel';
 import { useBatchTest } from './use-batch-test';
 import { useOwnership } from './use-ownership';
@@ -66,6 +70,7 @@ export interface UseDiscoveryReturn {
   discoveryResourceCount: number;
   discoveryError?: string;
   invalidResourcesMap: Record<string, { invalid: boolean; reason?: string }>;
+  authModeMap: Record<string, AuthMode>;
 
   // Origin preview
   isPreviewLoading: boolean;
@@ -94,11 +99,13 @@ export interface UseDiscoveryReturn {
   bulkData: {
     success: true;
     registered: number;
+    siwx: number;
     total: number;
     failed: number;
     skipped?: number;
     deprecated?: number;
     failedDetails?: { url: string; error: string; status?: number }[];
+    siwxDetails?: { url: string }[];
     skippedDetails?: { url: string; error: string; status?: number }[];
     originId?: string;
   } | null;
@@ -223,6 +230,17 @@ export function useDiscovery({
     return map;
   }, [effectiveResources]);
 
+  // Create map of URL -> authMode for displaying auth badges (e.g. SIWX).
+  const authModeMap: Record<string, AuthMode> = useMemo(() => {
+    const map: Record<string, AuthMode> = {};
+    for (const resource of effectiveResources) {
+      if (resource.authMode) {
+        map[resource.url] = resource.authMode;
+      }
+    }
+    return map;
+  }, [effectiveResources]);
+
   // Batch test query - uses wrapper hook for proper typing
   const batchTest = useBatchTest(
     effectiveResources,
@@ -292,6 +310,7 @@ export function useDiscovery({
         ? discoveryQuery.data.error
         : undefined,
     invalidResourcesMap,
+    authModeMap,
 
     // Origin preview
     isPreviewLoading: previewQuery.isLoading,
@@ -321,11 +340,13 @@ export function useDiscovery({
       ? {
           success: true as const,
           registered: bulkData.registered,
+          siwx: bulkData.siwx,
           total: bulkData.total,
           failed: bulkData.failed,
           skipped: bulkData.skipped,
           deprecated: bulkData.deprecated,
           failedDetails: bulkData.failedDetails,
+          siwxDetails: bulkData.siwxDetails,
           skippedDetails: bulkData.skippedDetails,
           originId: bulkData.originId,
         }

--- a/apps/scan/src/app/(app)/developer/_components/form.tsx
+++ b/apps/scan/src/app/(app)/developer/_components/form.tsx
@@ -54,6 +54,7 @@ export const TestEndpointForm = () => {
     payToAddresses,
     recoveredAddresses,
     verifiedAddresses,
+    authModeMap,
   } = useDiscovery({
     url,
   });
@@ -232,6 +233,7 @@ export const TestEndpointForm = () => {
             resources={discoveryResources}
             resourceCount={discoveryResourceCount}
             discoveryError={discoveryError}
+            authModeMap={authModeMap}
             isRegisteringAll={false}
             mode="test"
             preview={discoveryPreview}

--- a/apps/scan/src/app/api/x402/_handlers/registry-register-origin.ts
+++ b/apps/scan/src/app/api/x402/_handlers/registry-register-origin.ts
@@ -32,6 +32,7 @@ export async function handleRegistryRegisterOrigin(
   return jsonResponse({
     success: true,
     registered: result.registered,
+    siwx: result.siwx,
     failed: result.failed,
     skipped: result.skipped,
     deprecated: result.deprecated,
@@ -39,5 +40,6 @@ export async function handleRegistryRegisterOrigin(
     source: result.source,
     failedDetails:
       result.failedDetails.length > 0 ? result.failedDetails : undefined,
+    siwxDetails: result.siwxDetails.length > 0 ? result.siwxDetails : undefined,
   });
 }

--- a/apps/scan/src/hooks/use-register-from-origin.ts
+++ b/apps/scan/src/hooks/use-register-from-origin.ts
@@ -5,11 +5,13 @@ import { toast } from 'sonner';
 
 interface RegisterFromOriginSuccessData {
   registered: number;
+  siwx: number;
   failed: number;
   skipped: number;
   deprecated?: number;
   total: number;
   failedDetails?: { url: string; error: string; status?: number }[];
+  siwxDetails?: { url: string }[];
   skippedDetails?: { url: string; error: string; status?: number }[];
   originId?: string;
 }
@@ -49,6 +51,7 @@ export function useRegisterFromOrigin(
       if (showToasts) {
         const parts: string[] = [];
         if (data.registered > 0) parts.push(`${data.registered} registered`);
+        if (data.siwx > 0) parts.push(`${data.siwx} SIWX`);
         if (data.deprecated > 0) parts.push(`${data.deprecated} removed`);
         if (data.skipped > 0) parts.push(`${data.skipped} skipped`);
         if (data.failed > 0) parts.push(`${data.failed} failed`);
@@ -59,11 +62,13 @@ export function useRegisterFromOrigin(
 
       onSuccess?.({
         registered: data.registered,
+        siwx: data.siwx,
         failed: data.failed,
         skipped: data.skipped,
         deprecated: data.deprecated,
         total: data.total,
         failedDetails: data.failedDetails,
+        siwxDetails: data.siwxDetails,
         skippedDetails: data.skippedDetails,
         originId: data.originId,
       });

--- a/apps/scan/src/lib/discovery/register-origin.ts
+++ b/apps/scan/src/lib/discovery/register-origin.ts
@@ -3,6 +3,8 @@ import { getRegistrationErrorMessage } from './utils';
 import { registerResource } from '@/lib/resources';
 import { deprecateStaleResources } from '@/services/db/resources/resource';
 
+import type { AuthMode } from '@agentcash/discovery';
+
 const BULK_REGISTER_CONCURRENCY = 6;
 
 async function mapSettledWithConcurrency<T, R>(
@@ -49,27 +51,41 @@ async function mapSettledWithConcurrency<T, R>(
 
 export interface RegisterOriginResult {
   registered: number;
+  siwx: number;
   failed: number;
   skipped: number;
   deprecated: number;
   total: number;
   source: string | undefined;
   failedDetails: { url: string; error: string; status?: number }[];
+  siwxDetails: { url: string }[];
   skippedDetails: { url: string; error: string; status?: number }[];
   originId: string | undefined;
 }
 
 /**
  * Probe and register all resources from a discovery document.
- * Skips SIWX-only endpoints and endpoints without an input schema.
+ * Paid resources are probed and written to the resources table.
+ * SIWX-identified routes are a first-class positive outcome — they are
+ * reported back in `siwx`/`siwxDetails` but not written to the DB (until
+ * schema support lands). Endpoints missing an input schema are reported
+ * as skipped.
  * Deprecates resources from the same origin that are no longer in the list.
  */
 export async function registerResourcesFromDiscovery(
-  resources: { url: string }[],
+  resources: { url: string; authMode?: AuthMode }[],
   source: string | undefined
 ): Promise<RegisterOriginResult> {
   const results = await mapSettledWithConcurrency(resources, async resource => {
     const resourceUrl = resource.url;
+
+    if (resource.authMode === 'siwx') {
+      return {
+        success: true as const,
+        siwx: true as const,
+        url: resourceUrl,
+      };
+    }
 
     const probeResult = await probeX402Endpoint(resourceUrl);
 
@@ -85,11 +101,9 @@ export async function registerResourcesFromDiscovery(
 
     if (advisory.authMode === 'siwx') {
       return {
-        success: false as const,
-        skipped: true as const,
+        success: true as const,
+        siwx: true as const,
         url: resourceUrl,
-        error: 'SIWX auth-only endpoint (no payment requirements to index)',
-        status: 402,
       };
     }
 
@@ -116,6 +130,7 @@ export async function registerResourcesFromDiscovery(
   });
 
   const successfulResults: { url: string }[] = [];
+  const siwxResults: { url: string }[] = [];
   const failedResults: { url: string; error: string; status?: number }[] = [];
   const skippedResults: { url: string; error: string; status?: number }[] = [];
   let originId: string | undefined;
@@ -129,9 +144,13 @@ export async function registerResourcesFromDiscovery(
     if (result.status === 'fulfilled' && result.value) {
       const value = result.value;
       if ('success' in value && value.success) {
-        successfulResults.push({ url: resourceUrl });
-        if (!originId && 'resource' in value && value.resource?.origin?.id) {
-          originId = value.resource.origin.id;
+        if ('siwx' in value && value.siwx === true) {
+          siwxResults.push({ url: resourceUrl });
+        } else {
+          successfulResults.push({ url: resourceUrl });
+          if (!originId && 'resource' in value && value.resource?.origin?.id) {
+            originId = value.resource.origin.id;
+          }
         }
       } else if (
         'success' in value &&
@@ -170,12 +189,14 @@ export async function registerResourcesFromDiscovery(
 
   return {
     registered: successfulResults.length,
+    siwx: siwxResults.length,
     failed: failedResults.length,
     skipped: skippedResults.length,
     deprecated,
     total: results.length,
     source,
     failedDetails: failedResults,
+    siwxDetails: siwxResults,
     skippedDetails: skippedResults,
     originId,
   };

--- a/apps/scan/src/services/discovery/fetch-discovery.ts
+++ b/apps/scan/src/services/discovery/fetch-discovery.ts
@@ -66,7 +66,13 @@ export async function fetchDiscoveryDocument(
     endpoint => {
       try {
         const url = new URL(endpoint.path, discovered.origin).toString();
-        return [{ url, method: endpoint.method }];
+        return [
+          {
+            url,
+            method: endpoint.method,
+            ...(endpoint.authMode ? { authMode: endpoint.authMode } : {}),
+          },
+        ];
       } catch {
         return [];
       }

--- a/apps/scan/src/trpc/routers/developer.ts
+++ b/apps/scan/src/trpc/routers/developer.ts
@@ -96,6 +96,12 @@ export const developerRouter = createTRPCRouter({
                   'TRACE',
                 ])
                 .optional(),
+              /** Auth classification from discovery. SIWX routes are skipped
+               *  because they are identity-gated, not x402-paid — probing them
+               *  would incorrectly mark them as failed. */
+              authMode: z
+                .enum(['paid', 'siwx', 'apiKey', 'apiKey+paid', 'unprotected'])
+                .optional(),
               /** If true, this resource is invalid and should not be tested */
               invalid: z.boolean().optional(),
               /** Reason why resource is invalid */
@@ -115,10 +121,14 @@ export const developerRouter = createTRPCRouter({
           error: r.invalidReason ?? 'Invalid resource format',
         }));
 
-      // Only test valid resources
-      const validResources = input.resources.filter(r => !r.invalid);
+      // SIWX routes are identity-gated, not payment-protected. Skip probing
+      // them — they are surfaced via authModeMap on the client and should not
+      // appear in either the tested or failed buckets.
+      const probeableResources = input.resources.filter(
+        r => !r.invalid && r.authMode !== 'siwx'
+      );
       const testResults = await Promise.all(
-        validResources.map(r => testSingleResource(r.url, r.method))
+        probeableResources.map(r => testSingleResource(r.url, r.method))
       );
 
       // Combine test results with invalid results

--- a/apps/scan/src/types/discovery.ts
+++ b/apps/scan/src/types/discovery.ts
@@ -2,6 +2,8 @@
  * x402 Discovery Types
  */
 
+import type { AuthMode } from '@agentcash/discovery';
+
 /**
  * A discovered resource with URL and optional HTTP method.
  * Method is specified in discovery doc like "POST /api/resource"
@@ -17,11 +19,15 @@ export interface DiscoveredResource {
     | 'HEAD'
     | 'OPTIONS'
     | 'TRACE';
+  /** Auth classification from discovery (paid, siwx, apiKey, apiKey+paid, unprotected). */
+  authMode?: AuthMode;
   /** If true, this resource failed validation */
   invalid?: boolean;
   /** Error message if resource is invalid */
   invalidReason?: string;
 }
+
+export type { AuthMode };
 
 export type DiscoverySource =
   | 'openapi'


### PR DESCRIPTION
## Summary
- Threads `authMode` through the discovery fetch, `registerResourcesFromDiscovery`, and `developer.batchTest` so SIWX (identity-gated) routes are a first-class positive outcome instead of landing in the failed/skipped buckets.
- Fixes the bug where entering a URL on `/resources/register` triggered a preemptive batchTest that marked SIWX routes as failed (separate pipeline from the click path).
- Adds SIWX UI: "SIWX route detected" callout, SIWX Routes expander, and badges on resource rows, all in x402scan primary brand blue.

## Changes
**Click pipeline** — `register-origin.ts` short-circuits on `authMode === 'siwx'` from discovery and reports SIWX routes in a new `siwx`/`siwxDetails` bucket. `registry-register-origin` handler and `useRegisterFromOrigin` hook expose the new fields to the UI.

**Preemptive pipeline** — `developer.batchTest` accepts `authMode` in its input schema and filters SIWX routes out before probing, so `probeX402Endpoint` (which looks for x402 payment options only) no longer classifies them as failed.

**UI** — `DiscoveryPanel` gets SIWX-aware styling throughout using `primary` brand color. `/developer` test form wires `authModeMap` through to the panel. Previously-indigo SIWX classes are all swapped to `primary`.

**Drive-by** — ignore `.env*.local` files in `apps/scan`.

## Test plan
- [ ] Type a URL whose discovery doc contains an SIWX route into `/resources/register` — SIWX routes should no longer appear in the red "failed resources" expander.
- [ ] Click Register on a discovery doc with mixed paid + SIWX routes — verify the "Registration Complete" banner shows total registered (no `(N SIWX)` inline), the "SIWX route detected" callout appears below with brand-blue styling, and the SIWX Routes expander lists the URLs.
- [ ] Test an SIWX endpoint on `/developer` — verify the resource card renders with SIWX badge/label in brand blue, not red/purple.
- [ ] Typecheck passes (`pnpm -F scan types:check`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)