### PR TITLE
Increase Solana Bitquery Trigger machine

### DIFF
--- a/sync/transfers/trigger/chains/solana/bitquery/config.ts
+++ b/sync/transfers/trigger/chains/solana/bitquery/config.ts
@@ -16,5 +16,5 @@ export const solanaChainConfig: SyncConfig = {
   buildQuery,
   transformResponse,
   enabled: true,
-  machine: 'medium-1x',
+  machine: 'large-2x',
 };


### PR DESCRIPTION
## Summary
- Increase the Solana Bitquery transfers sync Trigger.dev machine from `medium-1x` to `large-2x`

## Testing
- `pnpm --filter @x402scan/sync-transfers types:check`