### PR TITLE
feat: Public API endpoint for programmatic resource registration

### DIFF
--- a/apps/scan/src/app/api/resources/register/README.md
+++ b/apps/scan/src/app/api/resources/register/README.md
@@ -1,0 +1,134 @@
+# Programmatic Resource Registration API
+
+## Endpoint
+
+```
+POST /api/resources/register
+```
+
+No authentication required. Designed for resource providers to register and refresh their x402-compatible resources programmatically.
+
+## Request Body
+
+The request body must be JSON with **one of** the following fields:
+
+### Single Resource Registration
+
+```json
+{
+  "url": "https://api.example.com/v1/chat"
+}
+```
+
+Registers a single x402-protected resource by URL. The endpoint will be probed to verify it returns a valid 402 response.
+
+### Origin-Based Registration
+
+```json
+{
+  "origin": "https://api.example.com"
+}
+```
+
+Discovers and registers all x402 resources from an origin. The server will look for:
+- `.well-known/x402` discovery document
+- OpenAPI spec with x402 extensions
+
+## Response
+
+### Success (Single Resource)
+
+```json
+{
+  "success": true,
+  "mode": "single",
+  "resource": { ... },
+  "accepts": [ ... ],
+  "registrationDetails": { ... }
+}
+```
+
+### Success (Origin-Based)
+
+```json
+{
+  "success": true,
+  "mode": "origin",
+  "registered": 5,
+  "failed": 0,
+  "skipped": 2,
+  "deprecated": 0,
+  "total": 7,
+  "source": "well-known"
+}
+```
+
+### Error Responses
+
+- `400` - Invalid JSON or validation error
+- `404` - No discovery document found (origin mode only)
+- `422` - Resource does not return valid 402 response or parse error
+
+## Examples
+
+### Register a single resource with curl
+
+```bash
+curl -X POST https://x402scan.com/api/resources/register \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://api.example.com/v1/chat"}'
+```
+
+### Register all resources from an origin
+
+```bash
+curl -X POST https://x402scan.com/api/resources/register \
+  -H "Content-Type: application/json" \
+  -d '{"origin": "https://api.example.com"}'
+```
+
+### JavaScript/TypeScript
+
+```typescript
+// Register a single resource
+const response = await fetch("https://x402scan.com/api/resources/register", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ url: "https://api.example.com/v1/chat" }),
+});
+const result = await response.json();
+
+// Register all resources from an origin
+const response = await fetch("https://x402scan.com/api/resources/register", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ origin: "https://api.example.com" }),
+});
+const result = await response.json();
+```
+
+### Python
+
+```python
+import requests
+
+# Register a single resource
+response = requests.post(
+    "https://x402scan.com/api/resources/register",
+    json={"url": "https://api.example.com/v1/chat"}
+)
+result = response.json()
+
+# Register all resources from an origin
+response = requests.post(
+    "https://x402scan.com/api/resources/register",
+    json={"origin": "https://api.example.com"}
+)
+result = response.json()
+```
+
+## Use Cases
+
+- **CI/CD Integration**: Automatically register new resources when deploying
+- **Resource Refresh**: Periodically re-register resources to update discovery data
+- **Batch Registration**: Register all resources from a server at once using origin mode

--- a/apps/scan/src/app/api/resources/register/route.ts
+++ b/apps/scan/src/app/api/resources/register/route.ts
@@ -1,0 +1,145 @@
+import { withCors, OPTIONS } from '@/lib/router';
+import { jsonResponse } from '@/app/api/x402/_lib/utils';
+import { registerResource } from '@/lib/resources';
+import { probeX402Endpoint } from '@/lib/discovery/probe';
+import { fetchDiscoveryDocument } from '@/services/discovery';
+import { registerResourcesFromDiscovery } from '@/lib/discovery/register-origin';
+import { z } from 'zod';
+
+export { OPTIONS };
+
+const registerBodySchema = z.object({
+  url: z.string().url().describe('URL of the x402-protected resource to register').optional(),
+  origin: z.string().url().describe('Origin URL to discover and register all x402 resources from').optional(),
+}).refine(
+  (data) => data.url || data.origin,
+  { message: 'Either url or origin must be provided' }
+);
+
+/**
+ * Public API endpoint for programmatic resource registration.
+ * 
+ * POST /api/resources/register
+ * 
+ * Request body (one of):
+ *   { "url": "https://api.example.com/endpoint" } - Register a single resource
+ *   { "origin": "https://api.example.com" } - Register all resources from an origin via discovery
+ * 
+ * No authentication required - designed for resource providers to register and refresh their offerings.
+ */
+export const POST = withCors(async (req: Request) => {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return jsonResponse(
+      { success: false, error: { type: 'invalid_json', message: 'Request body must be valid JSON' } },
+      400
+    );
+  }
+
+  const parsed = registerBodySchema.safeParse(body);
+  if (!parsed.success) {
+    return jsonResponse(
+      {
+        success: false,
+        error: {
+          type: 'validation_error',
+          message: parsed.error.issues.map(i => i.message).join(', '),
+        },
+      },
+      400
+    );
+  }
+
+  // Handle single URL registration
+  if (parsed.data.url) {
+    const url = parsed.data.url;
+    const probeResult = await probeX402Endpoint(
+      url.replaceAll('{', '').replaceAll('}', '')
+    );
+
+    if (!probeResult.success) {
+      return jsonResponse(
+        { success: false, error: { type: 'no_402', message: probeResult.error } },
+        422
+      );
+    }
+
+    const result = await registerResource(url, probeResult.advisory);
+
+    if (!result.success) {
+      return jsonResponse(
+        {
+          success: false,
+          error: {
+            type: 'parse_error',
+            parseErrors:
+              result.error.type === 'parseResponse'
+                ? result.error.parseErrors
+                : [JSON.stringify(result.error)],
+          },
+          data: result.data,
+        },
+        422
+      );
+    }
+
+    return jsonResponse(
+      JSON.parse(
+        JSON.stringify(
+          {
+            success: true,
+            mode: 'single',
+            resource: result.resource,
+            accepts: result.accepts,
+            registrationDetails: result.registrationDetails,
+          },
+          (_k, v: unknown) => (typeof v === 'bigint' ? Number(v) : v)
+        )
+      )
+    );
+  }
+
+  // Handle origin-based registration
+  if (parsed.data.origin) {
+    const origin = parsed.data.origin;
+    const discoveryResult = await fetchDiscoveryDocument(origin);
+
+    if (!discoveryResult.success) {
+      return jsonResponse(
+        {
+          success: false,
+          error: {
+            type: 'no_discovery',
+            message: discoveryResult.error ?? 'No discovery document found',
+          },
+        },
+        404
+      );
+    }
+
+    const result = await registerResourcesFromDiscovery(
+      discoveryResult.resources,
+      discoveryResult.source
+    );
+
+    return jsonResponse({
+      success: true,
+      mode: 'origin',
+      registered: result.registered,
+      failed: result.failed,
+      skipped: result.skipped,
+      deprecated: result.deprecated,
+      total: result.total,
+      source: result.source,
+      failedDetails:
+        result.failedDetails.length > 0 ? result.failedDetails : undefined,
+    });
+  }
+
+  return jsonResponse(
+    { success: false, error: { type: 'bad_request', message: 'Either url or origin must be provided' } },
+    400
+  );
+});


### PR DESCRIPTION
## Summary

Implements #104 - Add public API endpoint for programmatic resource registration.

### Changes

- Added `POST /api/resources/register` endpoint that does **not** require SIWX wallet authentication
- Supports two modes:
  - **Single URL**: Register a single x402-protected resource by URL
  - **Origin-based**: Discover and register all x402 resources from an origin via `.well-known/x402` or OpenAPI spec
- Added comprehensive API documentation with examples (curl, JavaScript, Python)

### API Usage

#### Register a single resource
```bash
curl -X POST https://x402scan.com/api/resources/register \
  -H "Content-Type: application/json" \
  -d '{"url": "https://api.example.com/v1/chat"}'
```

#### Register all resources from an origin
```bash
curl -X POST https://x402scan.com/api/resources/register \
  -H "Content-Type: application/json" \
  -d '{"origin": "https://api.example.com"}'
```

### Why a new endpoint instead of modifying the existing one?

The existing `/api/x402/registry/register` endpoint requires SIWX wallet authentication, which is used by the web UI. Creating a separate public endpoint preserves backward compatibility while enabling programmatic access for resource providers.

Closes #104