### PR TITLE
Support arbitrary x402 accept schemes

### DIFF
--- a/apps/scan/src/lib/resources.ts
+++ b/apps/scan/src/lib/resources.ts
@@ -123,7 +123,7 @@ export const registerResource = async (
   }
 
   const allMappedAccepts = x402Options.map(opt => ({
-    scheme: (opt.scheme ?? 'exact') as 'exact',
+    scheme: opt.scheme ?? 'exact',
     network: normalizeChainId(opt.network).replace('-', '_') as AcceptsNetwork,
     maxAmountRequired:
       ('amount' in opt ? opt.amount : opt.maxAmountRequired) ?? '0',

--- a/apps/scan/src/lib/x402/index.ts
+++ b/apps/scan/src/lib/x402/index.ts
@@ -25,7 +25,7 @@ export type InputSchema = OutputSchema['input'];
  * the database in a common format for v1 and v2.
  */
 export const normalizedAcceptSchema = z3.object({
-  scheme: z3.literal('exact'),
+  scheme: z3.string().min(1),
   network: z3.string(),
   maxAmountRequired: z3.string(),
   payTo: z3.string(),

--- a/apps/scan/src/lib/x402/schema.test.ts
+++ b/apps/scan/src/lib/x402/schema.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { extractFieldsFromSchema } from './schema';
 import { Methods } from '@/types/x402';
-import type { InputSchema } from '@/lib/x402';
+import { normalizedAcceptSchema, type InputSchema } from '@/lib/x402';
 
 function makeInputSchema(
   overrides: Partial<InputSchema> & { method: InputSchema['method'] }
@@ -75,5 +75,20 @@ describe('extractFieldsFromSchema - protocol header filtering', () => {
     const fields = extractFieldsFromSchema(inputSchema, Methods.GET, 'query');
     expect(fields).toHaveLength(1);
     expect(fields[0]!.name).toBe('authorization');
+  });
+});
+
+describe('normalizedAcceptSchema', () => {
+  it('accepts arbitrary non-empty x402 schemes', () => {
+    const result = normalizedAcceptSchema.safeParse({
+      scheme: 'upto',
+      network: 'base',
+      maxAmountRequired: '10000',
+      payTo: '0x1234567890123456789012345678901234567890',
+      asset: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+      maxTimeoutSeconds: 60,
+    });
+
+    expect(result.success).toBe(true);
   });
 });

--- a/apps/scan/src/lib/x402/v2/schema.test.ts
+++ b/apps/scan/src/lib/x402/v2/schema.test.ts
@@ -324,21 +324,29 @@ describe('parseV2', () => {
 
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.errors.some(e => e.startsWith('accepts.0.network'))).toBe(
+        true
+      );
     }
   });
 
   it('should return error for V1 version number', () => {
+    // A valid V1 response: parseX402Response dispatches by x402Version, so this
+    // parses successfully against the V1 schema. The V2-narrowing helper then
+    // rejects it for not being V2.
     const v1Response = {
       x402Version: 1,
       accepts: [
         {
           scheme: 'exact',
           network: 'eip155:8453',
-          amount: '10000',
+          maxAmountRequired: '10000',
+          resource: 'https://api.example.com/v1',
+          description: 'V1 endpoint',
           payTo: '0x1234567890123456789012345678901234567890',
           maxTimeoutSeconds: 60,
           asset: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+          extra: {},
         },
       ],
     };
@@ -347,7 +355,7 @@ describe('parseV2', () => {
 
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.errors).toEqual(['Not a V2 response']);
     }
   });
 

--- a/apps/scan/src/lib/x402/v2/schema.test.ts
+++ b/apps/scan/src/lib/x402/v2/schema.test.ts
@@ -347,7 +347,7 @@ describe('parseV2', () => {
 
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.errors.some(e => e.includes('x402Version'))).toBe(true);
+      expect(result.errors.length).toBeGreaterThan(0);
     }
   });
 
@@ -412,6 +412,32 @@ describe('parseV2', () => {
     if (result.success) {
       expect(result.data.accepts?.[0]?.extra?.name).toBe('USD Coin');
       expect(result.data.accepts?.[0]?.extra?.customField).toBe('custom value');
+    }
+  });
+
+  it('should parse non-exact V2 schemes such as upto', () => {
+    const response = {
+      x402Version: 2,
+      accepts: [
+        {
+          scheme: 'upto',
+          network: 'eip155:8453',
+          amount: '10000',
+          payTo: '0x1234567890123456789012345678901234567890',
+          maxTimeoutSeconds: 60,
+          asset: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+        },
+      ],
+      resource: {
+        url: 'https://api.example.com/upto',
+      },
+    };
+
+    const result = parseV2(response);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.accepts?.[0]?.scheme).toBe('upto');
     }
   });
 });

--- a/apps/scan/src/lib/x402/v2/schema.ts
+++ b/apps/scan/src/lib/x402/v2/schema.ts
@@ -1,28 +1,8 @@
-import type { Network } from '@x402/core/types';
+import {
+  PaymentRequirementsV2Schema,
+  ResourceInfoSchema,
+} from '@x402/core/schemas';
 import { z as z3 } from 'zod3';
-
-// NOTE(shafu): this was changed in V2, it does not support network names like base
-const ChainIdSchema = z3.custom<Network>(
-  val =>
-    typeof val === 'string' && /^[-a-z0-9]{3,8}:[-_a-zA-Z0-9]{1,64}$/.test(val),
-  { message: 'Invalid CAIP-2 network format' }
-);
-
-const resourceSchemaV2 = z3.object({
-  url: z3.string(),
-  description: z3.string().optional(),
-  mimeType: z3.string().optional(),
-});
-
-const paymentRequirementsSchemaV2 = z3.object({
-  scheme: z3.string(),
-  network: ChainIdSchema,
-  asset: z3.string(),
-  amount: z3.string(),
-  payTo: z3.string(),
-  maxTimeoutSeconds: z3.number(),
-  extra: z3.record(z3.string(), z3.any()).optional().nullable(), // Match @x402/core OptionalAny
-});
 
 const extensionsSchemaV2 = z3.object({
   bazaar: z3
@@ -41,8 +21,8 @@ const extensionsSchemaV2 = z3.object({
 export const x402ResponseSchemaV2 = z3.object({
   x402Version: z3.literal(2),
   error: z3.string().nullish(),
-  accepts: z3.array(paymentRequirementsSchemaV2).optional(),
-  resource: resourceSchemaV2.optional(),
+  accepts: z3.array(PaymentRequirementsV2Schema).optional(),
+  resource: ResourceInfoSchema.optional(),
   extensions: extensionsSchemaV2.nullish(),
 });
 

--- a/apps/scan/src/services/db/resources/resource.test.ts
+++ b/apps/scan/src/services/db/resources/resource.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { upsertResourceSchema } from './resource';
+
+describe('upsertResourceSchema', () => {
+  it('accepts non-exact x402 schemes for supported networks', () => {
+    const result = upsertResourceSchema.safeParse({
+      resource: 'https://api.example.com/upto',
+      type: 'http',
+      x402Version: 2,
+      lastUpdated: new Date(),
+      accepts: [
+        {
+          scheme: 'upto',
+          network: 'eip155:8453',
+          payTo: '0x1234567890123456789012345678901234567890',
+          description: 'Up to priced endpoint',
+          maxAmountRequired: '10000',
+          mimeType: 'application/json',
+          maxTimeoutSeconds: 60,
+          asset: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.accepts[0]?.scheme).toBe('upto');
+      expect(result.data.accepts[0]?.network).toBe('base');
+    }
+  });
+});

--- a/apps/scan/src/services/db/resources/resource.ts
+++ b/apps/scan/src/services/db/resources/resource.ts
@@ -28,7 +28,7 @@ export const upsertResourceSchema = z.object({
   metadata: z.record(z.string(), z.any()).optional(),
   accepts: z.array(
     z.object({
-      scheme: z.enum(['exact']),
+      scheme: z.string().min(1),
       network: z.union([
         z.enum([
           'base_sepolia',

--- a/apps/scan/src/services/db/resources/response.ts
+++ b/apps/scan/src/services/db/resources/response.ts
@@ -3,9 +3,7 @@ import { scanDb } from '@x402scan/scan-db';
 import type { Prisma } from '@x402scan/scan-db';
 import type { ParsedX402Response } from '@/lib/x402';
 
-const toPrismaJson = (
-  response: ParsedX402Response
-): Prisma.InputJsonValue => {
+const toPrismaJson = (response: ParsedX402Response): Prisma.InputJsonValue => {
   // Parsed x402 responses are JSON-safe by schema validation, but Prisma's
   // structural JSON input type requires nested objects to have index signatures.
   return response as unknown as Prisma.InputJsonValue;

--- a/packages/internal/databases/scan/prisma/migrations/20260505120000_accepts_scheme_string/migration.sql
+++ b/packages/internal/databases/scan/prisma/migrations/20260505120000_accepts_scheme_string/migration.sql
@@ -1,0 +1,6 @@
+-- Store arbitrary x402 payment schemes instead of constraining to the v1-only
+-- AcceptsScheme enum.
+ALTER TABLE "public"."Accepts"
+  ALTER COLUMN "scheme" TYPE TEXT USING "scheme"::text;
+
+DROP TYPE "public"."AcceptsScheme";

--- a/packages/internal/databases/scan/prisma/schema.prisma
+++ b/packages/internal/databases/scan/prisma/schema.prisma
@@ -104,10 +104,6 @@ model Resources {
   @@index([deprecatedAt])
 }
 
-enum AcceptsScheme {
-  exact
-}
-
 enum AcceptsNetwork {
   base_sepolia
   avalanche_fuji
@@ -125,7 +121,7 @@ enum AcceptsNetwork {
 model Accepts {
   id                String         @id @default(uuid())
   resourceId        String
-  scheme            AcceptsScheme
+  scheme            String
   description       String
   network           AcceptsNetwork
   maxAmountRequired BigInt

--- a/packages/internal/databases/scan/src/index.ts
+++ b/packages/internal/databases/scan/src/index.ts
@@ -33,7 +33,6 @@ export type {
 export {
   Role,
   ResourceType,
-  AcceptsScheme,
   AcceptsNetwork,
   SessionStatus,
   ServerWalletType,

--- a/packages/internal/databases/scan/src/types.ts
+++ b/packages/internal/databases/scan/src/types.ts
@@ -35,7 +35,6 @@ export type {
 export {
   Role,
   ResourceType,
-  AcceptsScheme,
   AcceptsNetwork,
   SessionStatus,
   ServerWalletType,


### PR DESCRIPTION
## Summary
- use @x402/core V2 schemas for payment requirement/resource parsing
- persist accept schemes as arbitrary strings instead of the v1-only exact enum
- preserve discovered schemes through registration and add upto regression coverage

## Verification
- pnpm format
- pnpm lint
- NODE_ENV=development NEXT_PUBLIC_NODE_ENV=development SCAN_DATABASE_URL=postgresql://user:pass@localhost:5432/scan SCAN_DATABASE_URL_UNPOOLED=postgresql://user:pass@localhost:5432/scan CDP_API_KEY_NAME=dummy CDP_API_KEY_ID=dummy CDP_API_KEY_SECRET=dummy CDP_WALLET_SECRET=dummy CRON_SECRET=dummy FREE_TIER_WALLET_NAME=dummy TRANSFERS_DB_URL=postgresql://user:pass@localhost:5432/transfers STRIPE_SECRET_KEY=dummy NEXT_PUBLIC_PROXY_URL=https://example.com NEXT_PUBLIC_SOLANA_RPC_URL=https://example.com NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=dummy pnpm check

Closes #818