### PR TITLE
feat(scan): link sender column to /buyer page via shared <Buyer> component

### DIFF
--- a/apps/scan/src/app/(app)/(home)/(overview)/_components/buyers/columns.tsx
+++ b/apps/scan/src/app/(app)/(home)/(overview)/_components/buyers/columns.tsx
@@ -1,13 +1,11 @@
 'use client';
 
-import Link from 'next/link';
-
 import { Calendar, DollarSign, Globe, Hash, Server, User } from 'lucide-react';
 
 import { HeaderCell } from '@/components/ui/data-table/header-cell';
 
-import { Address } from '@/components/ui/address';
 import { Facilitators } from '@/app/(app)/_components/facilitator';
+import { Buyer, BuyerSkeleton } from '@/app/(app)/_components/buyer';
 import { BuyerTopServers, LoadingBuyerTopServers } from './top-servers';
 
 import { formatTokenAmount } from '@/lib/token';
@@ -30,16 +28,14 @@ export const columns: ExtendedColumnDef<ColumnType>[] = [
       <HeaderCell Icon={User} label="Buyer" className="justify-start" />
     ),
     cell: ({ row }) => (
-      <Link href={`/buyer/${row.original.sender}`}>
-        <Address
-          address={row.original.sender}
-          disableCopy
-          className="font-normal hover:underline"
-        />
-      </Link>
+      <Buyer
+        address={row.original.sender}
+        addressClassName="font-normal"
+        disableCopy
+      />
     ),
     size: 225,
-    loading: () => <Skeleton className="h-4 w-32" />,
+    loading: () => <BuyerSkeleton />,
   },
   {
     accessorKey: 'top_servers',

--- a/apps/scan/src/app/(app)/(home)/_components/transactions/columns.tsx
+++ b/apps/scan/src/app/(app)/(home)/_components/transactions/columns.tsx
@@ -10,6 +10,7 @@ import { Address } from '@/components/ui/address';
 
 import { Seller, SellerSkeleton } from '@/app/(app)/_components/seller';
 import { Facilitator } from '@/app/(app)/_components/facilitator';
+import { Buyer, BuyerSkeleton } from '@/app/(app)/_components/buyer';
 
 import { formatCompactAgo } from '@/lib/utils';
 import { formatTokenAmount } from '@/lib/token';
@@ -62,13 +63,14 @@ export const columns: ExtendedColumnDef<ColumnType>[] = [
     accessorKey: 'sender',
     header: () => <HeaderCell Icon={User} label="Sender" className="mx-auto" />,
     cell: ({ row }) => (
-      <Address
+      <Buyer
         address={row.original.sender}
-        className="text-xs mx-auto block text-center"
+        addressClassName="text-xs mx-auto block text-center"
+        disableCopy
       />
     ),
     size: 150, // Fixed width for transaction count
-    loading: () => <Skeleton className="h-4 w-16 mx-auto" />,
+    loading: () => <BuyerSkeleton className="mx-auto" />,
   },
   {
     accessorKey: 'transaction_hash',

--- a/apps/scan/src/app/(app)/_components/buyer.tsx
+++ b/apps/scan/src/app/(app)/_components/buyer.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import Link from 'next/link';
+
+import { Skeleton } from '@/components/ui/skeleton';
+import { Address } from '@/components/ui/address';
+
+import { cn } from '@/lib/utils';
+
+import type { MixedAddress } from '@/types/address';
+
+interface Props {
+  address: MixedAddress;
+  disableCopy?: boolean;
+  addressClassName?: string;
+}
+
+export const Buyer: React.FC<Props> = ({
+  address,
+  addressClassName,
+  disableCopy,
+}) => {
+  return (
+    <Link
+      href={`/buyer/${address}`}
+      prefetch={false}
+      aria-label={`Buyer profile ${address}`}
+    >
+      <Address
+        address={address}
+        className={cn('text-xs font-medium hover:underline', addressClassName)}
+        disableCopy={disableCopy}
+      />
+    </Link>
+  );
+};
+
+interface BuyerSkeletonProps {
+  className?: string;
+}
+
+export const BuyerSkeleton: React.FC<BuyerSkeletonProps> = ({ className }) => {
+  return <Skeleton className={cn('h-4 w-32', className)} />;
+};

--- a/apps/scan/src/app/(app)/facilitator/[id]/_components/transactions/columns.tsx
+++ b/apps/scan/src/app/(app)/facilitator/[id]/_components/transactions/columns.tsx
@@ -7,6 +7,7 @@ import { HeaderCell } from '@/components/ui/data-table/header-cell';
 import { Address } from '@/components/ui/address';
 
 import { Seller, SellerSkeleton } from '@/app/(app)/_components/seller';
+import { Buyer, BuyerSkeleton } from '@/app/(app)/_components/buyer';
 
 import { TransfersSortingContext } from '@/app/(app)/_contexts/sorting/transfers/context';
 
@@ -37,13 +38,14 @@ export const columns: ExtendedColumnDef<ColumnType>[] = [
     accessorKey: 'sender',
     header: () => <HeaderCell Icon={User} label="Sender" className="mx-auto" />,
     cell: ({ row }) => (
-      <Address
+      <Buyer
         address={row.original.sender}
-        className="text-xs block text-center"
+        addressClassName="text-xs block text-center"
+        disableCopy
       />
     ),
     size: 200,
-    loading: () => <Skeleton className="h-4 w-16 mx-auto" />,
+    loading: () => <BuyerSkeleton className="mx-auto" />,
   },
   {
     accessorKey: 'transaction_hash',

--- a/apps/scan/src/app/(app)/recipient/[address]/_components/transactions/columns.tsx
+++ b/apps/scan/src/app/(app)/recipient/[address]/_components/transactions/columns.tsx
@@ -16,6 +16,7 @@ import type { RouterOutputs } from '@/trpc/client';
 import { TransfersSortingContext } from '@/app/(app)/_contexts/sorting/transfers/context';
 import { Chains } from '@/app/(app)/_components/chains';
 import { Facilitator } from '@/app/(app)/_components/facilitator';
+import { Buyer, BuyerSkeleton } from '@/app/(app)/_components/buyer';
 
 type ColumnType = RouterOutputs['public']['transfers']['list']['items'][number];
 
@@ -24,13 +25,14 @@ export const columns: ExtendedColumnDef<ColumnType>[] = [
     accessorKey: 'sender',
     header: () => <HeaderCell Icon={User} label="Sender" className="mr-auto" />,
     cell: ({ row }) => (
-      <Address
+      <Buyer
         address={row.original.sender}
-        className="text-xs block text-left"
+        addressClassName="text-xs block text-left"
+        disableCopy
       />
     ),
     size: 150,
-    loading: () => <Skeleton className="h-4 w-16 mr-auto" />,
+    loading: () => <BuyerSkeleton className="mr-auto" />,
   },
   {
     accessorKey: 'amount',


### PR DESCRIPTION
## Problem

The Sender column in transaction tables renders as plain `<Address>` text, while
the Recipient/Server column uses the `<Seller>` wrapper that links to
`/recipient/<address>` (or origin card). As a result, `/buyer/<address>` pages
exist and are reachable from the Top Buyers ranking, but cannot be reached by
clicking sender wallets in transactions — users have to copy the address into
the URL manually.

Closes #838. Refs #810 — addresses 5.2 (cross-entity navigation), and adjacent
to 5.3 (entity-tab consistency).

## Change

Add a `<Buyer>` component (`apps/scan/src/app/(app)/_components/buyer.tsx`)
that wraps `<Address>` in a `<Link href={`/buyer/${address}`}>`, and use it in
the four cells where buyer wallets are surfaced:

- `(home)/_components/transactions/columns.tsx` — covers `/` Latest Transactions and `/transactions`
- `recipient/[address]/_components/transactions/columns.tsx`
- `facilitator/[id]/_components/transactions/columns.tsx`
- `(home)/(overview)/_components/buyers/columns.tsx` — Top Buyers row, migrated from inline `<Link>+<Address>` to use the new `<Buyer>` (consolidates the only prior cell-level `/buyer/<addr>` link site under one component)

## Implementation notes

- **`prefetch={false}` on the Link**: `/buyer/[address]/(overview)/page.tsx`
  awaits a tRPC `api.public.buyers.all.stats.overall.prefetch(...)`, so default
  viewport-prefetch would fire ~10 backend stats queries per scroll-into-view
  of a transactions table (multiplied by sort/page churn). Hover/touch still
  prefetches on actual user intent.
- **`aria-label="Buyer profile <address>"`** so screen readers announce the
  link's purpose, not just the truncated wallet text.
- **`BuyerSkeleton({ className })`** so each cell preserves its pre-existing
  alignment (`mx-auto` / `mr-auto`) without a width/position shift on hydration.
- `@breadcrumbs/buyer/[address]/` already exists and is wired to `/buyer/<addr>`
  — no change needed there.

## Acknowledged scope choices

- **Tooltip on Sender**: previously hovering the truncated `0x12…ab` showed the
  full address via `<Address>`'s Copyable+Tooltip path. With `<Buyer disableCopy>`,
  `<Address>` short-circuits to a plain `<span>`, so both copy-on-click and the
  hover tooltip are gone. This matches the existing Top Buyers cell pattern
  (which has used `disableCopy` since it was added). Restoring the tooltip in
  the `disableCopy` branch is a few lines in `components/ui/address.tsx` but
  felt out of scope here — happy to send a follow-up.
- **`<Seller>` symmetry**: this PR adds `prefetch={false}`, `aria-label`, and
  `hover:underline` to `<Buyer>` but does not retrofit them onto `<Seller>`'s
  plain-link branch (or `<Origins>`'s Link). The intent is to ship `<Buyer>`
  first; happy to either fold the parity changes into this PR or follow up
  with a separate one — let me know which you prefer.

## Verification

- `pnpm tsc --noEmit` — no new errors. The pre-existing errors in
  `transactions/columns.tsx` are unchanged between base and head (verified via
  `git stash`-then-rerun); they originate from the missing prisma generated
  client on a fresh clone, not from this change.
- `pnpm eslint` — clean on all five changed files.
- Local `pnpm dev` walkthrough was not attempted: `apps/scan` requires CDP
  credentials + scan DB + transfers DB to boot. Reviewer-side validation welcome.

## Notes

- No API / DB / types changes. No new dependencies.
- `buyer/[address]/_components/transactions/columns.tsx` does not have a Sender
  column (a buyer's own transaction list), so no change there.
