### PR TITLE
fix(discovery): skip unexpanded OpenAPI path templates instead of storing them as literal URLs

### DIFF
--- a/apps/scan/src/services/discovery/fetch-discovery.ts
+++ b/apps/scan/src/services/discovery/fetch-discovery.ts
@@ -65,6 +65,17 @@ export async function fetchDiscoveryDocument(
   const resources: DiscoveredResource[] = discovered.endpoints.flatMap(
     endpoint => {
       try {
+        // OpenAPI-style paths like `/api/token-safety/{mint}` come back
+        // with the template literal intact — `@agentcash/discovery`
+        // doesn't substitute parameter examples, and `new URL()` just
+        // URL-encodes the braces, producing uncallable URLs like
+        // `.../%7Bmint%7D`. Skip these so we don't pollute the
+        // resources table with rows that can't be probed or invoked
+        // from the composer. Templated routes can still be registered
+        // via per-resource registration with the substituted URL.
+        if (/\{[^/}]+\}/.test(endpoint.path)) {
+          return [];
+        }
         const url = new URL(endpoint.path, discovered.origin).toString();
         return [
           {


### PR DESCRIPTION
## Summary

When an origin's `openapi.json` declares parameterized paths (e.g. `/api/token-safety/{mint}`), `fetchDiscoveryDocument` stores them in the resources table with the template literal still intact — URL-encoded as `%7Bmint%7D` etc. — producing uncallable URLs that pollute search results and waste probe attempts.

## Root cause

`@agentcash/discovery`'s `discoverOriginSchema` returns endpoint paths as-declared in the OpenAPI spec (it doesn't have access to parameter examples to substitute). The code in `apps/scan/src/services/discovery/fetch-discovery.ts:68` then runs `new URL(endpoint.path, discovered.origin)` — but `new URL()` doesn't expand templates; it URL-encodes the braces. The result is stored as a "resource URL" that no probe can resolve and the composer can't call.

## Concrete repro

deepnets.ai's openapi.json declares 13 path-parameter routes:

```bash
curl -s https://api.deepnets.ai/openapi.json | jq -r '.paths | keys[]' | grep '{'
# /api/holder-analysis/{mint}
# /api/network-details/{networkAddress}
# /api/network-details/{networkAddress}/wallets
# /api/social_research/{mint}
# /api/streamflow-locks/{mint}
# /api/tibane-staking/{mint}
# /api/token/{mint}/holder-graph
# /api/token/{mint}/stats
# /api/token-details/{mint}
# /api/token-details/{mint}/{analysis}
# /api/token-safety/{mint}
# /api/token-safety-history/{mint}
# /api/wallet-details/{address}
```

After `register-origin` runs against this origin, all 13 rows in the `resources` table for that origin have URLs like `https://api.deepnets.ai/api/token-safety/%7Bmint%7D` — none of which return a 200 to anything.

## Fix

Filter unexpanded path templates out at the discovery layer so they never reach the registration pipeline. The regex `/\{[^/}]+\}/` matches OpenAPI-style `{param}` segments while still allowing literal `{` characters that aren't path templates (defensive — vanishingly rare but cheap).

Templated routes can still be registered via per-resource registration with the substituted URL (the existing path); routes that flow through probe-based discovery already arrive with concrete URLs and are unaffected.

## Verification

- `pnpm types:check`: zero new errors (unchanged at 324 — all pre-existing in `packages/internal/databases/transfers` due to ungenerated Prisma clients).
- `npx eslint apps/scan/src/services/discovery/fetch-discovery.ts`: zero issues.
- `npx prettier --check ...`: clean.

## Companion PR

Pairs with #814 (preserve `extra` on accept rows so v1 validation accepts them). Both PRs are needed to fully fix x402scan composer search for any provider that uses OpenAPI-discovered path-parameter routes — #814 unblocks the read-side validation, this PR stops uncallable rows from being created in the first place.