### PR TITLE
chore: bump @agentcash/discovery to 1.6.4

### DIFF
--- a/apps/scan/package.json
+++ b/apps/scan/package.json
@@ -21,7 +21,7 @@
     "format:check": "pnpm -w format:check:dir ./apps/scan"
   },
   "dependencies": {
-    "@agentcash/discovery": "1.6.3",
+    "@agentcash/discovery": "1.6.4",
     "@neondatabase/serverless": "catalog:prisma",
     "@agentcash/router": "1.3.3",
     "@ai-sdk/openai": "^2.0.52",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,8 +303,8 @@ importers:
   apps/scan:
     dependencies:
       '@agentcash/discovery':
-        specifier: 1.6.3
-        version: 1.6.3
+        specifier: 1.6.4
+        version: 1.6.4
       '@agentcash/router':
         specifier: 1.3.3
         version: 1.3.3(@coinbase/x402@2.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@x402/core@2.11.0)(@x402/evm@2.11.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10))(@x402/extensions@2.11.0(bufferutil@4.0.9)(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typescript@5.9.3)(utf-8-validate@5.0.10))(@x402/svm@2.11.0(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)))(mppx@0.5.12(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(express@5.2.1)(typescript@5.9.3)(viem@2.47.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2))(zod-openapi@5.4.6(zod@4.3.6))(zod@4.3.6)
@@ -1009,8 +1009,6 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
-  packages/internal/databases/scan/generated/client: {}
-
   packages/internal/databases/transfers:
     dependencies:
       '@neondatabase/serverless':
@@ -1056,8 +1054,6 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
-
-  packages/internal/databases/transfers/generated/client: {}
 
   packages/internal/neverthrow:
     dependencies:
@@ -1209,8 +1205,8 @@ packages:
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
 
-  '@agentcash/discovery@1.6.3':
-    resolution: {integrity: sha512-fnyFTNS+VF5fj9ZhDxY8BACEEazJA66df/eeRbPUi/4vkRy5Y8cqoPgHe2b9cZkQN5oPaqenyrq5HC7TIgcIoA==}
+  '@agentcash/discovery@1.6.4':
+    resolution: {integrity: sha512-xwWciHH8ZhapkOr0R5BxAlGtowPtHHBiNsolArBRkGJea4tESjlSm+vu7S0caSWavKSwJdxv0YeJZTJ8ouCukQ==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -12296,7 +12292,7 @@ snapshots:
 
   '@adraffy/ens-normalize@1.11.1': {}
 
-  '@agentcash/discovery@1.6.3':
+  '@agentcash/discovery@1.6.4':
     dependencies:
       dereference-json-schema: 0.2.2
       neverthrow: 8.2.0


### PR DESCRIPTION
## Summary

- Bumps `@agentcash/discovery` from `1.6.3` to `1.6.4`
- Picks up fix for UTF-8 encoding in base64-decoded `Payment-Required` headers (Merit-Systems/agentcash-discovery#76)
- Non-ASCII characters (em dashes, curly quotes, etc.) in endpoint descriptions were rendered as mojibake

## Test plan

- [x] Merge after `1.6.4` is published to npm
- [ ] Re-register an affected endpoint and verify description renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)