### PR TITLE
Fix Solana x402 send challenge

### DIFF
--- a/apps/scan/src/app/api/x402/send/route.ts
+++ b/apps/scan/src/app/api/x402/send/route.ts
@@ -1,5 +1,5 @@
 import { router, solanaRouter, withCors, OPTIONS } from '@/lib/router';
-import { sendUsdcBodySchema } from '@/lib/schemas';
+import { chainSchema, sendUsdcBodySchema } from '@/lib/schemas';
 import { handleSend } from '@/app/api/x402/_handlers/send';
 import { Chain } from '@/types/chain';
 
@@ -27,15 +27,21 @@ const createSendHandler = (sendRouter: typeof router) =>
 const baseSendHandler = createSendHandler(router);
 const solanaSendHandler = createSendHandler(solanaRouter);
 
-async function getRequestedChain(req: NextRequest) {
-  const body = await req
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+async function getRequestedChain(req: NextRequest): Promise<Chain | undefined> {
+  const body: unknown = await req
     .clone()
     .json()
     .catch(() => undefined);
 
-  return typeof body === 'object' && body !== null && 'chain' in body
-    ? body.chain
-    : undefined;
+  if (!isRecord(body)) return undefined;
+
+  const chain = chainSchema.safeParse(body.chain);
+
+  return chain.success ? chain.data : undefined;
 }
 
 export const POST = withCors(async req => {

--- a/apps/scan/src/app/api/x402/send/route.ts
+++ b/apps/scan/src/app/api/x402/send/route.ts
@@ -1,11 +1,14 @@
-import { router, withCors, OPTIONS } from '@/lib/router';
+import { router, solanaRouter, withCors, OPTIONS } from '@/lib/router';
 import { sendUsdcBodySchema } from '@/lib/schemas';
 import { handleSend } from '@/app/api/x402/_handlers/send';
+import { Chain } from '@/types/chain';
+
+import type { NextRequest } from 'next/server';
 
 export { OPTIONS };
 
-export const POST = withCors(
-  router
+const createSendHandler = (sendRouter: typeof router) =>
+  sendRouter
     .route('x402/send')
     .path('x402/send')
     .paid(
@@ -19,5 +22,24 @@ export const POST = withCors(
     .method('POST')
     .body(sendUsdcBodySchema)
     .description('Send USDC to an address on Base or Solana')
-    .handler(({ body }) => Promise.resolve(handleSend(body)))
-);
+    .handler(({ body }) => Promise.resolve(handleSend(body)));
+
+const baseSendHandler = createSendHandler(router);
+const solanaSendHandler = createSendHandler(solanaRouter);
+
+async function getRequestedChain(req: NextRequest) {
+  const body = await req
+    .clone()
+    .json()
+    .catch(() => undefined);
+
+  return typeof body === 'object' && body !== null && 'chain' in body
+    ? body.chain
+    : undefined;
+}
+
+export const POST = withCors(async req => {
+  const chain = await getRequestedChain(req);
+
+  return chain === Chain.SOLANA ? solanaSendHandler(req) : baseSendHandler(req);
+});

--- a/apps/scan/src/lib/router.ts
+++ b/apps/scan/src/lib/router.ts
@@ -54,6 +54,19 @@ export const router = createRouter({
   },
 });
 
+export const solanaRouter = createRouter({
+  baseUrl: env.NEXT_PUBLIC_APP_URL,
+  payeeAddress:
+    env.X402_PAYEE_ADDRESS ?? '0x0000000000000000000000000000000000000001',
+  network: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+  discovery: {
+    title: 'x402scan',
+    version: '1.0.0',
+    description:
+      'Query indexed x402 payment data and send USDC on Base and Solana.',
+  },
+});
+
 export function withCors(
   handler: (req: NextRequest) => Promise<Response>
 ): (req: NextRequest) => Promise<Response> {


### PR DESCRIPTION
## Summary
- add a Solana x402 router configured for Solana mainnet CAIP-2
- dispatch `/api/x402/send` to the Base or Solana router based on the request body `chain` before building the payment challenge
- preserve the existing Base transfer challenge behavior

## Verification
- `pnpm --filter @x402scan/app types:check`
- local challenge probe returned Solana `Payment-Required` with `network: solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`, Solana USDC mint, and Solana `payTo`
- `npx agentcash fetch http://localhost:3001/api/x402/send -m POST -b '{"amount":1,"address":"GedsrmCHThhYpCVmxBuCVariiXXeVN8iJPtbuXDouJ3K","chain":"solana"}' --paymentNetwork solana --maxAmount 1.01 --format=json` succeeded\n- local Solana transaction: `5vhwczM7tpp8jcNhtuUv976BkdQhr6jhA6M85QUoCcc4oTyAyaeAaY2Kh95jBvszxG7hrkpNC1JGPQQ8cVWbsFiw`