### PR TITLE
fix: deduplicate ogImages by URL before upsert to prevent unique constraint violation

### DIFF
--- a/apps/scan/src/services/db/resources/origin.ts
+++ b/apps/scan/src/services/db/resources/origin.ts
@@ -45,8 +45,11 @@ export const upsertOrigin = async (
 
     const originId = upsertedOrigin.id;
 
+    // Deduplicate ogImages by URL to prevent unique constraint violations
+    const uniqueOgImages = [...new Map(origin.ogImages.map(img => [img.url, img])).values()];
+
     await Promise.all(
-      origin.ogImages.map(({ url, height, width, title, description }) =>
+      uniqueOgImages.map(({ url, height, width, title, description }) =>
         tx.ogImage.upsert({
           where: {
             originId_url: {


### PR DESCRIPTION
When multiple OG images share the same URL (e.g. from meta tags), the parallel `Promise.all` upsert calls race on the `(originId, url)` unique constraint, causing `PrismaClientKnownRequestError P2002`.

## Fix

Deduplicate the `ogImages` array by URL using a `Map` before upserting, keeping the last occurrence (matching the current upsert "last write wins" semantics).

```ts
const uniqueOgImages = [...new Map(origin.ogImages.map(img => [img.url, img])).values()];
```

Fixes #287