### PR TITLE
chore: bump @agentcash/discovery to 1.6.3

### DIFF
--- a/apps/scan/package.json
+++ b/apps/scan/package.json
@@ -21,7 +21,7 @@
     "format:check": "pnpm -w format:check:dir ./apps/scan"
   },
   "dependencies": {
-    "@agentcash/discovery": "1.6.1",
+    "@agentcash/discovery": "1.6.3",
     "@agentcash/router": "1.3.3",
     "@ai-sdk/openai": "^2.0.52",
     "@ai-sdk/react": "^2.0.68",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,8 +306,8 @@ importers:
   apps/scan:
     dependencies:
       '@agentcash/discovery':
-        specifier: 1.6.1
-        version: 1.6.1
+        specifier: 1.6.3
+        version: 1.6.3
       '@agentcash/router':
         specifier: 1.3.3
         version: 1.3.3(@coinbase/x402@2.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@x402/core@2.10.0)(@x402/evm@2.10.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10))(@x402/extensions@2.10.0(bufferutil@4.0.9)(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typescript@5.9.3)(utf-8-validate@5.0.10))(@x402/svm@2.10.0(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)))(mppx@0.5.12(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(express@5.2.1)(typescript@5.9.3)(viem@2.47.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2))(zod-openapi@5.4.6(zod@4.3.6))(zod@4.3.6)
@@ -1212,8 +1212,8 @@ packages:
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
 
-  '@agentcash/discovery@1.6.1':
-    resolution: {integrity: sha512-ScWkK0iPF+dIuUTXPAaTx/0yTb426c2ocA1LBcVHburpmWeiZT1N3qwSeT1dPoxMSCPyi0oJPV8tFopcdnB4RQ==}
+  '@agentcash/discovery@1.6.3':
+    resolution: {integrity: sha512-fnyFTNS+VF5fj9ZhDxY8BACEEazJA66df/eeRbPUi/4vkRy5Y8cqoPgHe2b9cZkQN5oPaqenyrq5HC7TIgcIoA==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -12296,7 +12296,7 @@ snapshots:
 
   '@adraffy/ens-normalize@1.11.1': {}
 
-  '@agentcash/discovery@1.6.1':
+  '@agentcash/discovery@1.6.3':
     dependencies:
       dereference-json-schema: 0.2.2
       neverthrow: 8.2.0


### PR DESCRIPTION
## Summary
- Bumps `@agentcash/discovery` in `apps/scan` from 1.6.1 → 1.6.3.
- Regenerated `pnpm-lock.yaml` to match.

## Test plan
- [ ] CI green (types, lint, tests, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)