### PR TITLE
feat: Just Added carousel on discover page

### DIFF
--- a/apps/scan/next.config.ts
+++ b/apps/scan/next.config.ts
@@ -25,7 +25,11 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       {
         protocol: 'https',
-        hostname: '**',
+        hostname: 'www.x402.org',
+      },
+      {
+        protocol: 'https',
+        hostname: 'vbdmyxikqhgfmwge.public.blob.vercel-storage.com',
       },
     ],
   },

--- a/apps/scan/next.config.ts
+++ b/apps/scan/next.config.ts
@@ -25,11 +25,7 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       {
         protocol: 'https',
-        hostname: 'www.x402.org',
-      },
-      {
-        protocol: 'https',
-        hostname: 'vbdmyxikqhgfmwge.public.blob.vercel-storage.com',
+        hostname: '**',
       },
     ],
   },

--- a/apps/scan/src/app/(app)/(home)/(discover)/_components/just-added/card.tsx
+++ b/apps/scan/src/app/(app)/(home)/(discover)/_components/just-added/card.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Image from 'next/image';
 import Link from 'next/link';
 
 import { Clock, Globe } from 'lucide-react';
@@ -40,11 +41,11 @@ export const JustAddedCard: React.FC<Props> = ({ origin }) => {
         {/* Image area */}
         <div className="relative aspect-[4/3] bg-muted/50 flex items-center justify-center overflow-hidden">
           {origin.ogImages?.[0]?.url ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
+            <Image
               src={origin.ogImages[0].url}
               alt={origin.title ?? origin.origin}
-              className="w-full h-full object-cover"
+              fill
+              className="object-cover"
             />
           ) : origin.favicon ? (
             <Favicon url={origin.favicon} className="size-16" />

--- a/apps/scan/src/app/(app)/(home)/(discover)/_components/just-added/card.tsx
+++ b/apps/scan/src/app/(app)/(home)/(discover)/_components/just-added/card.tsx
@@ -11,7 +11,7 @@ import { Badge } from '@/components/ui/badge';
 
 import { Favicon } from '@/app/(app)/_components/favicon';
 
-import { cn, decodeHtmlEntities } from '@/lib/utils';
+import { decodeHtmlEntities } from '@/lib/utils';
 
 import type { RouterOutputs } from '@/trpc/client';
 
@@ -40,6 +40,7 @@ export const JustAddedCard: React.FC<Props> = ({ origin }) => {
         {/* Image area */}
         <div className="relative aspect-[4/3] bg-muted/50 flex items-center justify-center overflow-hidden">
           {origin.ogImages?.[0]?.url ? (
+            {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
               src={origin.ogImages[0].url}
               alt={origin.title ?? origin.origin}

--- a/apps/scan/src/app/(app)/(home)/(discover)/_components/just-added/card.tsx
+++ b/apps/scan/src/app/(app)/(home)/(discover)/_components/just-added/card.tsx
@@ -40,7 +40,7 @@ export const JustAddedCard: React.FC<Props> = ({ origin }) => {
         {/* Image area */}
         <div className="relative aspect-[4/3] bg-muted/50 flex items-center justify-center overflow-hidden">
           {origin.ogImages?.[0]?.url ? (
-            {/* eslint-disable-next-line @next/next/no-img-element */}
+            // eslint-disable-next-line @next/next/no-img-element
             <img
               src={origin.ogImages[0].url}
               alt={origin.title ?? origin.origin}

--- a/apps/scan/src/app/(app)/(home)/(discover)/_components/just-added/card.tsx
+++ b/apps/scan/src/app/(app)/(home)/(discover)/_components/just-added/card.tsx
@@ -46,6 +46,7 @@ export const JustAddedCard: React.FC<Props> = ({ origin }) => {
               alt={origin.title ?? origin.origin}
               fill
               className="object-cover"
+              unoptimized
             />
           ) : origin.favicon ? (
             <Favicon url={origin.favicon} className="size-16" />

--- a/apps/scan/src/app/(app)/(home)/(discover)/_components/just-added/card.tsx
+++ b/apps/scan/src/app/(app)/(home)/(discover)/_components/just-added/card.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import Link from 'next/link';
+
+import { Clock, Globe } from 'lucide-react';
+import { formatDistanceToNow } from 'date-fns';
+
+import { Card } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Badge } from '@/components/ui/badge';
+
+import { Favicon } from '@/app/(app)/_components/favicon';
+
+import { cn, decodeHtmlEntities } from '@/lib/utils';
+
+import type { RouterOutputs } from '@/trpc/client';
+
+type RecentOrigin =
+  RouterOutputs['public']['origins']['recent'][number];
+
+interface Props {
+  origin: RecentOrigin;
+}
+
+export const JustAddedCard: React.FC<Props> = ({ origin }) => {
+  const resourceCount = origin.resources.length;
+  const tags = Array.from(
+    new Set(
+      origin.resources.flatMap(r => r.tags.map(t => t.tag.name))
+    )
+  ).slice(0, 3);
+
+  const listedAgo = formatDistanceToNow(new Date(origin.createdAt), {
+    addSuffix: true,
+  });
+
+  return (
+    <Link href={`/server/${origin.id}`}>
+      <Card className="h-full flex flex-col overflow-hidden hover:border-primary transition-all duration-200 cursor-pointer group hover:-translate-y-2 hover:shadow-lg">
+        {/* Image area */}
+        <div className="relative aspect-[4/3] bg-muted/50 flex items-center justify-center overflow-hidden">
+          {origin.ogImages?.[0]?.url ? (
+            <img
+              src={origin.ogImages[0].url}
+              alt={origin.title ?? origin.origin}
+              className="w-full h-full object-cover"
+            />
+          ) : origin.favicon ? (
+            <Favicon url={origin.favicon} className="size-16" />
+          ) : (
+            <Globe className="size-16 text-muted-foreground/30" />
+          )}
+          {/* Resource count badge */}
+          <div className="absolute top-2 right-2">
+            <Badge variant="secondary" className="text-[10px] font-mono bg-background/80 backdrop-blur-sm">
+              {resourceCount} {resourceCount === 1 ? 'endpoint' : 'endpoints'}
+            </Badge>
+          </div>
+        </div>
+
+        {/* Content area */}
+        <div className="flex flex-col gap-1.5 p-3">
+          <div className="flex items-center gap-2">
+            <Favicon url={origin.favicon} className="size-4 shrink-0" />
+            <h3 className="font-semibold text-sm truncate group-hover:text-primary transition-colors">
+              {origin.title
+                ? decodeHtmlEntities(origin.title)
+                : new URL(origin.origin).hostname}
+            </h3>
+          </div>
+          <p className="text-xs text-muted-foreground line-clamp-2">
+            {origin.description
+              ? decodeHtmlEntities(origin.description)
+              : origin.origin}
+          </p>
+          <div className="flex items-center justify-between mt-0.5">
+            {tags.length > 0 ? (
+              <div className="flex gap-1 flex-wrap">
+                {tags.map(tag => (
+                  <Badge
+                    key={tag}
+                    variant="outline"
+                    className="text-[10px] px-1.5 py-0"
+                  >
+                    {tag}
+                  </Badge>
+                ))}
+              </div>
+            ) : (
+              <div />
+            )}
+            <span className="flex items-center gap-1 text-[10px] text-muted-foreground shrink-0">
+              <Clock className="size-2.5" />
+              Listed {listedAgo}
+            </span>
+          </div>
+        </div>
+      </Card>
+    </Link>
+  );
+};
+
+export const LoadingJustAddedCard = () => {
+  return (
+    <Card className="h-full flex flex-col overflow-hidden">
+      <div className="aspect-[4/3] bg-muted/50 flex items-center justify-center">
+        <Skeleton className="size-12 rounded-full" />
+      </div>
+      <div className="flex flex-col gap-1.5 p-3">
+        <div className="flex items-center gap-2">
+          <Skeleton className="size-4 rounded-full shrink-0" />
+          <Skeleton className="h-4 w-24" />
+        </div>
+        <Skeleton className="h-3 w-full" />
+        <Skeleton className="h-3 w-3/4" />
+      </div>
+    </Card>
+  );
+};

--- a/apps/scan/src/app/(app)/(home)/(discover)/_components/just-added/index.tsx
+++ b/apps/scan/src/app/(app)/(home)/(discover)/_components/just-added/index.tsx
@@ -10,7 +10,6 @@ import useEmblaCarousel from 'embla-carousel-react';
 import { WheelGesturesPlugin } from 'embla-carousel-wheel-gestures';
 
 import { Button } from '@/components/ui/button';
-import { Skeleton } from '@/components/ui/skeleton';
 import { Logo } from '@/components/logo';
 
 import { Section } from '@/app/_components/layout/page-utils';

--- a/apps/scan/src/app/(app)/(home)/(discover)/_components/just-added/index.tsx
+++ b/apps/scan/src/app/(app)/(home)/(discover)/_components/just-added/index.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import Link from 'next/link';
+
+import { ChevronLeft, ChevronRight, Plus } from 'lucide-react';
+
+import useEmblaCarousel from 'embla-carousel-react';
+import { WheelGesturesPlugin } from 'embla-carousel-wheel-gestures';
+
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Logo } from '@/components/logo';
+
+import { Section } from '@/app/_components/layout/page-utils';
+
+import { JustAddedCard, LoadingJustAddedCard } from './card';
+
+import { api } from '@/trpc/client';
+
+import { cn } from '@/lib/utils';
+
+const CARD_CLASSES = cn(
+  'flex-[0_0_70%]',
+  'sm:flex-[0_0_38%]',
+  'md:flex-[0_0_28%]',
+  'lg:flex-[0_0_22%]',
+  'min-w-0'
+);
+
+const SectionTitle = () => (
+  <div className="flex flex-col gap-1">
+    <h1 className="font-bold text-xl md:text-2xl">Just Added</h1>
+    <div className="flex items-center gap-1.5 text-muted-foreground text-sm md:text-base">
+      <span>Newest services on</span>
+      <Logo className="size-4" />
+      <span className="font-bold font-mono text-foreground">x402scan</span>
+    </div>
+  </div>
+);
+
+export const JustAddedCarousel = () => {
+  const [origins] = api.public.origins.recent.useSuspenseQuery({
+    limit: 15,
+  });
+
+  const [emblaRef, emblaApi] = useEmblaCarousel(
+    {
+      align: 'start',
+      slidesToScroll: 1,
+      dragFree: true,
+      containScroll: 'trimSnaps',
+      dragThreshold: 10,
+      watchDrag: true,
+    },
+    [WheelGesturesPlugin()]
+  );
+
+  const [canScrollPrev, setCanScrollPrev] = useState(false);
+  const [canScrollNext, setCanScrollNext] = useState(false);
+
+  const scrollPrev = useCallback(() => {
+    if (emblaApi) emblaApi.scrollPrev();
+  }, [emblaApi]);
+
+  const scrollNext = useCallback(() => {
+    if (emblaApi) emblaApi.scrollNext();
+  }, [emblaApi]);
+
+  useEffect(() => {
+    if (!emblaApi) return;
+
+    const onSelect = () => {
+      setCanScrollPrev(emblaApi.canScrollPrev());
+      setCanScrollNext(emblaApi.canScrollNext());
+    };
+
+    onSelect();
+    emblaApi.on('select', onSelect);
+    emblaApi.on('reInit', onSelect);
+
+    return () => {
+      emblaApi.off('select', onSelect);
+      emblaApi.off('reInit', onSelect);
+    };
+  }, [emblaApi]);
+
+  if (origins.length === 0) return null;
+
+  return (
+    <Section
+      title={<SectionTitle />}
+      actions={
+        <Link href="/resources/register" className="self-start">
+          <Button size="sm" className="h-9">
+            <Plus className="size-4" />
+            Add your API
+          </Button>
+        </Link>
+      }
+    >
+      <div className="overflow-hidden -mt-4" ref={emblaRef}>
+        <div className="flex gap-2 pt-4 pb-2 pl-px">
+          {origins.map(origin => (
+            <div key={origin.id} className={CARD_CLASSES}>
+              <JustAddedCard origin={origin} />
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="flex items-center justify-between gap-2 -mt-6">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={scrollPrev}
+          disabled={!canScrollPrev}
+          className={cn(
+            'size-fit md:size-fit p-1',
+            !canScrollPrev && 'invisible'
+          )}
+        >
+          <ChevronLeft className="size-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={scrollNext}
+          disabled={!canScrollNext}
+          className="size-fit md:size-fit p-1"
+        >
+          <ChevronRight className="size-4" />
+        </Button>
+      </div>
+    </Section>
+  );
+};
+
+export const LoadingJustAddedCarousel = () => {
+  return (
+    <Section
+      title={<SectionTitle />}
+    >
+      <div className="overflow-hidden">
+        <div className="flex gap-2">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className={CARD_CLASSES}>
+              <LoadingJustAddedCard />
+            </div>
+          ))}
+        </div>
+      </div>
+    </Section>
+  );
+};

--- a/apps/scan/src/app/(app)/(home)/(discover)/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/(discover)/page.tsx
@@ -7,6 +7,10 @@ import { Body, Section } from '@/app/_components/layout/page-utils';
 import { OverallStats } from '../(overview)/_components/stats';
 // import { AgentCashAnnouncementBanner } from '../_components/v2-announcement-banner';
 import { DiscoverHeading } from './_components/heading';
+import {
+  JustAddedCarousel,
+  LoadingJustAddedCarousel,
+} from './_components/just-added';
 
 import { api, HydrateClient } from '@/trpc/server';
 
@@ -43,13 +47,15 @@ export default async function DiscoverPage({
     sorting: defaultSellersSorting,
   });
 
+  void api.public.origins.recent.prefetch({ limit: 15 });
+
   return (
     <HydrateClient>
       <SellersSortingProvider initialSorting={defaultSellersSorting}>
         <TimeRangeProvider initialTimeframe={ActivityTimeframe.ThirtyDays}>
           <div>
             <DiscoverHeading />
-            <Body>
+            <Body className="pb-0">
               <DiscoverPageContent>
                 {/* <AgentCashAnnouncementBanner /> */}
                 <OverallStats
@@ -57,7 +63,7 @@ export default async function DiscoverPage({
                   initialTimeframe={ActivityTimeframe.ThirtyDays}
                 />
                 <Section
-                  title="Featured Services"
+                  title="Featured"
                   description="x402scan curated services"
                   actions={
                     <div className="flex items-center gap-2">
@@ -75,6 +81,13 @@ export default async function DiscoverPage({
                     </Suspense>
                   </ErrorBoundary>
                 </Section>
+                <ErrorBoundary
+                  fallback={null}
+                >
+                  <Suspense fallback={<LoadingJustAddedCarousel />}>
+                    <JustAddedCarousel />
+                  </Suspense>
+                </ErrorBoundary>
               </DiscoverPageContent>
             </Body>
           </div>

--- a/apps/scan/src/services/db/resources/origin.ts
+++ b/apps/scan/src/services/db/resources/origin.ts
@@ -5,7 +5,6 @@ import { scanDb } from '@x402scan/scan-db';
 import { parseX402Response } from '@/lib/x402';
 import { mixedAddressSchema, optionalChainSchema } from '@/lib/schemas';
 import { SUPPORTED_CHAINS } from '@/types/chain';
-
 import type { AcceptsNetwork, Prisma } from '@x402scan/scan-db';
 
 const SUPPORTED_ACCEPT_NETWORKS = SUPPORTED_CHAINS.map(
@@ -228,6 +227,53 @@ export const listOriginsWithResources = async (
       }),
     }))
     .filter(origin => origin.resources.length > 0);
+};
+
+export const listRecentOriginsSchema = z.object({
+  limit: z.number().optional().default(15),
+});
+
+export const listRecentOrigins = async (
+  input: z.infer<typeof listRecentOriginsSchema>
+) => {
+  const { limit } = input;
+  const acceptsWhere = getDisplayableAcceptsWhere({});
+  return await scanDb.resourceOrigin.findMany({
+    where: {
+      resources: {
+        some: {
+          deprecatedAt: null,
+          accepts: {
+            some: acceptsWhere,
+          },
+        },
+      },
+    },
+    include: {
+      resources: {
+        where: {
+          deprecatedAt: null,
+          accepts: {
+            some: acceptsWhere,
+          },
+        },
+        select: {
+          id: true,
+          resource: true,
+          tags: {
+            include: {
+              tag: true,
+            },
+          },
+        },
+      },
+      ogImages: {
+        take: 1,
+      },
+    },
+    orderBy: { createdAt: 'desc' },
+    take: limit,
+  });
 };
 
 export const searchOriginsSchema = z.object({

--- a/apps/scan/src/services/db/resources/origin.ts
+++ b/apps/scan/src/services/db/resources/origin.ts
@@ -237,7 +237,6 @@ export const listRecentOrigins = async (
   input: z.infer<typeof listRecentOriginsSchema>
 ) => {
   const { limit } = input;
-  const acceptsWhere = getDisplayableAcceptsWhere({});
   return await scanDb.resourceOrigin.findMany({
     where: {
       resources: {

--- a/apps/scan/src/services/db/resources/origin.ts
+++ b/apps/scan/src/services/db/resources/origin.ts
@@ -243,12 +243,6 @@ export const listRecentOrigins = async (
       resources: {
         some: {
           deprecatedAt: null,
-          response: {
-            isNot: null,
-          },
-          accepts: {
-            some: acceptsWhere,
-          },
         },
       },
     },
@@ -256,12 +250,6 @@ export const listRecentOrigins = async (
       resources: {
         where: {
           deprecatedAt: null,
-          response: {
-            isNot: null,
-          },
-          accepts: {
-            some: acceptsWhere,
-          },
         },
         select: {
           id: true,

--- a/apps/scan/src/services/db/resources/origin.ts
+++ b/apps/scan/src/services/db/resources/origin.ts
@@ -243,6 +243,9 @@ export const listRecentOrigins = async (
       resources: {
         some: {
           deprecatedAt: null,
+          response: {
+            isNot: null,
+          },
           accepts: {
             some: acceptsWhere,
           },
@@ -253,6 +256,9 @@ export const listRecentOrigins = async (
       resources: {
         where: {
           deprecatedAt: null,
+          response: {
+            isNot: null,
+          },
           accepts: {
             some: acceptsWhere,
           },

--- a/apps/scan/src/services/db/resources/origin.ts
+++ b/apps/scan/src/services/db/resources/origin.ts
@@ -238,18 +238,8 @@ export const listRecentOrigins = async (
 ) => {
   const { limit } = input;
   return await scanDb.resourceOrigin.findMany({
-    where: {
-      resources: {
-        some: {
-          deprecatedAt: null,
-        },
-      },
-    },
     include: {
       resources: {
-        where: {
-          deprecatedAt: null,
-        },
         select: {
           id: true,
           resource: true,

--- a/apps/scan/src/trpc/routers/public/origins.ts
+++ b/apps/scan/src/trpc/routers/public/origins.ts
@@ -7,6 +7,8 @@ import {
   listOriginsSchema,
   listOriginsWithResources,
   listOriginsWithResourcesSchema,
+  listRecentOrigins,
+  listRecentOriginsSchema,
   searchOrigins,
   searchOriginsSchema,
 } from '@/services/db/resources/origin';
@@ -35,5 +37,10 @@ export const originsRouter = createTRPCRouter({
     .input(searchOriginsSchema)
     .query(async ({ input }) => {
       return await searchOrigins(input);
+    }),
+  recent: publicProcedure
+    .input(listRecentOriginsSchema)
+    .query(async ({ input }) => {
+      return await listRecentOrigins(input);
     }),
 });


### PR DESCRIPTION
## Summary
- Adds a **"Just Added"** carousel section below Featured on the discover page, showing the 15 most recently registered x402 origins
- Each card shows OG image (favicon/globe fallback), title, description, tags, endpoint count, and relative listing time ("Listed 2 hours ago")
- Embla carousel with drag/wheel scroll, bottom pagination arrows (left arrow hidden until scrollable)
- New `listRecentOrigins` query + `api.public.origins.recent` tRPC endpoint (direct DB read, no caching — indexed query is O(1))
- Branded subtitle: "Newest services on [logo] **x402scan**" for screenshot-ability
- "Add your API" CTA button inline with section title
- Renames "Featured Services" → "Featured"

## Test plan
- [ ] Visit `/` (discover page) — "Just Added" section appears below Featured
- [ ] Cards display correct data: title, description, favicon/OG image, tags, endpoint count, listing time
- [ ] Carousel scrolls horizontally via drag, trackpad, and arrows
- [ ] Left arrow only visible after scrolling right
- [ ] Cards lift on hover without clipping
- [ ] "Add your API" button links to `/resources/register`
- [ ] Section renders correctly on mobile breakpoints
