### PR TITLE
x402scan OgImage Unique Constraint

### DIFF
--- a/apps/scan/src/services/db/resources/origin.test.ts
+++ b/apps/scan/src/services/db/resources/origin.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@x402scan/scan-db', () => ({
+  scanDb: {},
+}));
+
+import { dedupeOgImagesByUrl } from './origin';
+
+describe('dedupeOgImagesByUrl', () => {
+  it('keeps one write per URL so OgImage upserts cannot race each other', () => {
+    const ogImages = dedupeOgImagesByUrl([
+      {
+        url: 'https://example.com/og.png',
+        width: 1200,
+        title: 'first',
+      },
+      {
+        url: 'https://example.com/og.png',
+        width: 1600,
+        title: 'last',
+      },
+      {
+        url: 'https://example.com/other.png',
+        height: 630,
+      },
+    ]);
+
+    expect(ogImages).toEqual([
+      {
+        url: 'https://example.com/og.png',
+        width: 1600,
+        title: 'last',
+      },
+      {
+        url: 'https://example.com/other.png',
+        height: 630,
+      },
+    ]);
+  });
+});

--- a/apps/scan/src/services/db/resources/origin.ts
+++ b/apps/scan/src/services/db/resources/origin.ts
@@ -23,6 +23,11 @@ const originSchema = z.object({
   ogImages: z.array(ogImageSchema),
 });
 
+type OgImageInput = z.infer<typeof ogImageSchema>;
+
+export const dedupeOgImagesByUrl = (ogImages: OgImageInput[]) =>
+  Array.from(new Map(ogImages.map(image => [image.url, image])).values());
+
 export const upsertOrigin = async (
   originInput: z.input<typeof originSchema>
 ) => {
@@ -44,9 +49,10 @@ export const upsertOrigin = async (
     });
 
     const originId = upsertedOrigin.id;
+    const ogImages = dedupeOgImagesByUrl(origin.ogImages);
 
     await Promise.all(
-      origin.ogImages.map(({ url, height, width, title, description }) =>
+      ogImages.map(({ url, height, width, title, description }) =>
         tx.ogImage.upsert({
           where: {
             originId_url: {


### PR DESCRIPTION
## Worthy Submission

# x402scan OgImage Unique Constraint

Fixes #287.

## Problem
`upsertOrigin` upserted every discovered OG image concurrently. When a registration payload included the same OG image URL more than once for the same origin, those parallel writes targeted the same unique key and could race into a Prisma unique constraint error.

## Solution
Added `dedupeOgImagesByUrl` and call it before the transactional `tx.ogImage.upsert` calls. The final image payload for each URL is retained, so each `(originId, url)` pair is written once per origin upsert.

## Files Changed
- `apps/scan/src/services/db/resources/origin.ts`
- `apps/scan/src/services/db/resources/origin.test.ts`

## Verification
- `git diff --check` passed.
- A Node runtime check of the same Map-based dedupe logic passed.
- `pnpm --filter @x402scan/app test:run apps/scan/src/services/db/resources/origin.test.ts` could not run on KAEL because the checkout had no `node_modules`/`vitest`, and KAEL had Node `v18.19.1` while repo packages require Node `>=20`.

## Submission Notes
Local branch: `algora/x402scan-ogimage-dedupe`
Commit: `3135a83eb0d856f538235d65a1c323f6c14d024b`

## Final Verification
verdict: `submit`

The PR is linked to the Merit bounty issue and contains a focused dedupe fix plus a regression test for duplicate OG image URLs in one origin upsert. The remaining Vercel failure is sponsor-side authorization for Merit Systems, not a contributor code failure.
