### PR TITLE
Block zero-resource server registration

### DIFF
--- a/apps/scan/src/app/api/x402/_handlers/registry-register-origin.ts
+++ b/apps/scan/src/app/api/x402/_handlers/registry-register-origin.ts
@@ -29,6 +29,21 @@ export async function handleRegistryRegisterOrigin(
     discoveryResult.source
   );
 
+  if (result.registered === 0) {
+    return jsonResponse(
+      {
+        success: false,
+        error: {
+          type: 'no_valid_resources',
+          message:
+            'No valid paid x402 resources were found for this origin. Add at least one paid x402 resource that passes validation to complete registration.',
+        },
+        result,
+      },
+      422
+    );
+  }
+
   return jsonResponse({
     success: true,
     registered: result.registered,

--- a/apps/scan/src/lib/resources.ts
+++ b/apps/scan/src/lib/resources.ts
@@ -154,6 +154,20 @@ export const registerResource = async (
     };
   }
 
+  const parsedPaymentRequiredBody = parseX402Response(
+    advisory.paymentRequiredBody
+  );
+  if (!parsedPaymentRequiredBody.success) {
+    return {
+      success: false as const,
+      data: advisory.paymentRequiredBody,
+      error: {
+        type: 'parseResponse' as const,
+        parseErrors: parsedPaymentRequiredBody.errors,
+      },
+    };
+  }
+
   const x402Version = x402Options[0]?.version ?? 1;
 
   const { og, metadata, favicon } = await scrapeOriginData(origin);

--- a/apps/scan/src/trpc/routers/public/resources.ts
+++ b/apps/scan/src/trpc/routers/public/resources.ts
@@ -250,7 +250,7 @@ export const resourcesRouter = createTRPCRouter({
           error: {
             type: 'noValidResources' as const,
             message:
-              'No valid paid x402 resources were registered for this server.',
+              'No valid paid x402 resources were found for this origin. Add at least one paid x402 resource that passes validation to complete registration.',
           },
           result,
         };

--- a/apps/scan/src/trpc/routers/public/resources.ts
+++ b/apps/scan/src/trpc/routers/public/resources.ts
@@ -244,6 +244,18 @@ export const resourcesRouter = createTRPCRouter({
         discoveryResult.source
       );
 
+      if (result.registered === 0) {
+        return {
+          success: false as const,
+          error: {
+            type: 'noValidResources' as const,
+            message:
+              'No valid paid x402 resources were registered for this server.',
+          },
+          result,
+        };
+      }
+
       return { success: true as const, ...result };
     }),
 


### PR DESCRIPTION
## Summary
- Reject origin registration unless discovery yields at least one working x402 paid tool endpoint.
- Treat SIWX-only origins, all-failed origins, and endpoints with invalid x402 payment-required bodies as unsuccessful registration attempts.
- Return a clear failure message when no valid paid x402 resources are found for an origin.