### PR TITLE
feat(scan): switch semantic search to AgentCash external API

### DIFF
--- a/apps/scan/src/app/(app)/(home)/(overview)/_components/sellers/featured-columns.tsx
+++ b/apps/scan/src/app/(app)/(home)/(overview)/_components/sellers/featured-columns.tsx
@@ -257,17 +257,20 @@ const ServerCell: React.FC<{ item: FeaturedServiceItem }> = ({ item }) => {
   const hasTooltipContent =
     recipients.length > 0 || endpoint !== undefined || otherOrigins.length > 0;
 
-  const trigger = (
-    <Link
-      href={`/server/${origin.id}`}
-      className="flex items-start gap-2.5 min-w-0 group py-0.5"
-    >
+  // Stub rows from search results have id === origin URL (no x402scan record
+  // exists yet). Linking to /server/<url> 404s, so jump out to the origin.
+  const isExternal = origin.id.startsWith('http');
+  const innerContent = (
+    <>
       <Favicon url={origin.favicon} className="size-6 shrink-0 mt-0.5" />
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-1.5 min-w-0">
           <span className="truncate text-sm font-medium group-hover:text-primary transition-colors">
             {title}
           </span>
+          {isExternal ? (
+            <ArrowUpRight className="size-3 text-muted-foreground shrink-0" />
+          ) : null}
           {otherOrigins.length > 0 ? (
             <span className="text-[10px] font-mono text-muted-foreground shrink-0">
               +{otherOrigins.length}
@@ -285,6 +288,24 @@ const ServerCell: React.FC<{ item: FeaturedServiceItem }> = ({ item }) => {
           </div>
         ) : null}
       </div>
+    </>
+  );
+
+  const trigger = isExternal ? (
+    <a
+      href={origin.origin}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex items-start gap-2.5 min-w-0 group py-0.5"
+    >
+      {innerContent}
+    </a>
+  ) : (
+    <Link
+      href={`/server/${origin.id}`}
+      className="flex items-start gap-2.5 min-w-0 group py-0.5"
+    >
+      {innerContent}
     </Link>
   );
 

--- a/apps/scan/src/env.ts
+++ b/apps/scan/src/env.ts
@@ -46,6 +46,10 @@ export const env = createEnv({
     AGENTCASH_DATABASE_URL: z.string().optional(),
     AGENTCASH_URL: z.string().optional(),
     AGENTCASH_INTERNAL_API_KEY: z.string().optional(),
+    // Bearer token for AgentCash's external search API
+    // (/api/external/search/*). Format: "<client_id>.<secret>" — paired
+    // server-side with SEARCH_EXTERNAL_API_KEYS=<client_id>:<sha256(secret)>.
+    AGENTCASH_SEARCH_API_KEY: z.string().optional(),
   },
   client: {
     NEXT_PUBLIC_APP_URL: z

--- a/apps/scan/src/lib/discover/search.ts
+++ b/apps/scan/src/lib/discover/search.ts
@@ -1,3 +1,5 @@
+import { env } from '@/env';
+
 export interface SearchResultEndpoint {
   method: string;
   path: string;
@@ -15,32 +17,84 @@ export interface SearchResult {
   endpoint?: SearchResultEndpoint;
 }
 
-/**
- * Calls agentcash.dev/api/internal/search for semantic search.
- * Falls back to empty results if the endpoint is unavailable.
- */
-import { env } from '@/env';
+// Wire response from /api/external/search/results — see agentcash
+// `services/search-v2` and `app/api/_lib/search-route-handlers.ts`.
+interface ExternalSearchResultRow {
+  resourceId: string;
+  method: string;
+  path: string;
+  title: string;
+  facets?: unknown;
+  authMode: string | null;
+  price: string | null;
+  protocols: string[];
+  originTitle: string;
+  originUrl: string;
+  favicon: string;
+  x402OriginId: string | null;
+  mppOriginId: string | null;
+}
 
+interface ExternalSearchResponse {
+  query: string;
+  latencyMs: number;
+  page: number;
+  totalResults: number;
+  results: ExternalSearchResultRow[];
+}
+
+/**
+ * Calls AgentCash's external search API (catalog-backed semantic search).
+ * Server-to-server only — keep the bearer token off the client.
+ */
 export async function searchDiscover(query: string): Promise<SearchResult[]> {
   if (!env.AGENTCASH_URL) {
     throw new Error('AGENTCASH_URL is not set');
   }
+  if (!env.AGENTCASH_SEARCH_API_KEY) {
+    throw new Error('AGENTCASH_SEARCH_API_KEY is not set');
+  }
 
-  const res = await fetch(`${env.AGENTCASH_URL}/api/internal/search`, {
-    method: 'POST',
+  const url = new URL('/api/external/search/results', env.AGENTCASH_URL);
+  url.searchParams.set('q', query);
+  url.searchParams.set('protocol', 'x402');
+  url.searchParams.set('limit', '20');
+  url.searchParams.set('broad', 'true');
+
+  const res = await fetch(url, {
+    method: 'GET',
     headers: {
-      'Content-Type': 'application/json',
-      ...(env.AGENTCASH_INTERNAL_API_KEY
-        ? { Authorization: `Bearer ${env.AGENTCASH_INTERNAL_API_KEY}` }
-        : {}),
+      Authorization: `Bearer ${env.AGENTCASH_SEARCH_API_KEY}`,
     },
-    body: JSON.stringify({ query }),
   });
 
   if (!res.ok) {
     throw new Error(`AgentCash search failed: ${res.status} ${res.statusText}`);
   }
 
-  const data = (await res.json()) as { results: SearchResult[] };
-  return data.results ?? [];
+  const data = (await res.json()) as ExternalSearchResponse;
+
+  // The catalog endpoint returns one row per resource (origin × method × path).
+  // Both consumers want one row per origin, so collapse here — first hit wins
+  // since results are already ranked by relevance.
+  const byOrigin = new Map<string, SearchResult>();
+  for (const row of data.results ?? []) {
+    if (byOrigin.has(row.originUrl)) continue;
+    byOrigin.set(row.originUrl, {
+      origin: row.originUrl,
+      title: row.originTitle || row.originUrl,
+      description: '',
+      favicon: row.favicon,
+      protocols: row.protocols,
+      endpoint: {
+        method: row.method,
+        path: row.path,
+        summary: row.title,
+        ...(row.authMode != null ? { authMode: row.authMode } : {}),
+        ...(row.price != null ? { price: row.price } : {}),
+      },
+    });
+  }
+
+  return Array.from(byOrigin.values());
 }

--- a/apps/scan/src/lib/discover/search.ts
+++ b/apps/scan/src/lib/discover/search.ts
@@ -59,7 +59,10 @@ export async function searchDiscover(query: string): Promise<SearchResult[]> {
   url.searchParams.set('q', query);
   url.searchParams.set('protocol', 'x402');
   url.searchParams.set('limit', '20');
-  url.searchParams.set('broad', 'true');
+  // broad=true would include resources without usage signals; pure embedding
+  // similarity then surfaces low-quality origins. Restricting to hasUsage
+  // resources cuts the noise.
+  url.searchParams.set('broad', 'false');
 
   const res = await fetch(url, {
     method: 'GET',


### PR DESCRIPTION
## Summary
- Swaps `lib/discover/search.ts` from `POST /api/internal/search` (legacy LLM-pick over `public.search_index`, single shared bearer, max 5 results) to `GET /api/external/search/results` (catalog `services/search-v2`, per-client API keys hashed server-side, up to 50 results, server-side `?protocol=x402` filter, edge cache).
- Adds `AGENTCASH_SEARCH_API_KEY` env var. Format: \`<client_id>.<secret>\` — paired with `SEARCH_EXTERNAL_API_KEYS=<client_id>:<sha256(secret)>` on the agentcash deployment.
- Catalog endpoint returns one row per resource (origin × method × path); helper collapses to one `SearchResult` per origin so dropdown + discover results table see the same shape they did before.
- Server-side x402 filter via `?protocol=x402` — the existing client-side `protocols.includes('x402')` filters become a no-op safety net.

## Why
This is the endpoint the agentcash README explicitly directs Merit-owned frontends to use:
> `/api/external/search/*` mirrors the browser autocomplete/results/events surface for Merit-owned frontends. x402scan, mppscan, and Poncho should call these from same-origin proxy routes using `SEARCH_EXTERNAL_API_KEYS`, not from browser code.

We already proxy via the `public.discover.search` tRPC procedure on the x402scan server, so the bearer never reaches the client.

## Provisioning required (preview will 500 until done)
1. Generate a secret + sha256 hash:
   ```bash
   SECRET=\$(openssl rand -hex 32)
   HASH=\$(node -e \"console.log(require('crypto').createHash('sha256').update(process.argv[1]).digest('hex'))\" \"\$SECRET\")
   echo \"AGENTCASH_SEARCH_API_KEY=x402scan_live.\$SECRET\"
   echo \"agentcash entry: x402scan_live:\$HASH\"
   ```
2. **agentcash deployment**: append \`x402scan_live:<hash>\` to `SEARCH_EXTERNAL_API_KEYS` (comma-separated).
3. **x402scan deployment**: set `AGENTCASH_SEARCH_API_KEY=x402scan_live.<secret>` for Preview + Production.

## Test plan
- [ ] Provision the API key on both sides per above.
- [ ] Hit the deploy preview, type a query with a space (\"send email\") in the home search bar — dropdown shows results.
- [ ] Press Enter — discover results table renders without \"No x402 results found\".
- [ ] Confirm response time is reasonable (catalog endpoint has \`s-maxage=30, stale-while-revalidate=300\` cache).
- [ ] Spot-check a few queries against agentcash.dev's own search to make sure relevance is comparable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)