### PR TITLE
fix: handle OgImage unique constraint conflict when multiple origins share the same OG image URL

### DIFF
--- a/apps/scan/src/services/db/resources/origin.ts
+++ b/apps/scan/src/services/db/resources/origin.ts
@@ -46,30 +46,53 @@ export const upsertOrigin = async (
     const originId = upsertedOrigin.id;
 
     await Promise.all(
-      origin.ogImages.map(({ url, height, width, title, description }) =>
-        tx.ogImage.upsert({
+      origin.ogImages.map(async ({ url, height, width, title, description }) => {
+        // First, try to find an existing OgImage with this URL for this origin
+        const existingOgImage = await tx.ogImage.findFirst({
           where: {
-            originId_url: {
-              originId,
-              url,
-            },
-          },
-          update: {
-            height,
-            width,
-            title,
-            description,
-          },
-          create: {
             originId,
             url,
-            height,
-            width,
-            title,
-            description,
           },
-        })
-      )
+        });
+
+        if (existingOgImage) {
+          // Update the existing OgImage
+          return tx.ogImage.update({
+            where: { id: existingOgImage.id },
+            data: {
+              height,
+              width,
+              title,
+              description,
+            },
+          });
+        }
+
+        // Try to create a new OgImage
+        try {
+          return await tx.ogImage.create({
+            data: {
+              originId,
+              url,
+              height,
+              width,
+              title,
+              description,
+            },
+          });
+        } catch (error: any) {
+          // If we get a unique constraint error on url, it means the URL is already
+          // used by another origin. In this case, we'll skip creating this OgImage
+          // since the URL metadata is the same regardless of which origin uses it.
+          if (error?.code === 'P2002' && error?.meta?.target?.includes('url')) {
+            console.warn(
+              `OgImage with URL ${url} already exists for a different origin. Skipping.`
+            );
+            return null;
+          }
+          throw error;
+        }
+      })
     );
 
     return tx.resourceOrigin.findUnique({


### PR DESCRIPTION
## Summary

Closes #287

This PR fixes the database unique constraint error that occurs when registering resources from different origins that share the same OG image URL.

## Problem

When attempting to register a new resource, the registration fails with a database unique constraint error:

```
Unique constraint failed on the fields: (url)
Invalid prisma.resourceOrigin.upsert() invocation
```

This happens when:
1. Resource A with URL: `https://subdomain.example.com/api/endpoint` registers with origin: `https://subdomain.example.com`
2. Resource B with URL: `https://example.com/api/endpoint` has origin: `https://example.com`
3. Both domains share the same OG image URL (e.g., due to redirect or shared CDN)
4. Registration fails with the unique constraint error

## Solution

The fix modifies the `upsertOrigin` function in `apps/scan/src/services/db/resources/origin.ts` to handle the case where an OG image URL is already used by another origin:

1. First checks if an OgImage with the same URL already exists for the current origin
2. If it exists, updates it with the new metadata
3. If it doesn't exist, tries to create a new one
4. If creation fails due to a unique constraint on the URL (used by another origin), it logs a warning and skips creation

This allows multiple origins to share the same OG image URL without causing registration failures.

## Changes

- Modified `upsertOrigin` function to handle unique constraint errors gracefully
- Added error handling for Prisma unique constraint violations (error code P2002)
- Added warning logging when skipping OgImage creation due to URL conflicts

## Testing

The fix has been tested to ensure:
- Existing functionality remains unchanged
- Multiple origins can now share the same OG image URL
- Proper error handling and logging is in place