### PR TITLE
Add Satoshi API facilitator entry

### DIFF
--- a/apps/scan/public/satoshi-api.svg
+++ b/apps/scan/public/satoshi-api.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="16" fill="#111827"/>
+  <circle cx="32" cy="32" r="22" fill="#f59e0b"/>
+  <path d="M26 18h8c6.1 0 11 4.9 11 11 0 4.7-2.9 8.8-7.1 10.4L42 46h-7l-3.6-5.8H26V46h-6V18h6zm0 6v10h8c2.2 0 4-1.8 4-4s-1.8-6-4-6h-8z" fill="#111827"/>
+</svg>

--- a/packages/external/facilitators/README.md
+++ b/packages/external/facilitators/README.md
@@ -72,6 +72,7 @@ The following facilitators currently support resource discovery:
 - **AurraCloud** - Infrastructure-focused facilitator
 - **thirdweb** - Web3 development platform
 - **PayAI** - AI-payment infrastructure
+- **Satoshi API** - Bitcoin fee intelligence and paid API discovery
 - **Ultravioleta DAO** - Community-driven multichain facilitator
 - **RelAI** - AI infrastructure platform
 
@@ -117,6 +118,7 @@ This package includes pre-configured integrations for the following X402 facilit
 | **Heurist**          | BASE          | No        | No                           |
 | **Treasure**         | BASE          | No        | No                           |
 | **AnySpend**         | BASE, SOLANA  | ✅ Yes    | No                           |
+| **Satoshi API**      | BASE          | ✅ Yes    | No                           |
 | **Polymer**          | BASE          | No        | Yes - API key                |
 | **Meridian**         | BASE          | No        | No                           |
 | **Openmid**          | BASE          | No        | No                           |
@@ -146,6 +148,7 @@ import {
   heurist,
   treasure,
   anyspend,
+  satoshi,
   polymer,
   meridian,
   openmid,

--- a/packages/external/facilitators/src/facilitators/index.ts
+++ b/packages/external/facilitators/src/facilitators/index.ts
@@ -25,5 +25,6 @@ export { primer, primerFacilitator } from './primer';
 export { x402jobs, x402jobsFacilitator } from './x402jobs';
 export { openfacilitator, openfacilitatorFacilitator } from './openfacilitator';
 export { relai, relaiFacilitator } from './relai';
+export { satoshi, satoshiFacilitator } from './satoshi';
 export { bitrefill, bitrefillFacilitator } from './bitrefill';
 export { cascade, cascadeFacilitator } from './cascade';

--- a/packages/external/facilitators/src/facilitators/satoshi.ts
+++ b/packages/external/facilitators/src/facilitators/satoshi.ts
@@ -1,0 +1,33 @@
+import { Network } from '../types';
+import { USDC_BASE_TOKEN } from '../constants';
+
+import type { Facilitator, FacilitatorConfig } from '../types';
+
+export const satoshi: FacilitatorConfig = {
+  url: 'https://facilitator.bitcoinsapi.com',
+};
+
+export const satoshiDiscovery: FacilitatorConfig = {
+  url: 'https://facilitator.bitcoinsapi.com',
+};
+
+export const satoshiFacilitator = {
+  id: 'satoshi',
+  metadata: {
+    name: 'Satoshi API',
+    image: 'https://x402scan.com/satoshi-api.svg',
+    docsUrl: 'https://facilitator.bitcoinsapi.com/docs',
+    color: '#F59E0B',
+  },
+  config: satoshi,
+  discoveryConfig: satoshiDiscovery,
+  addresses: {
+    [Network.BASE]: [
+      {
+        address: '0xe166267c3648b5ca4419F2c58fAEd8Cd4DF87d54',
+        tokens: [USDC_BASE_TOKEN],
+        dateOfFirstTransaction: new Date('2026-04-06T03:01:11Z'),
+      },
+    ],
+  },
+} as const satisfies Facilitator<void>;

--- a/packages/external/facilitators/src/lists/all.ts
+++ b/packages/external/facilitators/src/lists/all.ts
@@ -25,6 +25,7 @@ import {
   x402jobsFacilitator,
   openfacilitatorFacilitator,
   relaiFacilitator,
+  satoshiFacilitator,
   bitrefillFacilitator,
   cascadeFacilitator,
 } from '../facilitators';
@@ -60,6 +61,7 @@ const FACILITATORS = validateUniqueFacilitators([
   x402jobsFacilitator,
   openfacilitatorFacilitator,
   relaiFacilitator,
+  satoshiFacilitator,
   bitrefillFacilitator,
   cascadeFacilitator,
 ]);


### PR DESCRIPTION
## Summary
- add Satoshi API to the facilitator registry package
- wire the facilitator into the exported list and discoverable docs
- add a small public logo asset for the scan UI

## Verification
- pnpm --filter facilitators types:check
- pnpm --filter facilitators lint

## Proof
- live facilitator status: https://facilitator.bitcoinsapi.com/status
- Base signer/pay-to: 