### PR TITLE
Respect JSON Schema constraints in probe sample-body builder

### DIFF
--- a/apps/scan/src/lib/discovery/utils/build-sample-body.test.ts
+++ b/apps/scan/src/lib/discovery/utils/build-sample-body.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import { buildSampleBodyFromInputSchema } from './build-sample-body';
+
+describe('buildSampleBodyFromInputSchema', () => {
+  it('respects exclusiveMinimum: 0 (agentcash /api/send regression)', () => {
+    // Pulled from agentcash.dev's bazaar input body schema. The previous
+    // builder emitted `amount: 0`, which agentcash's zod validator rejected
+    // before the paywall, so the probe never saw a 402.
+    const schema = {
+      type: 'object',
+      properties: {
+        amount: { type: 'number', exclusiveMinimum: 0 },
+        address: { type: 'string', minLength: 1 },
+        network: { type: 'string', enum: ['base', 'tempo', 'solana'] },
+      },
+      required: ['amount', 'address', 'network'],
+      additionalProperties: false,
+    };
+
+    const sample = buildSampleBodyFromInputSchema(schema);
+    expect(sample).toBeDefined();
+    expect(typeof sample!.amount).toBe('number');
+    expect(sample!.amount).toBeGreaterThan(0);
+    expect(sample!.address).toBe('sample');
+    expect(sample!.network).toBe('base');
+  });
+
+  it('honors minimum (inclusive) on integers', () => {
+    const sample = buildSampleBodyFromInputSchema({
+      type: 'object',
+      properties: { count: { type: 'integer', minimum: 5 } },
+      required: ['count'],
+    });
+    expect(sample!.count).toBe(5);
+  });
+
+  it('snaps up to multipleOf above the minimum', () => {
+    const sample = buildSampleBodyFromInputSchema({
+      type: 'object',
+      properties: {
+        chunkSize: { type: 'integer', minimum: 1, multipleOf: 5 },
+      },
+      required: ['chunkSize'],
+    });
+    expect(sample!.chunkSize).toBe(5);
+  });
+
+  it('honors pre-draft-06 boolean exclusiveMinimum paired with minimum', () => {
+    const sample = buildSampleBodyFromInputSchema({
+      type: 'object',
+      properties: {
+        rate: { type: 'number', minimum: 0, exclusiveMinimum: true },
+      },
+      required: ['rate'],
+    });
+    expect(typeof sample!.rate).toBe('number');
+    expect(sample!.rate).toBeGreaterThan(0);
+  });
+
+  it('derives a value below the maximum when 0 is excluded', () => {
+    const sample = buildSampleBodyFromInputSchema({
+      type: 'object',
+      properties: { delta: { type: 'integer', maximum: -1 } },
+      required: ['delta'],
+    });
+    expect(sample!.delta).toBeLessThanOrEqual(-1);
+  });
+
+  it('pads strings up to minLength', () => {
+    const sample = buildSampleBodyFromInputSchema({
+      type: 'object',
+      properties: { token: { type: 'string', minLength: 32 } },
+      required: ['token'],
+    });
+    expect(typeof sample!.token).toBe('string');
+    expect((sample!.token as string).length).toBeGreaterThanOrEqual(32);
+  });
+
+  it('clamps strings down to maxLength', () => {
+    const sample = buildSampleBodyFromInputSchema({
+      type: 'object',
+      properties: { tag: { type: 'string', maxLength: 3 } },
+      required: ['tag'],
+    });
+    expect((sample!.tag as string).length).toBeLessThanOrEqual(3);
+  });
+
+  it('emits format-conformant strings for common formats', () => {
+    const sample = buildSampleBodyFromInputSchema({
+      type: 'object',
+      properties: {
+        contact: { type: 'string', format: 'email' },
+        homepage: { type: 'string', format: 'uri' },
+        id: { type: 'string', format: 'uuid' },
+        when: { type: 'string', format: 'date-time' },
+      },
+      required: ['contact', 'homepage', 'id', 'when'],
+    });
+    expect(sample!.contact).toMatch(/.+@.+\..+/);
+    expect(sample!.homepage).toMatch(/^https?:\/\//);
+    expect(sample!.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    );
+    expect(sample!.when).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('returns the const value when present', () => {
+    const sample = buildSampleBodyFromInputSchema({
+      type: 'object',
+      properties: { kind: { const: 'http' } },
+      required: ['kind'],
+    });
+    expect(sample!.kind).toBe('http');
+  });
+
+  it('clamps array length to maxItems', () => {
+    const sample = buildSampleBodyFromInputSchema({
+      type: 'object',
+      properties: {
+        tags: {
+          type: 'array',
+          minItems: 5,
+          maxItems: 2,
+          items: { type: 'string' },
+        },
+      },
+      required: ['tags'],
+    });
+    expect(Array.isArray(sample!.tags)).toBe(true);
+    expect((sample!.tags as unknown[]).length).toBe(2);
+  });
+
+  it('still defaults to 0 when no numeric bounds are given', () => {
+    const sample = buildSampleBodyFromInputSchema({
+      type: 'object',
+      properties: { n: { type: 'number' } },
+      required: ['n'],
+    });
+    expect(sample!.n).toBe(0);
+  });
+});

--- a/apps/scan/src/lib/discovery/utils/build-sample-body.ts
+++ b/apps/scan/src/lib/discovery/utils/build-sample-body.ts
@@ -6,6 +6,10 @@
  * issue its 402 challenge. Walking the spec's required fields yields a body
  * that satisfies validation so the live 402 — including chain-level
  * payTo/asset/network details — is reachable.
+ *
+ * Honors JSON Schema constraints — numeric bounds, string length/format,
+ * `const`, array bounds — so the generated body passes server-side
+ * validators that go beyond required-field checks.
  */
 
 const MAX_DEPTH = 8;
@@ -23,6 +27,7 @@ function asArray(value: unknown): unknown[] {
 function buildFromSchema(schema: unknown, depth: number): unknown {
   if (depth > MAX_DEPTH || !isRecord(schema)) return null;
 
+  if ('const' in schema) return schema.const;
   if (Array.isArray(schema.enum) && schema.enum.length > 0)
     return schema.enum[0];
   if ('default' in schema) return schema.default;
@@ -52,13 +57,19 @@ function buildFromSchema(schema: unknown, depth: number): unknown {
       typeof schema.minItems === 'number' && schema.minItems > 0
         ? schema.minItems
         : 1;
-    return Array.from({ length: minItems }, () =>
+    const maxItems =
+      typeof schema.maxItems === 'number' && schema.maxItems > 0
+        ? schema.maxItems
+        : Number.POSITIVE_INFINITY;
+    const length = Math.min(minItems, maxItems);
+    return Array.from({ length }, () =>
       buildFromSchema(schema.items, depth + 1)
     );
   }
 
-  if (types.includes('string')) return 'sample';
-  if (types.includes('integer') || types.includes('number')) return 0;
+  if (types.includes('string')) return pickString(schema);
+  if (types.includes('integer')) return pickNumber(schema, true);
+  if (types.includes('number')) return pickNumber(schema, false);
   if (types.includes('boolean')) return false;
   if (types.includes('null')) return null;
 
@@ -68,6 +79,136 @@ function buildFromSchema(schema: unknown, depth: number): unknown {
   }
 
   return {};
+}
+
+/**
+ * Picks a numeric value satisfying the schema's bounds.
+ *
+ * Handles both JSON Schema 2020-12 (`exclusiveMinimum`/`exclusiveMaximum` as
+ * numbers) and pre-draft-06 (booleans paired with `minimum`/`maximum`).
+ *
+ * Strategy: derive the strictest lower bound, then snap up to a `multipleOf`
+ * if present. If only an upper bound is constrained and 0 fails it, derive
+ * from the upper instead.
+ */
+function pickNumber(schema: JsonSchema, isInteger: boolean): number {
+  const minimum = typeof schema.minimum === 'number' ? schema.minimum : undefined;
+  const maximum = typeof schema.maximum === 'number' ? schema.maximum : undefined;
+
+  const rawExMin = schema.exclusiveMinimum;
+  const rawExMax = schema.exclusiveMaximum;
+  const exclusiveMinimum: number | undefined =
+    typeof rawExMin === 'number'
+      ? rawExMin
+      : rawExMin === true && minimum !== undefined
+        ? minimum
+        : undefined;
+  const exclusiveMaximum: number | undefined =
+    typeof rawExMax === 'number'
+      ? rawExMax
+      : rawExMax === true && maximum !== undefined
+        ? maximum
+        : undefined;
+
+  const multipleOf =
+    typeof schema.multipleOf === 'number' && schema.multipleOf > 0
+      ? schema.multipleOf
+      : undefined;
+
+  const stepUp = (n: number): number => {
+    if (multipleOf !== undefined) {
+      return (Math.floor(n / multipleOf) + 1) * multipleOf;
+    }
+    return isInteger ? Math.floor(n) + 1 : n + 1;
+  };
+
+  const stepDown = (n: number): number => {
+    if (multipleOf !== undefined) {
+      return (Math.ceil(n / multipleOf) - 1) * multipleOf;
+    }
+    return isInteger ? Math.ceil(n) - 1 : n - 1;
+  };
+
+  let candidate: number;
+  if (
+    exclusiveMinimum !== undefined &&
+    (minimum === undefined || exclusiveMinimum >= minimum)
+  ) {
+    candidate = stepUp(exclusiveMinimum);
+  } else if (minimum !== undefined) {
+    candidate =
+      multipleOf !== undefined
+        ? Math.ceil(minimum / multipleOf) * multipleOf
+        : minimum;
+  } else if (exclusiveMaximum !== undefined && exclusiveMaximum <= 0) {
+    candidate = stepDown(exclusiveMaximum);
+  } else if (maximum !== undefined && maximum < 0) {
+    candidate =
+      multipleOf !== undefined
+        ? Math.floor(maximum / multipleOf) * multipleOf
+        : maximum;
+  } else {
+    candidate = multipleOf ?? 0;
+  }
+
+  if (isInteger) candidate = Math.trunc(candidate);
+  return candidate;
+}
+
+/**
+ * Picks a string value honoring `const`, `format`, and `min/maxLength`.
+ *
+ * `pattern` is intentionally not satisfied here — solving an arbitrary regex
+ * is out of scope. If a server requires a `pattern`, the probe will fail and
+ * the operator can register manually.
+ */
+function pickString(schema: JsonSchema): string {
+  const format = typeof schema.format === 'string' ? schema.format : undefined;
+  const minLength =
+    typeof schema.minLength === 'number' ? schema.minLength : undefined;
+  const maxLength =
+    typeof schema.maxLength === 'number' ? schema.maxLength : undefined;
+
+  let value = sampleByFormat(format) ?? 'sample';
+
+  if (minLength !== undefined && value.length < minLength) {
+    value = value.padEnd(minLength, 'x');
+  }
+  if (maxLength !== undefined && value.length > maxLength) {
+    value = value.slice(0, maxLength);
+  }
+  return value;
+}
+
+function sampleByFormat(format: string | undefined): string | undefined {
+  switch (format) {
+    case 'email':
+    case 'idn-email':
+      return 'user@example.com';
+    case 'uri':
+    case 'iri':
+    case 'uri-reference':
+    case 'iri-reference':
+    case 'url':
+      return 'https://example.com';
+    case 'uuid':
+      return '00000000-0000-4000-8000-000000000000';
+    case 'date':
+      return '2025-01-01';
+    case 'date-time':
+      return '2025-01-01T00:00:00Z';
+    case 'time':
+      return '00:00:00';
+    case 'ipv4':
+      return '127.0.0.1';
+    case 'ipv6':
+      return '::1';
+    case 'hostname':
+    case 'idn-hostname':
+      return 'example.com';
+    default:
+      return undefined;
+  }
 }
 
 /**

--- a/apps/scan/src/lib/discovery/utils/build-sample-body.ts
+++ b/apps/scan/src/lib/discovery/utils/build-sample-body.ts
@@ -92,8 +92,10 @@ function buildFromSchema(schema: unknown, depth: number): unknown {
  * from the upper instead.
  */
 function pickNumber(schema: JsonSchema, isInteger: boolean): number {
-  const minimum = typeof schema.minimum === 'number' ? schema.minimum : undefined;
-  const maximum = typeof schema.maximum === 'number' ? schema.maximum : undefined;
+  const minimum =
+    typeof schema.minimum === 'number' ? schema.minimum : undefined;
+  const maximum =
+    typeof schema.maximum === 'number' ? schema.maximum : undefined;
 
   const rawExMin = schema.exclusiveMinimum;
   const rawExMax = schema.exclusiveMaximum;


### PR DESCRIPTION
## Summary

- The probe's no-body fallback synthesizes a request body from the OpenAPI `inputSchema` so paywalled servers that validate input before the paywall can still return a 402. The walker honored required fields and types, but ignored value-level constraints — so it could produce bodies the server rejected with 400 before the paywall fired.
- agentcash.dev/api/send is the live regression: `amount: { type: 'number', exclusiveMinimum: 0 }`. The builder emitted `amount: 0`, agentcash returned 400 ("Too small: expected number to be >0"), and registration came back with `"No valid x402 response found"` despite the endpoint advertising both Base and Solana via CAIP-2.
- `pickNumber` / `pickString` now honor `minimum`, `exclusiveMinimum` (2020-12 number form **and** pre-draft-06 boolean form), `maximum`, `exclusiveMaximum`, `multipleOf`, `minLength`, `maxLength`, and the common `format` values (`email`, `uri`, `uuid`, `date`, `date-time`, `time`, `ipv4`, `ipv6`, `hostname`). `const` is honored at the top of `buildFromSchema`, and array length is clamped to `maxItems`.
- `pattern` is intentionally not solved — out of scope for sample generation.

## Test plan

- [x] `apps/scan/src/lib/discovery/utils/build-sample-body.test.ts` — 11 cases covering each constraint family, including the agentcash regression
- [x] `npx vitest run src/lib/discovery/utils/build-sample-body.test.ts` — 11/11 pass locally
- [x] End-to-end against live agentcash: `POST /api/send` with the new sample body returns **402** with the `payment-required` header (was 400 before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)