### PR TITLE
Document programmatic resource registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ pnpm dev:sync
 ## Documentation
 
 - **[x402 Discovery Document Guide](./docs/DISCOVERY.md)** - Learn how to implement discovery for your x402 server to enable automatic resource registration
+- **[Programmatic Resource Registration](./docs/PROGRAMMATIC_REGISTRATION.md)** - Add or refresh resources with the public registry API
 
 ## Contributing
 
@@ -59,6 +60,8 @@ We're actively seeking contributors to help build x402scan. We believe an ecosys
 ### Add Resources
 
 If you know of a resource that is not yet listed, you can add it by visiting [https://www.x402scan.com/resources/register](https://www.x402scan.com/resources/register) and submitting the URL. If the URL returns a valid x402 schema, it will be added to the resources list automatically.
+
+Resource providers can also register or refresh listings programmatically with the public registry API. See [Programmatic Resource Registration](./docs/PROGRAMMATIC_REGISTRATION.md) for request examples.
 
 ### Add Facilitators
 

--- a/docs/PROGRAMMATIC_REGISTRATION.md
+++ b/docs/PROGRAMMATIC_REGISTRATION.md
@@ -1,0 +1,73 @@
+# Programmatic Resource Registration
+
+x402scan exposes public registry endpoints for resource providers that need to add or refresh listings without using the website form.
+
+Registry writes require SIWX authentication and are free. The first request receives a SIWX challenge, then the client retries with a signed `SIGN-IN-WITH-X` header. The x402scan MCP `fetch_with_auth` tool automates that flow for EVM wallets.
+
+## Register or Refresh One Resource
+
+Use `POST /api/x402/registry/register` when you already know the exact x402-protected endpoint.
+
+```http
+POST /api/x402/registry/register HTTP/1.1
+Host: www.x402scan.com
+Content-Type: application/json
+SIGN-IN-WITH-X: <signed-siwx-proof>
+
+{
+  "url": "https://api.example.com/paid-resource"
+}
+```
+
+The endpoint probes the resource URL, validates the x402 challenge, and upserts the listing. Calling it again for the same URL refreshes the stored resource metadata, payment requirements, and last-updated timestamp.
+
+Successful responses include the registered resource, accepted payment options, and registration details:
+
+```json
+{
+  "success": true,
+  "resource": {},
+  "accepts": [],
+  "registrationDetails": {}
+}
+```
+
+If the URL does not return a valid x402 challenge, the endpoint returns `422` with a parseable error.
+
+## Register or Refresh an Origin
+
+Use `POST /api/x402/registry/register-origin` when your server publishes discovery metadata through OpenAPI or `/.well-known/x402`.
+
+```http
+POST /api/x402/registry/register-origin HTTP/1.1
+Host: www.x402scan.com
+Content-Type: application/json
+SIGN-IN-WITH-X: <signed-siwx-proof>
+
+{
+  "origin": "https://api.example.com"
+}
+```
+
+The endpoint discovers resources for the origin, registers valid x402 routes, skips SIWX-only routes, reports failures, and deprecates stale resources that are no longer present in discovery.
+
+Example response shape:
+
+```json
+{
+  "success": true,
+  "registered": 2,
+  "siwx": 1,
+  "failed": 0,
+  "skipped": 0,
+  "deprecated": 0,
+  "total": 3,
+  "source": "openapi"
+}
+```
+
+## Discovery Requirements
+
+For reliable automatic registration, publish an OpenAPI document at `/openapi.json` with x402 payment metadata. `/.well-known/x402` is also supported for compatibility.
+
+See the [Discovery Document Guide](./DISCOVERY.md) for accepted formats, validation commands, and common failure reasons.


### PR DESCRIPTION
## Summary
- add provider-facing docs for registering or refreshing x402 resources via the public registry API
- document both single-resource and origin discovery registration endpoints
- link the new guide from the README resource contribution section

## Verification
- pnpm format:check:dir README.md docs/PROGRAMMATIC_REGISTRATION.md

Fixes #104
/claim #104