### PR TITLE
Increase footer spacing for Built by Merit

### DIFF
--- a/apps/scan/src/app/_components/layout/footer.tsx
+++ b/apps/scan/src/app/_components/layout/footer.tsx
@@ -22,7 +22,7 @@ export function Footer() {
             href="https://merit.systems"
             target="_blank"
             rel="noopener noreferrer"
-            className="absolute left-1/2 -translate-x-1/2 flex items-center gap-2.5 group"
+            className="absolute left-1/2 -translate-x-1/2 flex items-center gap-2 group"
           >
             <span className="text-xs font-medium tracking-wide text-muted-foreground group-hover:text-foreground transition-colors uppercase">
               Built by

--- a/apps/scan/src/app/_components/layout/footer.tsx
+++ b/apps/scan/src/app/_components/layout/footer.tsx
@@ -22,7 +22,7 @@ export function Footer() {
             href="https://merit.systems"
             target="_blank"
             rel="noopener noreferrer"
-            className="absolute left-1/2 -translate-x-1/2 flex items-center gap-1.5 group"
+            className="absolute left-1/2 -translate-x-1/2 flex items-center gap-2.5 group"
           >
             <span className="text-xs font-medium tracking-wide text-muted-foreground group-hover:text-foreground transition-colors uppercase">
               Built by


### PR DESCRIPTION
## Summary
- Increase gap between "Built by" text and Merit logo from `gap-1.5` (6px) to `gap-2.5` (10px) to match the internal spacing between the Merit icon and "MERIT" text in the logo SVG

## Test plan
- [ ] Check deploy preview footer spacing visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)