### PR TITLE
fix(scan): standardize aggregate numeric return types across services

### DIFF
--- a/apps/scan/src/app/(app)/_components/agents/table/columns.tsx
+++ b/apps/scan/src/app/(app)/_components/agents/table/columns.tsx
@@ -89,7 +89,7 @@ export const columns: ExtendedColumnDef<ColumnType>[] = [
     ),
     cell: ({ row }) => (
       <div className="text-center font-mono text-xs">
-        {Math.cbrt(Number(row.original.score)).toLocaleString(undefined, {
+        {Math.cbrt(row.original.score).toLocaleString(undefined, {
           notation: 'compact',
           maximumFractionDigits: 2,
           minimumFractionDigits: 2,

--- a/apps/scan/src/lib/db/numeric.test.ts
+++ b/apps/scan/src/lib/db/numeric.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+
+import { aggregateCount, aggregateString } from './numeric';
+
+describe('aggregateCount', () => {
+  it('accepts a bigint and returns a number', () => {
+    const result = aggregateCount.parse(BigInt(42));
+    expect(result).toBe(42);
+    expect(typeof result).toBe('number');
+  });
+
+  it('passes through a number unchanged', () => {
+    expect(aggregateCount.parse(17)).toBe(17);
+  });
+
+  it('accepts a numeric string and coerces it', () => {
+    expect(aggregateCount.parse('100')).toBe(100);
+  });
+
+  it('accepts zero', () => {
+    expect(aggregateCount.parse(BigInt(0))).toBe(0);
+    expect(aggregateCount.parse(0)).toBe(0);
+    expect(aggregateCount.parse('0')).toBe(0);
+  });
+
+  it('accepts negative values', () => {
+    expect(aggregateCount.parse(BigInt(-5))).toBe(-5);
+    expect(aggregateCount.parse('-5')).toBe(-5);
+  });
+
+  it('rejects bigints larger than Number.MAX_SAFE_INTEGER', () => {
+    const unsafe = BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1);
+    const result = aggregateCount.safeParse(unsafe);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-numeric strings', () => {
+    expect(aggregateCount.safeParse('not a number').success).toBe(false);
+    expect(aggregateCount.safeParse('').success).toBe(false);
+  });
+
+  it('rejects Infinity and NaN', () => {
+    expect(aggregateCount.safeParse(Infinity).success).toBe(false);
+    expect(aggregateCount.safeParse(NaN).success).toBe(false);
+  });
+
+  it('is JSON-serialisable (the whole point of this schema)', () => {
+    const round = JSON.parse(
+      JSON.stringify({ value: aggregateCount.parse(BigInt(123)) })
+    ) as { value: number };
+    expect(round.value).toBe(123);
+  });
+});
+
+describe('aggregateString', () => {
+  it('stringifies a bigint', () => {
+    expect(aggregateString.parse(BigInt(42))).toBe('42');
+  });
+
+  it('stringifies an oversized bigint losslessly', () => {
+    const unsafe = BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1);
+    expect(aggregateString.parse(unsafe)).toBe(unsafe.toString());
+  });
+
+  it('stringifies a number', () => {
+    expect(aggregateString.parse(17)).toBe('17');
+  });
+
+  it('passes numeric strings through', () => {
+    expect(aggregateString.parse('100')).toBe('100');
+  });
+
+  it('rejects non-numeric strings', () => {
+    expect(aggregateString.safeParse('abc').success).toBe(false);
+  });
+
+  it('is JSON-serialisable', () => {
+    const round = JSON.parse(
+      JSON.stringify({ value: aggregateString.parse(BigInt(999)) })
+    ) as { value: string };
+    expect(round.value).toBe('999');
+  });
+});

--- a/apps/scan/src/lib/db/numeric.ts
+++ b/apps/scan/src/lib/db/numeric.ts
@@ -1,0 +1,99 @@
+import z from 'zod';
+
+/**
+ * Standard Zod schema for aggregate numeric values returned by raw SQL queries
+ * (COUNT, SUM, etc.) in CDP-SQL / Postgres services.
+ *
+ * Background: the `pg` driver and Prisma's `queryRaw` surface `COUNT()` / `SUM()`
+ * as JavaScript `BigInt` (or as strings when the value exceeds the safe-integer
+ * range). Previously these were parsed with `z.bigint()`, which is:
+ *   1. Not serializable by Next.js' `unstable_cache` / `'use cache'` — any service
+ *      wrapped by `createCachedQuery`/`createCachedPaginatedQuery` crashes at the
+ *      cache boundary with `TypeError: Do not know how to serialize a BigInt`.
+ *   2. Awkward for consumers — every call site had to `Number(row.value)` before
+ *      chart libs / `Intl.NumberFormat` could handle it.
+ *
+ * `aggregateCount` is the project-wide standard: it accepts bigint / number /
+ * numeric-string inputs and always yields a plain `number`. For the aggregate
+ * domains x402scan tracks (tool calls, user counts, transfer counts, volume
+ * in base units) the values are well inside `Number.MAX_SAFE_INTEGER`
+ * (2^53 − 1 ≈ 9 × 10^15) so this is lossless in practice; if a future aggregate
+ * can exceed that range, use `aggregateString` instead and keep arbitrary
+ * precision as a string on the wire.
+ */
+export const aggregateCount = z
+  .union([z.bigint(), z.number(), z.string()])
+  .transform((value, ctx) => {
+    if (typeof value === 'number') {
+      if (!Number.isFinite(value)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'aggregateCount must be a finite number',
+        });
+        return z.NEVER;
+      }
+      return value;
+    }
+    if (typeof value === 'bigint') {
+      if (
+        value > BigInt(Number.MAX_SAFE_INTEGER) ||
+        value < BigInt(Number.MIN_SAFE_INTEGER)
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            'aggregateCount exceeds Number.MAX_SAFE_INTEGER — use aggregateString',
+        });
+        return z.NEVER;
+      }
+      return Number(value);
+    }
+    // string
+    if (!/^-?\d+(\.\d+)?$/.test(value)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `aggregateCount received non-numeric string: ${value}`,
+      });
+      return z.NEVER;
+    }
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'aggregateCount string did not parse to finite number',
+      });
+      return z.NEVER;
+    }
+    return parsed;
+  });
+
+/**
+ * Standard schema for aggregate numeric values that can exceed
+ * `Number.MAX_SAFE_INTEGER` (e.g. on-chain token amounts in base units over
+ * long time ranges). Always returns a decimal string — callers that need
+ * bigint math can `BigInt(value)`, callers that just format for display can
+ * use `Intl.NumberFormat` directly on the string.
+ */
+export const aggregateString = z
+  .union([z.bigint(), z.number(), z.string()])
+  .transform((value, ctx) => {
+    if (typeof value === 'string') {
+      if (!/^-?\d+(\.\d+)?$/.test(value)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `aggregateString received non-numeric string: ${value}`,
+        });
+        return z.NEVER;
+      }
+      return value;
+    }
+    if (typeof value === 'bigint') return value.toString();
+    if (!Number.isFinite(value)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'aggregateString must be a finite number',
+      });
+      return z.NEVER;
+    }
+    return value.toString();
+  });

--- a/apps/scan/src/services/db/agent-config/get.ts
+++ b/apps/scan/src/services/db/agent-config/get.ts
@@ -3,6 +3,7 @@ import z from 'zod';
 import { scanDb, Prisma } from '@x402scan/scan-db';
 
 import { queryRaw } from '../query';
+import { aggregateCount } from '@/lib/db/numeric';
 
 export const getAgentConfigurationDetails = async (id: string) => {
   const agentConfiguration = await scanDb.agentConfiguration.findUnique({
@@ -133,9 +134,9 @@ export const getAgentConfiguration = async (id: string, userId?: string) => {
         updatedAt: z.date(),
         model: z.string().nullable(),
         starterPrompts: z.array(z.string()),
-        userCount: z.bigint(),
-        messageCount: z.bigint(),
-        toolCallCount: z.bigint(),
+        userCount: aggregateCount,
+        messageCount: aggregateCount,
+        toolCallCount: aggregateCount,
         resources: z.array(
           z.object({
             id: z.string(),

--- a/apps/scan/src/services/db/agent-config/list.ts
+++ b/apps/scan/src/services/db/agent-config/list.ts
@@ -4,6 +4,7 @@ import { scanDb, Prisma } from '@x402scan/scan-db';
 
 import { queryRaw } from '../query';
 
+import { aggregateCount } from '@/lib/db/numeric';
 import { sortingSchema, timeframeSchema } from '@/lib/schemas';
 import type { PaginatedQueryParams } from '@/lib/pagination';
 import { toPaginatedResponse } from '@/lib/pagination';
@@ -137,11 +138,11 @@ const listTopAgentConfigurationsUncached = async (
           image: z.string().nullable(),
           visibility: z.enum(['public', 'private']),
           createdAt: z.date(),
-          user_count: z.bigint(),
-          chat_count: z.bigint(),
-          message_count: z.bigint(),
-          tool_call_count: z.bigint(),
-          score: z.bigint(),
+          user_count: aggregateCount,
+          chat_count: aggregateCount,
+          message_count: aggregateCount,
+          tool_call_count: aggregateCount,
+          score: aggregateCount,
           resources: z.array(
             z.object({
               id: z.string(),

--- a/apps/scan/src/services/db/agent-config/stats/overall.ts
+++ b/apps/scan/src/services/db/agent-config/stats/overall.ts
@@ -6,6 +6,7 @@ import {
   createCachedArrayQuery,
   createStandardCacheKey,
 } from '@/lib/cache';
+import { aggregateCount } from '@/lib/db/numeric';
 
 import { differenceInMilliseconds, getUnixTime } from 'date-fns';
 
@@ -40,10 +41,10 @@ const getOverallActivityUncached = async (
     `,
     z.array(
       z.object({
-        user_count: z.bigint(),
-        agent_count: z.bigint(),
-        message_count: z.bigint(),
-        tool_call_count: z.bigint(),
+        user_count: aggregateCount,
+        agent_count: aggregateCount,
+        message_count: aggregateCount,
+        tool_call_count: aggregateCount,
       })
     )
   );

--- a/apps/scan/src/services/db/composer/tool-call.ts
+++ b/apps/scan/src/services/db/composer/tool-call.ts
@@ -2,6 +2,7 @@ import z from 'zod';
 import { scanDb, Prisma } from '@x402scan/scan-db';
 import { queryRaw } from '../query';
 
+import { aggregateCount } from '@/lib/db/numeric';
 import { sortingSchema } from '@/lib/schemas';
 import type { PaginatedQueryParams } from '@/lib/pagination';
 import { toPaginatedResponse } from '@/lib/pagination';
@@ -128,9 +129,9 @@ const listTopToolsUncached = async (
         z.object({
           id: z.string(),
           resource: z.string(),
-          tool_calls: z.bigint(),
-          agent_configurations: z.bigint(),
-          unique_users: z.bigint(),
+          tool_calls: aggregateCount,
+          agent_configurations: aggregateCount,
+          unique_users: aggregateCount,
           latest_call_time: z.date().nullable(),
           origin: z.object({
             id: z.string(),


### PR DESCRIPTION
Closes #45

## Summary

Replace ad-hoc `z.bigint()` schemas in raw SQL services with a shared `aggregateCount` zod schema. Count/sum aggregates now consistently return `number`, so they round-trip through `unstable_cache` / `'use cache'` boundaries without the `Do not know how to serialize a BigInt` crash, and consumers no longer need to `Number(...)` before passing values to charts or `Intl.NumberFormat`.

## Background

Every service affected here is wrapped by `createCachedQuery` or `createCachedPaginatedQuery`. The underlying `pg` driver surfaces raw-SQL `COUNT`/`SUM` as bigint. Parsing those with `z.bigint()` meant:

1. The first cache write crashed (`TypeError: Do not know how to serialize a BigInt`).
2. Callers had to do things like `Math.cbrt(Number(row.original.score))` because `Math.cbrt` doesn't accept bigint.

The existing `getOverallBucketedActivity` in `agent-config/stats/overall.ts` already used `z.coerce.number()` for the same purpose, so there were two conflicting patterns in the same file. This PR unifies the project around a single reusable schema.

## Design

```ts
// apps/scan/src/lib/db/numeric.ts

/** bigint | number | numeric-string  ->  number, fails above MAX_SAFE_INTEGER */
export const aggregateCount = z.union([z.bigint(), z.number(), z.string()])
  .transform((value, ctx) => /* safe coercion */);

/** bigint | number | numeric-string  ->  decimal string, lossless */
export const aggregateString = z.union([z.bigint(), z.number(), z.string()])
  .transform((value, ctx) => /* stringify, preserving precision */);
```

Counts of users / chats / tool calls / messages are many orders of magnitude below 2^53 − 1, so `aggregateCount` is lossless in practice. For future services that could exceed that bound (USDC base-unit volume summed over long windows, etc.), `aggregateString` preserves arbitrary precision on the wire.

## Converted services

- `services/db/composer/tool-call.ts`  —  `listTopTools` (3 columns)
- `services/db/agent-config/stats/overall.ts`  —  `getOverallActivity` (4 columns)
- `services/db/agent-config/list.ts`  —  `listTopAgentConfigurations` (5 columns)
- `services/db/agent-config/get.ts`  —  `getAgentConfiguration` (3 columns)

## Consumer cleanup

`app/(app)/_components/agents/table/columns.tsx`:
```diff
-  {Math.cbrt(Number(row.original.score)).toLocaleString(...)}
+  {Math.cbrt(row.original.score).toLocaleString(...)}
```

All other consumers (`composer/(home)/_components/stats/charts.tsx`, `composer/(home)/_components/lib/agent-card.tsx`, the admin tables) already treated these fields as number-shaped by going through `.toLocaleString(...)`, which is legal on both bigint and number — so no other call-site changes needed.

## Tests

Adds **15 vitest cases** in `apps/scan/src/lib/db/numeric.test.ts` covering:

- bigint / number / numeric-string inputs
- negative values and zero
- oversized-bigint rejection (above `Number.MAX_SAFE_INTEGER`)
- invalid strings, `NaN`, `Infinity` rejection
- JSON round-trip (directly exercising the cache-serialisation property that motivated the issue)

```
✓ src/lib/db/numeric.test.ts (15 tests) 5ms

Test Files  1 passed (1)
     Tests  15 passed (15)
```

Lint clean on all touched files. `types:check` has no new errors (pre-existing errors are unrelated — missing generated Next.js `PageProps` / `LayoutProps` and missing `@x402scan/analytics-db` / `@x402scan/partners-db` packages).

## Compat notes

The schema accepts string inputs too, so if any service ever switches from `queryRaw` to a driver that surfaces numerics as strings (e.g. for base-unit amounts), the return shape stays stable.

/claim #45