### PR TITLE
Link AgentCash featured services header

### DIFF
--- a/apps/scan/src/app/(app)/(home)/(overview)/_components/sellers/featured-columns.tsx
+++ b/apps/scan/src/app/(app)/(home)/(overview)/_components/sellers/featured-columns.tsx
@@ -205,22 +205,35 @@ export const featuredServiceColumns: ExtendedColumnDef<FeaturedServiceItem>[] =
     {
       accessorKey: 'tryIt',
       header: () => (
-        <div className="flex items-center justify-center" title="AgentCash">
-          <Image
-            src="/agentcash-light.svg"
-            alt="AgentCash"
-            width={16}
-            height={16}
-            className="size-4 block dark:hidden"
-          />
-          <Image
-            src="/agentcash-dark.svg"
-            alt="AgentCash"
-            width={16}
-            height={16}
-            className="size-4 hidden dark:block"
-          />
-        </div>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <a
+              href="https://agentcash.dev"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Call all x402 resources through AgentCash"
+              className="mx-auto flex size-7 items-center justify-center rounded-md transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <Image
+                src="/agentcash-light.svg"
+                alt=""
+                width={16}
+                height={16}
+                className="size-4 block dark:hidden"
+              />
+              <Image
+                src="/agentcash-dark.svg"
+                alt=""
+                width={16}
+                height={16}
+                className="size-4 hidden dark:block"
+              />
+            </a>
+          </TooltipTrigger>
+          <TooltipContent side="left" className="max-w-xs">
+            Call all x402 resources through AgentCash.
+          </TooltipContent>
+        </Tooltip>
       ),
       cell: ({ row }) => {
         const origin = row.original.origins[0]?.origin;

--- a/apps/scan/src/app/(app)/(home)/(overview)/_components/sellers/featured-columns.tsx
+++ b/apps/scan/src/app/(app)/(home)/(overview)/_components/sellers/featured-columns.tsx
@@ -211,7 +211,7 @@ export const featuredServiceColumns: ExtendedColumnDef<FeaturedServiceItem>[] =
               href="https://agentcash.dev"
               target="_blank"
               rel="noopener noreferrer"
-              aria-label="Call all x402 resources through AgentCash"
+              aria-label="Call all x402 resources with AgentCash"
               className="mx-auto flex size-7 items-center justify-center rounded-md transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
               <Image
@@ -231,7 +231,7 @@ export const featuredServiceColumns: ExtendedColumnDef<FeaturedServiceItem>[] =
             </a>
           </TooltipTrigger>
           <TooltipContent side="left" className="max-w-xs">
-            Call all x402 resources through AgentCash.
+            Call all x402 resources with AgentCash.
           </TooltipContent>
         </Tooltip>
       ),


### PR DESCRIPTION
## Summary
- Add a tooltip to the AgentCash featured services table header
- Link the AgentCash logo header to https://agentcash.dev in a new tab
- Use lowercase x402 in the hover and accessibility text

## Test
- pnpm --filter @x402scan/app exec eslint src/app/'(app)'/'(home)'/'(overview)'/_components/sellers/featured-columns.tsx