### PR TITLE
chore: migrate to @signinwithethereum/siwe

### DIFF
--- a/apps/scan/package.json
+++ b/apps/scan/package.json
@@ -125,7 +125,7 @@
     "resumable-stream": "^2.2.8",
     "server-only": "catalog:",
     "shiki": "^3.13.0",
-    "siwe": "catalog:",
+    "@signinwithethereum/siwe": "catalog:",
     "sonner": "^2.0.7",
     "streamdown": "^1.4.0",
     "stripe": "^20.1.2",

--- a/apps/scan/package.json
+++ b/apps/scan/package.json
@@ -126,7 +126,7 @@
     "resumable-stream": "^2.2.8",
     "server-only": "catalog:",
     "shiki": "^3.13.0",
-    "siwe": "catalog:",
+    "@signinwithethereum/siwe": "catalog:",
     "sonner": "^2.0.7",
     "streamdown": "^1.4.0",
     "stripe": "^20.1.2",

--- a/apps/scan/src/auth/providers/siwe/provider.ts
+++ b/apps/scan/src/auth/providers/siwe/provider.ts
@@ -1,4 +1,4 @@
-import { SiweMessage } from 'siwe';
+import { SiweMessage } from '@signinwithethereum/siwe';
 import Credentials, {
   type CredentialsConfig,
 } from 'next-auth/providers/credentials';

--- a/apps/scan/src/auth/providers/siwe/provider.ts
+++ b/apps/scan/src/auth/providers/siwe/provider.ts
@@ -1,4 +1,4 @@
-import { SiweMessage } from 'siwe';
+import { SiweMessage } from '@signinwithethereum/siwe';
 import Credentials, {
   type CredentialsConfig,
 } from 'next-auth/providers/credentials';
@@ -130,6 +130,7 @@ async function verifySignature({
 }) {
   const result = await siwe.verify({
     signature: credentials.signedMessage,
+    domain: siwe.domain,
     nonce,
   });
   if (!result.success) {

--- a/apps/scan/src/auth/providers/siwe/sign-in.ts
+++ b/apps/scan/src/auth/providers/siwe/sign-in.ts
@@ -1,4 +1,4 @@
-import { SiweMessage } from 'siwe';
+import { SiweMessage } from '@signinwithethereum/siwe';
 import { SIWE_PROVIDER_ID, SIWE_STATEMENT } from './constants';
 import { getCsrfToken, signIn } from 'next-auth/react';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ catalogs:
       specifier: ^0.0.74
       version: 0.0.74
   default:
+    '@signinwithethereum/siwe':
+      specifier: ^4.1.0
+      version: 4.1.0
     '@types/node':
       specifier: ^20.19.27
       version: 20.19.27
@@ -47,9 +50,6 @@ catalogs:
     server-only:
       specifier: ^0.0.1
       version: 0.0.1
-    siwe:
-      specifier: ^3.0.0
-      version: 3.0.0
     superjson:
       specifier: ^2.2.6
       version: 2.2.6
@@ -420,6 +420,9 @@ importers:
       '@radix-ui/react-use-controllable-state':
         specifier: ^1.2.2
         version: 1.2.2(@types/react@19.2.2)(react@19.2.2)
+      '@signinwithethereum/siwe':
+        specifier: 'catalog:'
+        version: 4.1.0(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(viem@2.47.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       '@solana-program/token':
         specifier: ^0.7.0
         version: 0.7.0(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))
@@ -606,9 +609,6 @@ importers:
       shiki:
         specifier: ^3.13.0
         version: 3.14.0
-      siwe:
-        specifier: 'catalog:'
-        version: 3.0.0(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.2(react@19.2.2))(react@19.2.2)
@@ -4505,6 +4505,20 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@signinwithethereum/siwe-parser@4.1.0':
+    resolution: {integrity: sha512-aS+bU5QpTQgMpC6HjQHuKJpltUrkyGUVNuhuBLARa39wF1B+m05/4bgnf2qrEcgQONfU36A2Nbn3ibmwhHkc2Q==}
+
+  '@signinwithethereum/siwe@4.1.0':
+    resolution: {integrity: sha512-NT56M82i+A2uBU++F9PSBvEYPcjUV3BdClRVojWt3cbe7WizIVH1wi2qKJJR570RLHZvr8q1gUf0E90WymlMeA==}
+    peerDependencies:
+      ethers: ^5.7.0 || ^6.13.0
+      viem: 2.47.0
+    peerDependenciesMeta:
+      ethers:
+        optional: true
+      viem:
+        optional: true
+
   '@sindresorhus/is@7.1.1':
     resolution: {integrity: sha512-rO92VvpgMc3kfiTjGT52LEtJ8Yc5kCWhZjLQ3LwlA4pSgPpQO7bVpYXParOD8Jwf+cVQECJo3yP/4I8aZtUQTQ==}
     engines: {node: '>=18'}
@@ -5464,9 +5478,6 @@ packages:
 
   '@spruceid/siwe-parser@2.1.2':
     resolution: {integrity: sha512-d/r3S1LwJyMaRAKQ0awmo9whfXeE88Qt00vRj91q5uv5ATtWIQEGJ67Yr5eSZw5zp1/fZCXZYuEckt8lSkereQ==}
-
-  '@spruceid/siwe-parser@3.0.0':
-    resolution: {integrity: sha512-Y92k63ilw/8jH9Ry4G2e7lQd0jZAvb0d/Q7ssSD0D9mp/Zt2aCXIc3g0ny9yhplpAx1QXHsMz/JJptHK/zDGdw==}
 
   '@stablelib/binary@1.0.1':
     resolution: {integrity: sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==}
@@ -10963,11 +10974,6 @@ packages:
 
   siwe@2.3.2:
     resolution: {integrity: sha512-aSf+6+Latyttbj5nMu6GF3doMfv2UYj83hhwZgUF20ky6fTS83uVhkQABdIVnEuS8y1bBdk7p6ltb9SmlhTTlA==}
-    peerDependencies:
-      ethers: ^5.6.8 || ^6.0.8
-
-  siwe@3.0.0:
-    resolution: {integrity: sha512-P2/ry7dHYJA6JJ5+veS//Gn2XDwNb3JMvuD6xiXX8L/PJ1SNVD4a3a8xqEbmANx+7kNQcD8YAh1B9bNKKvRy/g==}
     peerDependencies:
       ethers: ^5.6.8 || ^6.0.8
 
@@ -16961,6 +16967,18 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@signinwithethereum/siwe-parser@4.1.0':
+    dependencies:
+      '@noble/hashes': 1.8.0
+      apg-js: 4.4.0
+
+  '@signinwithethereum/siwe@4.1.0(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(viem@2.47.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
+    dependencies:
+      '@signinwithethereum/siwe-parser': 4.1.0
+    optionalDependencies:
+      ethers: 6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      viem: 2.47.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+
   '@sindresorhus/is@7.1.1': {}
 
   '@socket.io/component-emitter@3.1.2': {}
@@ -18475,11 +18493,6 @@ snapshots:
       apg-js: 4.4.0
       uri-js: 4.4.1
       valid-url: 1.0.9
-
-  '@spruceid/siwe-parser@3.0.0':
-    dependencies:
-      '@noble/hashes': 1.8.0
-      apg-js: 4.4.0
 
   '@stablelib/binary@1.0.1':
     dependencies:
@@ -26638,12 +26651,6 @@ snapshots:
       ethers: 6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       uri-js: 4.4.1
       valid-url: 1.0.9
-
-  siwe@3.0.0(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
-    dependencies:
-      '@spruceid/siwe-parser': 3.0.0
-      '@stablelib/random': 1.0.2
-      ethers: 6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
 
   slash@3.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ catalogs:
       specifier: ^0.0.74
       version: 0.0.74
   default:
+    '@signinwithethereum/siwe':
+      specifier: ^4.1.0
+      version: 4.2.0
     '@types/node':
       specifier: ^20.19.27
       version: 20.19.27
@@ -47,9 +50,6 @@ catalogs:
     server-only:
       specifier: ^0.0.1
       version: 0.0.1
-    siwe:
-      specifier: ^3.0.0
-      version: 3.0.0
     superjson:
       specifier: ^2.2.6
       version: 2.2.6
@@ -431,6 +431,9 @@ importers:
       '@radix-ui/react-use-controllable-state':
         specifier: ^1.2.2
         version: 1.2.2(@types/react@19.2.2)(react@19.2.2)
+      '@signinwithethereum/siwe':
+        specifier: 'catalog:'
+        version: 4.2.0(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(viem@2.47.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       '@solana-program/token':
         specifier: ^0.7.0
         version: 0.7.0(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))
@@ -617,9 +620,6 @@ importers:
       shiki:
         specifier: ^3.13.0
         version: 3.14.0
-      siwe:
-        specifier: 'catalog:'
-        version: 3.0.0(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.2(react@19.2.2))(react@19.2.2)
@@ -1009,6 +1009,8 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
+  packages/internal/databases/scan/generated/client: {}
+
   packages/internal/databases/transfers:
     dependencies:
       '@neondatabase/serverless':
@@ -1054,6 +1056,8 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+
+  packages/internal/databases/transfers/generated/client: {}
 
   packages/internal/neverthrow:
     dependencies:
@@ -5460,21 +5464,6 @@ packages:
 
   '@speed-highlight/core@1.2.12':
     resolution: {integrity: sha512-uilwrK0Ygyri5dToHYdZSjcvpS2ZwX0w5aSt3GCEN9hrjxWCoeV4Z2DTXuxjwbntaLQIEEAlCeNQss5SoHvAEA==}
-
-  '@spruceid/siwe-parser@3.0.0':
-    resolution: {integrity: sha512-Y92k63ilw/8jH9Ry4G2e7lQd0jZAvb0d/Q7ssSD0D9mp/Zt2aCXIc3g0ny9yhplpAx1QXHsMz/JJptHK/zDGdw==}
-
-  '@stablelib/binary@1.0.1':
-    resolution: {integrity: sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==}
-
-  '@stablelib/int@1.0.1':
-    resolution: {integrity: sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w==}
-
-  '@stablelib/random@1.0.2':
-    resolution: {integrity: sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==}
-
-  '@stablelib/wipe@1.0.1':
-    resolution: {integrity: sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg==}
 
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
@@ -10944,11 +10933,6 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
-  siwe@3.0.0:
-    resolution: {integrity: sha512-P2/ry7dHYJA6JJ5+veS//Gn2XDwNb3JMvuD6xiXX8L/PJ1SNVD4a3a8xqEbmANx+7kNQcD8YAh1B9bNKKvRy/g==}
-    peerDependencies:
-      ethers: ^5.6.8 || ^6.0.8
-
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -12288,7 +12272,8 @@ packages:
 
 snapshots:
 
-  '@adraffy/ens-normalize@1.10.1': {}
+  '@adraffy/ens-normalize@1.10.1':
+    optional: true
 
   '@adraffy/ens-normalize@1.11.1': {}
 
@@ -14386,6 +14371,7 @@ snapshots:
   '@noble/curves@1.2.0':
     dependencies:
       '@noble/hashes': 1.3.2
+    optional: true
 
   '@noble/curves@1.4.2':
     dependencies:
@@ -14407,7 +14393,8 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
 
-  '@noble/hashes@1.3.2': {}
+  '@noble/hashes@1.3.2':
+    optional: true
 
   '@noble/hashes@1.4.0': {}
 
@@ -18132,24 +18119,6 @@ snapshots:
 
   '@speed-highlight/core@1.2.12': {}
 
-  '@spruceid/siwe-parser@3.0.0':
-    dependencies:
-      '@noble/hashes': 1.8.0
-      apg-js: 4.4.0
-
-  '@stablelib/binary@1.0.1':
-    dependencies:
-      '@stablelib/int': 1.0.1
-
-  '@stablelib/int@1.0.1': {}
-
-  '@stablelib/random@1.0.2':
-    dependencies:
-      '@stablelib/binary': 1.0.1
-      '@stablelib/wipe': 1.0.1
-
-  '@stablelib/wipe@1.0.1': {}
-
   '@standard-schema/spec@1.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -18803,6 +18772,7 @@ snapshots:
   '@types/node@22.7.5':
     dependencies:
       undici-types: 6.19.8
+    optional: true
 
   '@types/node@24.9.2':
     dependencies:
@@ -20594,7 +20564,8 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  aes-js@4.0.0-beta.5: {}
+  aes-js@4.0.0-beta.5:
+    optional: true
 
   agent-base@6.0.2:
     dependencies:
@@ -22377,6 +22348,7 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+    optional: true
 
   event-target-polyfill@0.0.4: {}
 
@@ -26144,12 +26116,6 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
-  siwe@3.0.0(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
-    dependencies:
-      '@spruceid/siwe-parser': 3.0.0
-      '@stablelib/random': 1.0.2
-      ethers: 6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-
   slash@3.0.0: {}
 
   slug@6.1.0: {}
@@ -26707,7 +26673,8 @@ snapshots:
 
   tslib@1.14.1: {}
 
-  tslib@2.7.0: {}
+  tslib@2.7.0:
+    optional: true
 
   tslib@2.8.1: {}
 
@@ -26861,7 +26828,8 @@ snapshots:
 
   uncrypto@0.1.3: {}
 
-  undici-types@6.19.8: {}
+  undici-types@6.19.8:
+    optional: true
 
   undici-types@6.21.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,7 +18,7 @@ catalog:
   tsx: ^4.21.0
   tsup: ^8.5.1
   viem: ^2.47.0
-  siwe: ^3.0.0
+  '@signinwithethereum/siwe': ^4.1.0
   vitest: ^4.0.16
   rimraf: ^5.0.5
 


### PR DESCRIPTION
# chore: migrate to @signinwithethereum/siwe

## Summary

This mirrors the same migration done in [x402-foundation/x402#1917](https://github.com/x402-foundation/x402/pull/1917).

Migrates x402scan from the old Spruce `siwe` package (v3.0.0) to `@signinwithethereum/siwe` (Ethereum Identity Foundation, v4.1.0).

Stewardship of the SIWE standard has [moved to the Ethereum Identity Foundation](https://x.com/BrantlyMillegan/status/1956389297461899533) ([GitHub](https://github.com/signinwithethereum)). [`@signinwithethereum/siwe`](https://www.npmjs.com/package/@signinwithethereum/siwe) is the official successor TypeScript implementation. The new package:

- Supports **viem natively** as a peer dependency (alongside optional ethers)
- Has first-class **EIP-1271** and **EIP-6492** smart wallet verification
- Maintains the same `SiweMessage` API — constructor, `prepareMessage()`, and `verify()` are identical


## Changes

| File | Change |
|------|--------|
| `pnpm-workspace.yaml` | Catalog: `siwe: ^3.0.0` → `'@signinwithethereum/siwe': ^4.1.0` |
| `apps/scan/package.json` | `"siwe": "catalog:"` → `"@signinwithethereum/siwe": "catalog:"` |
| `apps/scan/src/auth/providers/siwe/provider.ts` | Updated import path |
| `apps/scan/src/auth/providers/siwe/sign-in.ts` | Updated import path |
| `pnpm-lock.yaml` | Lockfile updated to reflect dependency change |

No behavioral changes. The `SiweMessage` constructor, `prepareMessage()`, and `verify()` APIs are identical between the old and new packages.

## Checklist

- [x] Import paths updated (2 files)
- [x] Catalog version updated in `pnpm-workspace.yaml`
- [x] Package dependency updated in `apps/scan/package.json`
- [x] `pnpm install` succeeds
- [x] TypeScript compiles with no new errors
