### PR TITLE
Add OpenAPI spec import to resource registration

### DIFF
--- a/apps/scan/package.json
+++ b/apps/scan/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "@agentcash/discovery": "1.6.4",
-    "@neondatabase/serverless": "catalog:prisma",
     "@agentcash/router": "1.3.3",
     "@ai-sdk/openai": "^2.0.52",
     "@ai-sdk/react": "^2.0.68",
@@ -36,6 +35,7 @@
     "@lmnr-ai/lmnr": "^0.7.4",
     "@mdx-js/loader": "catalog:mdx",
     "@mdx-js/react": "catalog:mdx",
+    "@neondatabase/serverless": "catalog:prisma",
     "@next/mdx": "catalog:next",
     "@octokit/rest": "^22.0.0",
     "@openrouter/ai-sdk-provider": "^1.5.4",
@@ -138,6 +138,7 @@
     "vaul": "^1.1.2",
     "viem": "catalog:",
     "wagmi": "^2.17.5",
+    "yaml": "^2.8.2",
     "zod": "catalog:",
     "zod3": "npm:zod@^3.24.2"
   },

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -100,6 +100,13 @@ interface OpenApiImportResource {
   label: string;
 }
 
+interface ManualRegistrationTarget {
+  id: string;
+  url: string;
+  method?: OpenApiMethod;
+  label?: string;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
@@ -135,7 +142,10 @@ function resolveOpenApiServer(
     .map(server => (isRecord(server) ? server.url : undefined))
     .find((value): value is string => typeof value === 'string');
 
-  const rawBaseUrl = serverUrl ?? fallbackBaseUrl;
+  const rawBaseUrl =
+    serverUrl ??
+    resolveSwaggerServer(document, fallbackBaseUrl) ??
+    fallbackBaseUrl;
   if (!rawBaseUrl) {
     throw new Error('OpenAPI document needs an absolute server URL.');
   }
@@ -147,6 +157,42 @@ function resolveOpenApiServer(
   } catch {
     throw new Error('OpenAPI server URL is invalid.');
   }
+}
+
+function resolveSwaggerServer(
+  document: Record<string, unknown>,
+  fallbackBaseUrl: string | null
+): string | null {
+  if (typeof document.swagger !== 'string') {
+    return null;
+  }
+
+  const host = typeof document.host === 'string' ? document.host : null;
+  if (!host) {
+    return null;
+  }
+
+  const schemes = Array.isArray(document.schemes) ? document.schemes : [];
+  let fallbackScheme = 'https';
+  if (fallbackBaseUrl) {
+    try {
+      fallbackScheme = new URL(fallbackBaseUrl).protocol.replace(/:$/, '');
+    } catch {
+      fallbackScheme = 'https';
+    }
+  }
+  const scheme =
+    schemes.find((value): value is string => typeof value === 'string') ??
+    fallbackScheme;
+  const basePath =
+    typeof document.basePath === 'string' && document.basePath.length > 0
+      ? document.basePath
+      : '';
+  const normalizedBasePath = basePath.startsWith('/')
+    ? basePath
+    : `/${basePath}`;
+
+  return `${scheme}://${host}${normalizedBasePath}`.replace(/\/$/, '');
 }
 
 function operationHasX402Metadata(operation: Record<string, unknown>): boolean {
@@ -205,8 +251,28 @@ function parseOpenApiResources(
   return {
     baseUrl,
     resources: Array.from(
-      new Map(resources.map(resource => [resource.url, resource])).values()
+      new Map(
+        resources.map(resource => [getOpenApiResourceKey(resource), resource])
+      ).values()
     ),
+  };
+}
+
+function getOpenApiResourceKey(resource: OpenApiImportResource): string {
+  return `${resource.method} ${normalizeUrl(resource.url)}`;
+}
+
+function createManualTarget(
+  url: string,
+  method?: OpenApiMethod,
+  label?: string
+): ManualRegistrationTarget {
+  const normalizedUrl = normalizeUrl(url);
+  return {
+    id: method ? `${method} ${normalizedUrl}` : normalizedUrl,
+    url: normalizedUrl,
+    method,
+    label,
   };
 }
 
@@ -243,7 +309,7 @@ function getPrimaryProbeError(
 export const RegisterResourceForm = () => {
   const [url, setUrl] = useState('');
   const [headers, setHeaders] = useState<{ name: string; value: string }[]>([]);
-  const [manualUrls, setManualUrls] = useState<string[]>([]);
+  const [manualUrls, setManualUrls] = useState<ManualRegistrationTarget[]>([]);
   const [manualListError, setManualListError] = useState<string | null>(null);
   const [manualProgress, setManualProgress] = useState<{
     current: number;
@@ -288,7 +354,8 @@ export const RegisterResourceForm = () => {
   const normalizedUrl = useMemo(() => normalizeUrl(url.trim()), [url]);
 
   const queueOrigin = useMemo(
-    () => (manualUrls.length > 0 ? safeGetOrigin(manualUrls[0] ?? '') : null),
+    () =>
+      manualUrls.length > 0 ? safeGetOrigin(manualUrls[0]?.url ?? '') : null,
     [manualUrls]
   );
 
@@ -298,17 +365,19 @@ export const RegisterResourceForm = () => {
     hasDiscoveryResources && manualUrls.length === 0;
 
   const canUseManualMode = isValidUrl && !isOriginOnly;
-  const currentUrlAlreadyInManualList = manualUrls.includes(normalizedUrl);
+  const currentUrlAlreadyInManualList = manualUrls.some(
+    target => target.id === normalizedUrl
+  );
   const canAddCurrentUrl =
     canUseManualMode &&
     !currentUrlAlreadyInManualList &&
     (!queueOrigin || queueOrigin === urlOrigin);
 
-  const manualTargets =
+  const manualTargets: ManualRegistrationTarget[] =
     manualUrls.length > 0
       ? manualUrls
       : canUseManualMode
-        ? [normalizedUrl]
+        ? [createManualTarget(normalizedUrl)]
         : [];
 
   const testedResourceByUrl = useMemo(() => {
@@ -326,14 +395,6 @@ export const RegisterResourceForm = () => {
     }
     return map;
   }, [failedResources]);
-
-  const openApiResourceByUrl = useMemo(() => {
-    const map = new Map<string, OpenApiImportResource>();
-    for (const resource of openApiResources) {
-      map.set(resource.url, resource);
-    }
-    return map;
-  }, [openApiResources]);
 
   const currentManualTested = testedResourceByUrl.get(normalizedUrl);
   const currentManualFailed =
@@ -388,7 +449,7 @@ export const RegisterResourceForm = () => {
     }
 
     if (!currentUrlAlreadyInManualList) {
-      setManualUrls(current => [...current, normalizedUrl]);
+      setManualUrls(current => [...current, createManualTarget(normalizedUrl)]);
     }
 
     setManualListError(null);
@@ -396,8 +457,8 @@ export const RegisterResourceForm = () => {
     setManualProgress(null);
   };
 
-  const handleRemoveManualUrl = (targetUrl: string) => {
-    setManualUrls(current => current.filter(item => item !== targetUrl));
+  const handleRemoveManualUrl = (targetId: string) => {
+    setManualUrls(current => current.filter(item => item.id !== targetId));
     setManualResult(null);
     setManualProgress(null);
     setManualListError(null);
@@ -435,7 +496,9 @@ export const RegisterResourceForm = () => {
 
     try {
       const parsed = parseOpenApiResources(openApiSpec, fallbackBaseUrl);
-      const resources = parsed.resources.map(resource => resource.url);
+      const resources = parsed.resources.map(resource =>
+        createManualTarget(resource.url, resource.method, resource.label)
+      );
       setManualUrls(resources);
       setOpenApiResources(parsed.resources);
       setUrl(parsed.baseUrl);
@@ -467,7 +530,7 @@ export const RegisterResourceForm = () => {
     await runManualRegistration(manualTargets);
   };
 
-  const runManualRegistration = async (targets: string[]) => {
+  const runManualRegistration = async (targets: ManualRegistrationTarget[]) => {
     if (targets.length === 0 || isRegisteringManual) {
       return;
     }
@@ -480,14 +543,15 @@ export const RegisterResourceForm = () => {
     const failedDetails: { url: string; error: string; status?: number }[] = [];
 
     for (let index = 0; index < targets.length; index += 1) {
-      const targetUrl = targets[index] ?? '';
+      const target = targets[index];
+      if (!target) continue;
       setManualProgress({ current: index + 1, total: targets.length });
 
       try {
         const result = await registerMutation.mutateAsync({
-          url: targetUrl,
+          url: target.url,
           headers: requestHeaders,
-          method: openApiResourceByUrl.get(targetUrl)?.method,
+          method: target.method,
         });
 
         if (result.success) {
@@ -501,12 +565,12 @@ export const RegisterResourceForm = () => {
         }
 
         failedDetails.push({
-          url: targetUrl,
+          url: target.url,
           error: getErrorMessageFromRegisterResult(result),
         });
       } catch (error) {
         failedDetails.push({
-          url: targetUrl,
+          url: target.url,
           error: error instanceof Error ? error.message : 'Request failed',
         });
       }
@@ -525,7 +589,7 @@ export const RegisterResourceForm = () => {
       failed: failedDetails.length,
       failedDetails,
       originId,
-      origin: safeGetOrigin(targets[0] ?? ''),
+      origin: safeGetOrigin(targets[0]?.url ?? ''),
     });
 
     setIsRegisteringManual(false);
@@ -536,7 +600,7 @@ export const RegisterResourceForm = () => {
       return;
     }
 
-    await runManualRegistration([normalizedUrl]);
+    await runManualRegistration([createManualTarget(normalizedUrl)]);
   };
 
   const renderProbeCard = () => {
@@ -889,13 +953,12 @@ export const RegisterResourceForm = () => {
               </p>
               <ul className="space-y-1">
                 {manualUrls.map(item => (
-                  <li key={item} className="flex items-center gap-2 text-xs">
+                  <li key={item.id} className="flex items-center gap-2 text-xs">
                     <div className="flex-1 min-w-0">
-                      <code className="font-mono break-all">{item}</code>
-                      {openApiResourceByUrl.get(item) ? (
+                      <code className="font-mono break-all">{item.url}</code>
+                      {item.method ? (
                         <p className="text-[10px] text-muted-foreground mt-0.5">
-                          {openApiResourceByUrl.get(item)?.method}{' '}
-                          {openApiResourceByUrl.get(item)?.label}
+                          {item.method} {item.label}
                         </p>
                       ) : null}
                     </div>
@@ -903,7 +966,7 @@ export const RegisterResourceForm = () => {
                       type="button"
                       variant="ghost"
                       size="icon"
-                      onClick={() => handleRemoveManualUrl(item)}
+                      onClick={() => handleRemoveManualUrl(item.id)}
                     >
                       <Trash2 className="size-4" />
                     </Button>

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -2,16 +2,20 @@
 
 import { useMemo, useState } from 'react';
 
+import type { ChangeEvent } from 'react';
+
 import {
   ArrowDown,
   CheckCircle2,
   ChevronDown,
+  FileText,
   Loader2,
   Plus,
   Server,
   CircleHelp,
   Trash2,
   TriangleAlert,
+  Upload,
   XCircle,
 } from 'lucide-react';
 
@@ -31,6 +35,7 @@ import {
 } from '@/components/ui/collapsible';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
 import {
   Tooltip,
   TooltipContent,
@@ -47,6 +52,7 @@ import { cn } from '@/lib/utils';
 import { normalizeUrl } from '@/lib/url';
 import { api } from '@/trpc/client';
 import Link from 'next/link';
+import { parse as parseYaml } from 'yaml';
 import { z } from 'zod';
 
 interface ManualRegistrationResult {
@@ -84,6 +90,125 @@ const registerSuccessResultSchema = z.object({
     }),
   }),
 });
+
+const OPENAPI_METHODS = ['get', 'post', 'put', 'patch', 'delete'] as const;
+type OpenApiMethod = Uppercase<(typeof OPENAPI_METHODS)[number]>;
+
+interface OpenApiImportResource {
+  url: string;
+  method: OpenApiMethod;
+  label: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseOpenApiDocument(input: string): Record<string, unknown> {
+  const trimmed = input.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Paste an OpenAPI document first.');
+  }
+
+  const parsed: unknown =
+    trimmed.startsWith('{') || trimmed.startsWith('[')
+      ? JSON.parse(trimmed)
+      : parseYaml(trimmed);
+
+  if (!isRecord(parsed)) {
+    throw new Error('OpenAPI document must be an object.');
+  }
+
+  if (!('openapi' in parsed) && !('swagger' in parsed)) {
+    throw new Error('Document is missing an openapi or swagger version field.');
+  }
+
+  return parsed;
+}
+
+function resolveOpenApiServer(
+  document: Record<string, unknown>,
+  fallbackBaseUrl: string | null
+): string {
+  const servers = Array.isArray(document.servers) ? document.servers : [];
+  const serverUrl = servers
+    .map(server => (isRecord(server) ? server.url : undefined))
+    .find((value): value is string => typeof value === 'string');
+
+  const rawBaseUrl = serverUrl ?? fallbackBaseUrl;
+  if (!rawBaseUrl) {
+    throw new Error('OpenAPI document needs an absolute server URL.');
+  }
+
+  try {
+    return new URL(rawBaseUrl, fallbackBaseUrl ?? undefined)
+      .toString()
+      .replace(/\/$/, '');
+  } catch {
+    throw new Error('OpenAPI server URL is invalid.');
+  }
+}
+
+function operationHasX402Metadata(operation: Record<string, unknown>): boolean {
+  if ('x-payment-info' in operation) {
+    return true;
+  }
+
+  const responses = operation.responses;
+  return isRecord(responses) && '402' in responses;
+}
+
+function buildOpenApiResourceUrl(baseUrl: string, path: string): string {
+  const normalizedBase = baseUrl.replace(/\/+$/, '');
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return `${normalizedBase}${normalizedPath}`;
+}
+
+function parseOpenApiResources(
+  specText: string,
+  fallbackBaseUrl: string | null
+): { baseUrl: string; resources: OpenApiImportResource[] } {
+  const document = parseOpenApiDocument(specText);
+  const baseUrl = resolveOpenApiServer(document, fallbackBaseUrl);
+  const paths = document.paths;
+
+  if (!isRecord(paths)) {
+    throw new Error('OpenAPI document has no paths object.');
+  }
+
+  const resources: OpenApiImportResource[] = [];
+
+  for (const [path, pathItem] of Object.entries(paths)) {
+    if (!isRecord(pathItem)) continue;
+
+    for (const method of OPENAPI_METHODS) {
+      const operation = pathItem[method];
+      if (!isRecord(operation) || !operationHasX402Metadata(operation)) {
+        continue;
+      }
+
+      const url = buildOpenApiResourceUrl(baseUrl, path);
+      const summary =
+        typeof operation.summary === 'string' ? operation.summary : undefined;
+      resources.push({
+        url,
+        method: method.toUpperCase() as OpenApiMethod,
+        label: summary ?? path,
+      });
+    }
+  }
+
+  if (resources.length === 0) {
+    throw new Error('No x402 operations found in this OpenAPI document.');
+  }
+
+  return {
+    baseUrl,
+    resources: Array.from(
+      new Map(resources.map(resource => [resource.url, resource])).values()
+    ),
+  };
+}
 
 function safeGetOrigin(url: string): string | null {
   try {
@@ -127,6 +252,12 @@ export const RegisterResourceForm = () => {
   const [isRegisteringManual, setIsRegisteringManual] = useState(false);
   const [manualResult, setManualResult] =
     useState<ManualRegistrationResult | null>(null);
+  const [openApiSpec, setOpenApiSpec] = useState('');
+  const [openApiBaseUrl, setOpenApiBaseUrl] = useState('');
+  const [openApiError, setOpenApiError] = useState<string | null>(null);
+  const [openApiResources, setOpenApiResources] = useState<
+    OpenApiImportResource[]
+  >([]);
 
   const utils = api.useUtils();
 
@@ -163,6 +294,8 @@ export const RegisterResourceForm = () => {
 
   const hasDiscoveryResources =
     discoveryFound && actualDiscoveredResources.length > 0;
+  const shouldUseDiscoveryRegistration =
+    hasDiscoveryResources && manualUrls.length === 0;
 
   const canUseManualMode = isValidUrl && !isOriginOnly;
   const currentUrlAlreadyInManualList = manualUrls.includes(normalizedUrl);
@@ -193,6 +326,14 @@ export const RegisterResourceForm = () => {
     }
     return map;
   }, [failedResources]);
+
+  const openApiResourceByUrl = useMemo(() => {
+    const map = new Map<string, OpenApiImportResource>();
+    for (const resource of openApiResources) {
+      map.set(resource.url, resource);
+    }
+    return map;
+  }, [openApiResources]);
 
   const currentManualTested = testedResourceByUrl.get(normalizedUrl);
   const currentManualFailed =
@@ -233,6 +374,7 @@ export const RegisterResourceForm = () => {
     setManualResult(null);
     setManualProgress(null);
     setManualListError(null);
+    setOpenApiError(null);
   };
 
   const handleAddCurrentUrl = () => {
@@ -268,9 +410,46 @@ export const RegisterResourceForm = () => {
     setManualListError(null);
     setManualProgress(null);
     setManualResult(null);
+    setOpenApiSpec('');
+    setOpenApiBaseUrl('');
+    setOpenApiError(null);
+    setOpenApiResources([]);
     setIsRegisteringManual(false);
     registerMutation.reset();
     resetBulk();
+  };
+
+  const handleOpenApiFile = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    setOpenApiSpec(await file.text());
+    setOpenApiError(null);
+  };
+
+  const handleImportOpenApiSpec = () => {
+    const explicitBaseUrl = openApiBaseUrl.trim();
+    const fallbackBaseUrl =
+      explicitBaseUrl.length > 0
+        ? explicitBaseUrl
+        : (urlOrigin ?? safeGetOrigin(url));
+
+    try {
+      const parsed = parseOpenApiResources(openApiSpec, fallbackBaseUrl);
+      const resources = parsed.resources.map(resource => resource.url);
+      setManualUrls(resources);
+      setOpenApiResources(parsed.resources);
+      setUrl(parsed.baseUrl);
+      setManualResult(null);
+      setManualProgress(null);
+      setManualListError(null);
+      setOpenApiError(null);
+      resetBulk();
+    } catch (error) {
+      setOpenApiResources([]);
+      setOpenApiError(
+        error instanceof Error ? error.message : 'Unable to parse OpenAPI spec.'
+      );
+    }
   };
 
   const handleRegisterDiscovered = () => {
@@ -308,6 +487,7 @@ export const RegisterResourceForm = () => {
         const result = await registerMutation.mutateAsync({
           url: targetUrl,
           headers: requestHeaders,
+          method: openApiResourceByUrl.get(targetUrl)?.method,
         });
 
         if (result.success) {
@@ -396,7 +576,7 @@ export const RegisterResourceForm = () => {
       );
     }
 
-    if (hasDiscoveryResources) {
+    if (shouldUseDiscoveryRegistration) {
       const previewResources = actualDiscoveredResources.slice(0, 8);
       const hiddenCount =
         actualDiscoveredResources.length - previewResources.length;
@@ -542,7 +722,7 @@ export const RegisterResourceForm = () => {
                 value={url}
                 onChange={event => handleUrlChange(event.target.value)}
               />
-              {!hasDiscoveryResources && (
+              {!shouldUseDiscoveryRegistration && (
                 <Button
                   type="button"
                   variant="outline"
@@ -557,6 +737,69 @@ export const RegisterResourceForm = () => {
             </div>
             {manualListError && (
               <p className="text-xs text-red-600">{manualListError}</p>
+            )}
+          </div>
+
+          <div className="rounded-md border p-4 space-y-3">
+            <div className="flex items-start gap-3">
+              <FileText className="size-5 text-muted-foreground mt-0.5 shrink-0" />
+              <div className="space-y-1">
+                <Label>OpenAPI Spec</Label>
+                <p className="text-xs text-muted-foreground">
+                  Paste or upload a JSON/YAML spec to queue x402 operations for
+                  registration.
+                </p>
+              </div>
+            </div>
+            <div className="grid gap-2 md:grid-cols-[1fr_auto]">
+              <Input
+                type="text"
+                placeholder="Base URL if the spec uses relative servers"
+                value={openApiBaseUrl}
+                onChange={event => setOpenApiBaseUrl(event.target.value)}
+              />
+              <Label className="inline-flex items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-medium hover:bg-muted cursor-pointer">
+                <Upload className="size-4" />
+                Upload
+                <Input
+                  type="file"
+                  accept=".json,.yaml,.yml,application/json,application/yaml,text/yaml,text/x-yaml"
+                  onChange={event => {
+                    void handleOpenApiFile(event);
+                  }}
+                  className="sr-only"
+                />
+              </Label>
+            </div>
+            <Textarea
+              value={openApiSpec}
+              onChange={event => {
+                setOpenApiSpec(event.target.value);
+                setOpenApiError(null);
+              }}
+              placeholder={
+                'openapi: 3.1.0\nservers:\n  - url: https://api.example.com\npaths: ...'
+              }
+              className="min-h-36 font-mono text-xs"
+            />
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleImportOpenApiSpec}
+                disabled={openApiSpec.trim().length === 0}
+              >
+                Parse OpenAPI Spec
+              </Button>
+              {openApiResources.length > 0 && (
+                <p className="text-xs text-muted-foreground">
+                  Queued {openApiResources.length} x402 operation
+                  {openApiResources.length === 1 ? '' : 's'}.
+                </p>
+              )}
+            </div>
+            {openApiError && (
+              <p className="text-xs text-red-600">{openApiError}</p>
             )}
           </div>
 
@@ -639,7 +882,7 @@ export const RegisterResourceForm = () => {
             </CollapsibleContent>
           </Collapsible>
 
-          {manualUrls.length > 0 && !hasDiscoveryResources && (
+          {manualUrls.length > 0 && !shouldUseDiscoveryRegistration && (
             <div className="border rounded-md p-3 space-y-2">
               <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
                 Manual URLs ({manualUrls.length})
@@ -647,7 +890,15 @@ export const RegisterResourceForm = () => {
               <ul className="space-y-1">
                 {manualUrls.map(item => (
                   <li key={item} className="flex items-center gap-2 text-xs">
-                    <code className="font-mono break-all flex-1">{item}</code>
+                    <div className="flex-1 min-w-0">
+                      <code className="font-mono break-all">{item}</code>
+                      {openApiResourceByUrl.get(item) ? (
+                        <p className="text-[10px] text-muted-foreground mt-0.5">
+                          {openApiResourceByUrl.get(item)?.method}{' '}
+                          {openApiResourceByUrl.get(item)?.label}
+                        </p>
+                      ) : null}
+                    </div>
                     <Button
                       type="button"
                       variant="ghost"
@@ -663,7 +914,7 @@ export const RegisterResourceForm = () => {
           )}
         </CardContent>
         <CardFooter className="flex-col items-stretch gap-2">
-          {hasDiscoveryResources ? (
+          {shouldUseDiscoveryRegistration ? (
             <>
               <Button
                 variant="turbo"
@@ -790,7 +1041,7 @@ export const RegisterResourceForm = () => {
         <DiscoveryPanel
           origin={activeSummaryOrigin}
           isLoading={false}
-          found={hasDiscoveryResources}
+          found={shouldUseDiscoveryRegistration}
           source={discoverySource}
           resources={[]}
           resourceCount={0}

--- a/apps/scan/src/app/api/x402/_handlers/registry-register.ts
+++ b/apps/scan/src/app/api/x402/_handlers/registry-register.ts
@@ -8,10 +8,11 @@ import type { z } from 'zod';
 export async function handleRegistryRegister(
   body: z.infer<typeof registryRegisterBodySchema>
 ) {
-  const { url } = body;
+  const { url, method } = body;
 
   const probeResult = await probeX402Endpoint(
-    url.replaceAll('{', '').replaceAll('}', '')
+    url.replaceAll('{', '').replaceAll('}', ''),
+    method
   );
 
   if (!probeResult.success) {

--- a/apps/scan/src/app/api/x402/_lib/schemas.ts
+++ b/apps/scan/src/app/api/x402/_lib/schemas.ts
@@ -112,6 +112,10 @@ export const registryRegisterBodySchema = z.object({
     .string()
     .url()
     .describe('URL of the x402-protected resource to register'),
+  method: z
+    .enum(['GET', 'POST', 'PUT', 'PATCH', 'DELETE'])
+    .optional()
+    .describe('Preferred HTTP method from OpenAPI discovery'),
 });
 
 export const registryRegisterOriginBodySchema = z.object({

--- a/apps/scan/src/lib/discovery/register-origin.ts
+++ b/apps/scan/src/lib/discovery/register-origin.ts
@@ -76,7 +76,7 @@ export interface RegisterOriginResult {
  * Deprecates resources from the same origin that are no longer in the list.
  */
 export async function registerResourcesFromDiscovery(
-  resources: { url: string; authMode?: AuthMode }[],
+  resources: { url: string; method?: string; authMode?: AuthMode }[],
   source: string | undefined
 ): Promise<RegisterOriginResult> {
   const originResourceCounts = new Map(
@@ -100,7 +100,7 @@ export async function registerResourcesFromDiscovery(
       };
     }
 
-    const probeResult = await probeX402Endpoint(resourceUrl);
+    const probeResult = await probeX402Endpoint(resourceUrl, resource.method);
 
     if (!probeResult.success) {
       return {

--- a/apps/scan/src/trpc/routers/public/resources.ts
+++ b/apps/scan/src/trpc/routers/public/resources.ts
@@ -137,13 +137,15 @@ export const resourcesRouter = createTRPCRouter({
     .input(
       z.object({
         url: z.url(),
+        method: z.enum(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']).optional(),
         headers: z.record(z.string(), z.string()).optional(),
         body: z.object().optional(),
       })
     )
     .mutation(async ({ input }) => {
       const probeResult = await probeX402Endpoint(
-        input.url.toString().replaceAll('{', '').replaceAll('}', '')
+        input.url.toString().replaceAll('{', '').replaceAll('}', ''),
+        input.method
       );
 
       if (!probeResult.success) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -653,6 +653,9 @@ importers:
       wagmi:
         specifier: ^2.17.5
         version: 2.19.1(@azure/identity@4.13.0)(@azure/storage-blob@12.30.0)(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.2))(@types/react@19.2.2)(@vercel/blob@2.0.0)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(ioredis@5.8.2)(react@19.2.2)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)
+      yaml:
+        specifier: ^2.8.2
+        version: 2.8.2
       zod:
         specifier: 'catalog:'
         version: 4.3.6


### PR DESCRIPTION
## Summary
- add a JSON/YAML OpenAPI importer to the Add Server form
- extract x402 operations from pasted or uploaded specs and queue them for registration
- pass preferred HTTP methods through tRPC/public registry registration and origin discovery probing
- add `yaml` as a direct app dependency for YAML specs

## Verification
- pnpm format:check:dir apps/scan/src/app/\(app\)/\(home\)/resources/register/_components/form.tsx apps/scan/src/trpc/routers/public/resources.ts apps/scan/src/lib/discovery/register-origin.ts apps/scan/src/app/api/x402/_lib/schemas.ts apps/scan/src/app/api/x402/_handlers/registry-register.ts apps/scan/package.json pnpm-lock.yaml
- pnpm --filter @x402scan/app exec eslint 'src/app/(app)/(home)/resources/register/_components/form.tsx' 'src/app/api/x402/_lib/schemas.ts'
- pnpm --filter @x402scan/scan-db db:generate
- pnpm --filter @x402scan/transfers-db db:generate

## Build note
- `pnpm --filter @x402scan/app build` is still blocked locally by existing workspace package resolution errors for `@x402scan/analytics-db`, `@x402scan/partners-db`, `@x402scan/neverthrow`, and `facilitators`; this occurs after generating Prisma clients and is outside the touched files.

Fixes #97
/claim #97