### PR TITLE
fix: deduplicate OG image upserts

### DIFF
--- a/apps/scan/src/services/db/resources/origin.test.ts
+++ b/apps/scan/src/services/db/resources/origin.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const db = vi.hoisted(() => ({
+  ogImageUpsert: vi.fn(),
+  resourceOriginFindUnique: vi.fn(),
+  resourceOriginUpsert: vi.fn(),
+  transaction: vi.fn(),
+}));
+
+vi.mock('@x402scan/scan-db', () => ({
+  scanDb: {
+    $transaction: db.transaction,
+  },
+}));
+
+import { upsertOrigin } from './origin';
+
+interface MockTransactionClient {
+  ogImage: {
+    upsert: typeof db.ogImageUpsert;
+  };
+  resourceOrigin: {
+    findUnique: typeof db.resourceOriginFindUnique;
+    upsert: typeof db.resourceOriginUpsert;
+  };
+}
+
+type MockTransactionCallback = (
+  transactionClient: MockTransactionClient
+) => unknown;
+
+describe('upsertOrigin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    db.resourceOriginUpsert.mockResolvedValue({ id: 'origin-1' });
+    db.ogImageUpsert.mockResolvedValue({});
+    db.resourceOriginFindUnique.mockResolvedValue({
+      id: 'origin-1',
+      ogImages: [],
+    });
+    db.transaction.mockImplementation((callback: MockTransactionCallback) =>
+      Promise.resolve(
+        callback({
+          ogImage: {
+            upsert: db.ogImageUpsert,
+          },
+          resourceOrigin: {
+            findUnique: db.resourceOriginFindUnique,
+            upsert: db.resourceOriginUpsert,
+          },
+        })
+      )
+    );
+  });
+
+  it('upserts each OG image URL once per origin', async () => {
+    await upsertOrigin({
+      origin: 'https://example.com',
+      ogImages: [
+        {
+          url: 'https://cdn.example.com/og.png',
+          height: 100,
+          width: 200,
+          title: 'First image',
+        },
+        {
+          url: 'https://cdn.example.com/og.png',
+          height: 300,
+          width: 400,
+          title: 'Updated image',
+        },
+      ],
+    });
+
+    expect(db.ogImageUpsert).toHaveBeenCalledTimes(1);
+    expect(db.ogImageUpsert).toHaveBeenCalledWith({
+      where: {
+        originId_url: {
+          originId: 'origin-1',
+          url: 'https://cdn.example.com/og.png',
+        },
+      },
+      update: {
+        description: undefined,
+        height: 300,
+        title: 'Updated image',
+        width: 400,
+      },
+      create: {
+        description: undefined,
+        height: 300,
+        originId: 'origin-1',
+        title: 'Updated image',
+        url: 'https://cdn.example.com/og.png',
+        width: 400,
+      },
+    });
+  });
+});

--- a/apps/scan/src/services/db/resources/origin.ts
+++ b/apps/scan/src/services/db/resources/origin.ts
@@ -75,8 +75,14 @@ export const upsertOrigin = async (
 
     const originId = upsertedOrigin.id;
 
+    const uniqueOgImages = [
+      ...new Map(
+        origin.ogImages.map(ogImage => [ogImage.url, ogImage])
+      ).values(),
+    ];
+
     await Promise.all(
-      origin.ogImages.map(({ url, height, width, title, description }) =>
+      uniqueOgImages.map(({ url, height, width, title, description }) =>
         tx.ogImage.upsert({
           where: {
             originId_url: {


### PR DESCRIPTION
Fixes #287.

## Summary
- deduplicate scraped OG images by URL before running batched upserts
- add a regression test for duplicate og:image URLs within the same origin

## Tests
- pnpm --filter @x402scan/app test:run src/services/db/resources/origin.test.ts
- pnpm --dir apps/scan exec eslint src/services/db/resources/origin.test.ts --max-warnings 0
- pnpm --filter @x402scan/app format:check
- git diff --check