### PR TITLE
feat(scan): source Featured Services from AgentCash catalog with x402 usage

### DIFF
--- a/apps/scan/src/app/(app)/(home)/(discover)/_components/discover-origins.tsx
+++ b/apps/scan/src/app/(app)/(home)/(discover)/_components/discover-origins.tsx
@@ -24,7 +24,7 @@ export const DiscoverSellersTable: React.FC<Props> = ({ originUrls }) => {
   const [topSellers] = api.public.sellers.bazaar.list.useSuspenseQuery({
     chain,
     pagination: {
-      page_size: 100,
+      page_size: 400,
     },
     timeframe,
     sorting,

--- a/apps/scan/src/app/(app)/(home)/(discover)/_components/discover-origins.tsx
+++ b/apps/scan/src/app/(app)/(home)/(discover)/_components/discover-origins.tsx
@@ -12,23 +12,18 @@ import {
 } from '@/app/(app)/(home)/(overview)/_components/sellers/featured-columns';
 import { api } from '@/trpc/client';
 
-interface Props {
-  originUrls: string[];
-}
-
-export const DiscoverSellersTable: React.FC<Props> = ({ originUrls }) => {
+export const DiscoverSellersTable: React.FC = () => {
   const { sorting } = useSellersSorting();
   const { timeframe } = useTimeRangeContext();
   const { chain } = useChain();
 
-  const [topSellers] = api.public.sellers.bazaar.list.useSuspenseQuery({
+  const [topSellers] = api.public.sellers.bazaar.featured.useSuspenseQuery({
     chain,
     pagination: {
       page_size: 400,
     },
     timeframe,
     sorting,
-    originUrls,
   });
 
   return (

--- a/apps/scan/src/app/(app)/(home)/(discover)/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/(discover)/page.tsx
@@ -10,7 +10,6 @@ import { DiscoverHeading } from './_components/heading';
 
 import { api, HydrateClient } from '@/trpc/server';
 
-import { getDiscoverOrigins } from '@/lib/discover/origins';
 import { getChainForPage } from '@/app/(app)/_lib/chain/page';
 
 import {
@@ -33,19 +32,15 @@ export default async function DiscoverPage({
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const resolvedParams = await searchParams;
-  const [chain, originUrls] = await Promise.all([
-    getChainForPage(resolvedParams),
-    getDiscoverOrigins(),
-  ]);
+  const chain = await getChainForPage(resolvedParams);
 
-  void api.public.sellers.bazaar.list.prefetch({
+  void api.public.sellers.bazaar.featured.prefetch({
     chain,
     pagination: {
       page_size: 400,
     },
     timeframe: ActivityTimeframe.ThirtyDays,
     sorting: defaultSellersSorting,
-    originUrls,
   });
 
   return (
@@ -76,7 +71,7 @@ export default async function DiscoverPage({
                     }
                   >
                     <Suspense fallback={<LoadingDiscoverSellersTable />}>
-                      <DiscoverSellersTable originUrls={originUrls} />
+                      <DiscoverSellersTable />
                     </Suspense>
                   </ErrorBoundary>
                 </Section>

--- a/apps/scan/src/app/(app)/(home)/(discover)/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/(discover)/page.tsx
@@ -41,7 +41,7 @@ export default async function DiscoverPage({
   void api.public.sellers.bazaar.list.prefetch({
     chain,
     pagination: {
-      page_size: 100,
+      page_size: 400,
     },
     timeframe: ActivityTimeframe.ThirtyDays,
     sorting: defaultSellersSorting,

--- a/apps/scan/src/app/api/cron/warm-cache/route.ts
+++ b/apps/scan/src/app/api/cron/warm-cache/route.ts
@@ -8,7 +8,6 @@ import { ActivityTimeframe } from '@/types/timeframes';
 import { facilitatorAddresses } from '@/lib/facilitators';
 import { CACHE_DURATION_MINUTES } from '@/lib/cache-constants';
 import { Chain } from '@/types/chain';
-import { getDiscoverOrigins } from '@/lib/discover/origins';
 
 import type { NextRequest } from 'next/server';
 import { checkCronSecret } from '@/lib/cron';
@@ -117,23 +116,19 @@ function getHomePageTasks(
         chain,
       }),
 
-    // Discover page variant — bazaar.list filtered by curated x402 origins.
-    // The discover page passes originUrls from getDiscoverOrigins(), which
-    // produces a different cache key from the unfiltered /all variant above.
-    // This task warms both getDiscoverOrigins() (its own Redis cache) and
-    // the bazaar.list cache for that input shape.
-    async () => {
-      const originUrls = await getDiscoverOrigins();
-      return api.public.sellers.bazaar.list({
+    // Discover page variant — bazaar.featured resolves the AgentCash catalog
+    // origin set server-side, so the cache key omits the 305-element URL list.
+    // Warms both getDiscoverOrigins() (its own Redis cache) and the
+    // bazaar.list cache for the resulting input shape.
+    () =>
+      api.public.sellers.bazaar.featured({
         pagination: {
-          page_size: 100,
+          page_size: 400,
         },
         timeframe,
         sorting: defaultSellersSorting,
         chain,
-        originUrls,
-      });
-    },
+      }),
 
     // Top Servers (Bazaar) - overall stats
     // Uses origin-based MV (pre-joined), not stats.bazaar.overall which

--- a/apps/scan/src/lib/discover/origins.ts
+++ b/apps/scan/src/lib/discover/origins.ts
@@ -12,7 +12,7 @@ function getAgentCashSql() {
   return neon(connectionUrl);
 }
 
-const CACHE_KEY = 'discover:origins:all';
+const CACHE_KEY = 'discover:origins:catalog:v1';
 
 const getDiscoverOriginsUncached = async (): Promise<string[]> => {
   const sql = getAgentCashSql();
@@ -24,12 +24,20 @@ const getDiscoverOriginsUncached = async (): Promise<string[]> => {
   }
 
   const t0 = performance.now();
+  // Source: AgentCash catalog. We want every origin that supports x402 AND has
+  // observed x402 usage (trusted txns or recent last-seen). Ranked by the same
+  // trust-weighted score AgentCash's catalog search uses as its usage signal.
   const rows = (await sql`
-    SELECT origin, protocols
-    FROM search_index
-    WHERE 'x402' = ANY(protocols)
-    ORDER BY position ASC
-  `) as { origin: string; protocols: string[] }[];
+    SELECT o.origin_url AS origin
+    FROM catalog.indexed_origins o
+    JOIN catalog.origin_usage_signals s ON s.origin_url = o.origin_url
+    WHERE 'x402' = ANY(o.protocols)
+      AND o.dismissed_at IS NULL
+      AND (s.x402_trusted_txn_count > 0 OR s.x402_last_seen_at IS NOT NULL)
+    ORDER BY s.score_weighted_txn_mass DESC NULLS LAST,
+             s.trusted_txn_count DESC,
+             o.origin_url ASC
+  `) as { origin: string }[];
   console.log(
     `[discover] getDiscoverOrigins=${(performance.now() - t0).toFixed(0)}ms (${rows.length} origins)`
   );
@@ -38,8 +46,8 @@ const getDiscoverOriginsUncached = async (): Promise<string[]> => {
 };
 
 /**
- * Fetches tier-1 x402 origin URLs from the agent-cash search index.
- * Cached in Redis for the standard cache duration.
+ * Fetches x402-supporting, x402-active origins from the AgentCash catalog
+ * (catalog.indexed_origins ⨝ catalog.origin_usage_signals). Cached in Redis.
  */
 export const getDiscoverOrigins = async (): Promise<string[]> => {
   const redis = getRedisClient();

--- a/apps/scan/src/services/db/bazaar/schema.ts
+++ b/apps/scan/src/services/db/bazaar/schema.ts
@@ -6,3 +6,11 @@ export const listBazaarOriginsInputSchema = listTopSellersMVInputSchema.extend({
   tags: z.array(z.string()).optional(),
   originUrls: z.array(z.string()).optional(),
 });
+
+// Featured variant has no `originUrls` — the server resolves the AgentCash
+// catalog set internally (~305 URLs). Sending those over the wire on every
+// re-sort would blow tRPC's URL length limit.
+export const listFeaturedBazaarOriginsInputSchema =
+  listTopSellersMVInputSchema.extend({
+    tags: z.array(z.string()).optional(),
+  });

--- a/apps/scan/src/trpc/routers/public/sellers.ts
+++ b/apps/scan/src/trpc/routers/public/sellers.ts
@@ -9,7 +9,11 @@ import {
 } from '@/services/transfers/sellers/list-mv';
 
 import { listBazaarOrigins } from '@/services/db/bazaar/origins';
-import { listBazaarOriginsInputSchema } from '@/services/db/bazaar/schema';
+import {
+  listBazaarOriginsInputSchema,
+  listFeaturedBazaarOriginsInputSchema,
+} from '@/services/db/bazaar/schema';
+import { getDiscoverOrigins } from '@/lib/discover/origins';
 import { sellerStatisticsMVInputSchema } from '@/services/transfers/sellers/stats/overall-mv';
 import { bucketedSellerStatisticsMVInputSchema } from '@/services/transfers/sellers/stats/bucketed-mv';
 import { getOverallSellerStatisticsMV } from '@/services/transfers/sellers/stats/overall-mv';
@@ -51,6 +55,12 @@ export const sellersRouter = createTRPCRouter({
       .input(listBazaarOriginsInputSchema)
       .query(async ({ input, ctx: { pagination } }) => {
         return await listBazaarOrigins(input, pagination);
+      }),
+    featured: paginatedProcedure
+      .input(listFeaturedBazaarOriginsInputSchema)
+      .query(async ({ input, ctx: { pagination } }) => {
+        const originUrls = await getDiscoverOrigins();
+        return await listBazaarOrigins({ ...input, originUrls }, pagination);
       }),
     stats: {
       // Use origin_stats_aggregated_* views which are pre-joined with payto_origin_map


### PR DESCRIPTION
## Summary
- Replaces the legacy `public.search_index` query with `catalog.indexed_origins ⨝ catalog.origin_usage_signals`, filtered to origins that actually have x402 usage (\`x402_trusted_txn_count > 0\` OR \`x402_last_seen_at IS NOT NULL\`) and ordered by AgentCash's trust-weighted txn mass.
- Yields ~305 origins (vs ~150 from \`search_index\`) with real on-chain activity.
- Bumps \`bazaar.list\` page_size 100 → 400 so all of them fit in one page after Base/Solana recipient grouping.
- Bumps Redis cache key to \`discover:origins:catalog:v1\` to invalidate warmed entries from the old query shape.

## Test plan
- [x] Verify the Featured Services table on \`/\` (Discover tab) shows substantially more origins than before.
- [x] Spot-check that high-traffic origins (stableenrich, stableflare, stablestudio) are at the top.
- [x] Confirm warm-cache cron (\`/api/cron/warm-cache\`) still completes without errors.
- [x] Confirm no MPP-only origins appear in the table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)