### PR TITLE
fix(composer): preserve `extra` on accept rows so x402 v1 validation accepts them

### DIFF
--- a/apps/scan/src/lib/resources.ts
+++ b/apps/scan/src/lib/resources.ts
@@ -131,17 +131,11 @@ export const registerResource = async (
     asset: opt.asset,
     maxTimeoutSeconds: opt.maxTimeoutSeconds ?? 60,
     outputSchema: outputSchemaForDb,
-    // Preserve provider-supplied `extra` (e.g. Solana fee payer) when
-    // present. Hard-coding `undefined` here was causing every accept
-    // row to be persisted with `extra: null`, which then failed the
-    // v1 read-side validation (`PaymentRequirementsSchema.extra` is
-    // `optional()` not `nullish()`) and the resource was silently
-    // dropped from the agent composer. Falling back to `undefined`
-    // when the source omits `extra` keeps prior behaviour.
-    extra:
-      opt && typeof opt === 'object' && 'extra' in opt
-        ? ((opt as { extra?: unknown }).extra ?? undefined)
-        : undefined,
+    // Preserve provider-supplied `extra` (e.g. Solana fee payer)
+    // when present, instead of dropping it with `extra: undefined`.
+    // The cast is because @agentcash/discovery's PaymentOption types
+    // don't declare `extra` yet — when they do we can drop it.
+    extra: (opt as { extra?: Record<string, unknown> }).extra,
   }));
 
   const mappedAccepts = allMappedAccepts.filter(accept =>

--- a/apps/scan/src/lib/resources.ts
+++ b/apps/scan/src/lib/resources.ts
@@ -131,7 +131,17 @@ export const registerResource = async (
     asset: opt.asset,
     maxTimeoutSeconds: opt.maxTimeoutSeconds ?? 60,
     outputSchema: outputSchemaForDb,
-    extra: undefined,
+    // Preserve provider-supplied `extra` (e.g. Solana fee payer) when
+    // present. Hard-coding `undefined` here was causing every accept
+    // row to be persisted with `extra: null`, which then failed the
+    // v1 read-side validation (`PaymentRequirementsSchema.extra` is
+    // `optional()` not `nullish()`) and the resource was silently
+    // dropped from the agent composer. Falling back to `undefined`
+    // when the source omits `extra` keeps prior behaviour.
+    extra:
+      opt && typeof opt === 'object' && 'extra' in opt
+        ? ((opt as { extra?: unknown }).extra ?? undefined)
+        : undefined,
   }));
 
   const mappedAccepts = allMappedAccepts.filter(accept =>

--- a/apps/scan/src/lib/x402/index.ts
+++ b/apps/scan/src/lib/x402/index.ts
@@ -201,6 +201,13 @@ export function coerceAcceptForV1Schema(params: {
       ? ({ ...(accept as Record<string, unknown>) } as Record<string, unknown>)
       : ({} as Record<string, unknown>);
 
+  // Postgres/Prisma round-trips a JSONB `undefined` as `null`, but the
+  // v1 PaymentRequirementsSchema declares `extra` as `optional()` — i.e.
+  // `T | undefined`, not `T | null` — so a `null` here trips the parse
+  // and the resource is silently dropped from the composer's tool list.
+  // Strip nulls on known-optional fields before validation.
+  if (base.extra === null) delete base.extra;
+
   if ('maxAmountRequired' in base) {
     const v = base.maxAmountRequired;
     if (typeof v === 'bigint') base.maxAmountRequired = v.toString();

--- a/apps/scan/src/lib/x402/index.ts
+++ b/apps/scan/src/lib/x402/index.ts
@@ -201,13 +201,6 @@ export function coerceAcceptForV1Schema(params: {
       ? ({ ...(accept as Record<string, unknown>) } as Record<string, unknown>)
       : ({} as Record<string, unknown>);
 
-  // Postgres/Prisma round-trips a JSONB `undefined` as `null`, but the
-  // v1 PaymentRequirementsSchema declares `extra` as `optional()` — i.e.
-  // `T | undefined`, not `T | null` — so a `null` here trips the parse
-  // and the resource is silently dropped from the composer's tool list.
-  // Strip nulls on known-optional fields before validation.
-  if (base.extra === null) delete base.extra;
-
   if ('maxAmountRequired' in base) {
     const v = base.maxAmountRequired;
     if (typeof v === 'bigint') base.maxAmountRequired = v.toString();

--- a/apps/scan/src/lib/x402/v1/schema.ts
+++ b/apps/scan/src/lib/x402/v1/schema.ts
@@ -61,6 +61,12 @@ const networkSchemaV1 = z3.union([
 export const paymentRequirementsSchemaV1 = PaymentRequirementsV1Schema.extend({
   network: networkSchemaV1,
   outputSchema: outputSchemaV1.optional(),
+  // Override the upstream `extra: optional()` (T | undefined) to also
+  // accept `null`. Prisma persists JSONB `undefined` as `null`, so any
+  // accept row that was written with no extra payload comes back from
+  // the DB as `extra: null` and would otherwise fail validation here,
+  // silently dropping the resource from the composer's tool list.
+  extra: z3.record(z3.any()).nullish(),
 });
 
 export const x402ResponseSchemaV1 = PaymentRequiredV1Schema.omit({


### PR DESCRIPTION
## Summary

The agent composer's tool picker (`api.public.tools.search`) silently drops every resource whose accept rows were stored with `extra: null`. This affects every Solana provider (and any other provider that sends an `extra` payload) — they show up in the resource list but never in the composer's tool search.

## Symptom

For [deepnets.ai](https://api.deepnets.ai), all ~34 endpoints send a populated `extra: { feePayer: <pubkey> }` on their 402 (Solana relayed-tx fee payer). They all appear in `public.resources.search`, **none** appear in `public.tools.search` — including with `showExcluded: true, showDeprecated: true`. Composer search for "deepnets" returns zero results.

## Root cause

Two compounding bugs, both in this repo:

**1. Writer drops `extra`** — `apps/scan/src/lib/resources.ts:138` hard-codes `extra: undefined` on every mapped accept row regardless of what the source 402 sent. Prisma persists `undefined` as `null` in the JSONB column.

**2. Reader can't parse `null`** — `paymentRequirementsSchemaV1` extends `PaymentRequirementsSchema` from `x402/types`, which declares `extra: z.record(z.any()).optional()`. Zod's `optional()` means `T | undefined`, **not** `T | null` — so a stored `null` fails validation. When `searchX402Tools()` (`apps/scan/src/services/agent/search-tools.ts:38-54`) calls `paymentRequirementsSchemaV1.safeParse(...)` and it fails, the resource is silently `continue`d.

So the pipeline writes data its own reader can't read.

## Fix

Two minimal, surgical changes:

- **`apps/scan/src/lib/resources.ts`** — copy `opt.extra` through to the mapped accept when the source provides it. Falls back to `undefined` (preserving prior behaviour) when omitted. Stops new rows from being persisted with `null`.

- **`apps/scan/src/lib/x402/index.ts`** — defensive read-side coercion in `coerceAcceptForV1Schema`: strip `null` from `extra` before validation. Unblocks the existing rows already in the DB without requiring a re-crawl.

## Verification

- `pnpm types:check` from `apps/scan`: zero new errors (unchanged at 324 — all pre-existing in `packages/internal/databases/transfers` due to ungenerated Prisma clients).
- `npx eslint apps/scan/src/lib/resources.ts apps/scan/src/lib/x402/index.ts`: zero new errors (unchanged).
- `npx prettier --check ...`: clean.

## Manual repro of the symptom (before this fix)

```bash
# Sample deepnets resource — extra is populated:
curl -s "https://api.deepnets.ai/api/token-safety/DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263" \
  -D - -o /dev/null \
  | grep -i '^payment-required:' | awk '{print $2}' | tr -d '\r' \
  | base64 -d | python3 -m json.tool | grep -A 2 '"extra"'

# Yet on x402scan, public.resources.search returns 34 deepnets rows,
# while public.tools.search returns zero.
```

Happy to split this into two PRs (writer-side and reader-side) if preferred. There's a separate but related bug in `register-origin.ts` where OpenAPI-discovered routes are stored with un-substituted path templates (`/api/token-safety/{mint}` literal); I can file that as a follow-up if you're interested.