### PR TITLE
Fix HTML entity and UTF-8 mojibake decoding

### DIFF
--- a/apps/scan/src/app/(app)/(home)/(overview)/_components/sellers/featured-columns.tsx
+++ b/apps/scan/src/app/(app)/(home)/(overview)/_components/sellers/featured-columns.tsx
@@ -30,7 +30,7 @@ import {
 import { Favicon } from '@/app/(app)/_components/favicon';
 
 import {
-  decodeHtmlEntities,
+  cleanExternalText,
   formatAddress,
   formatCompactAgo,
 } from '@/lib/utils';
@@ -257,10 +257,10 @@ const ServerCell: React.FC<{ item: FeaturedServiceItem }> = ({ item }) => {
 
   const hostname = new URL(origin.origin).hostname;
   const rawTitle = origin.title?.trim();
-  const title = rawTitle ? decodeHtmlEntities(rawTitle) : hostname;
+  const title = rawTitle ? cleanExternalText(rawTitle) : hostname;
   const rawDescription = origin.description?.trim();
   const description = rawDescription
-    ? decodeHtmlEntities(rawDescription)
+    ? cleanExternalText(rawDescription)
     : null;
   const showHostnameLine = title !== hostname;
 

--- a/apps/scan/src/app/(app)/(home)/resources/(overview)/_components/carousel/origin-card/index.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/(overview)/_components/carousel/origin-card/index.tsx
@@ -16,7 +16,7 @@ import { Favicon } from '@/app/(app)/_components/favicon';
 import { FooterStat, LoadingFooterStat } from './stat';
 
 import { convertTokenAmount } from '@/lib/token';
-import { decodeHtmlEntities } from '@/lib/utils';
+import { cleanExternalText } from '@/lib/utils';
 
 import type { RouterOutputs } from '@/trpc/client';
 
@@ -41,7 +41,7 @@ export const OriginCard: React.FC<Props> = ({ origin }) => {
               <div className="flex-1 overflow-hidden">
                 <CardTitle className="font-bold text-sm md:text-base truncate group-hover:text-primary transition-colors">
                   {originWithMetadata.title
-                    ? decodeHtmlEntities(originWithMetadata.title)
+                    ? cleanExternalText(originWithMetadata.title)
                     : 'No Title'}
                 </CardTitle>
                 <p className="text-[10px] md:text-xs text-muted-foreground truncate font-mono">
@@ -51,7 +51,7 @@ export const OriginCard: React.FC<Props> = ({ origin }) => {
             </div>
             <CardDescription className="text-muted-foreground text-[10px] md:text-xs line-clamp-2">
               {originWithMetadata?.description
-                ? decodeHtmlEntities(originWithMetadata.description)
+                ? cleanExternalText(originWithMetadata.description)
                 : 'No description'}
             </CardDescription>
           </CardHeader>

--- a/apps/scan/src/app/(app)/@breadcrumbs/server/[id]/layout.tsx
+++ b/apps/scan/src/app/(app)/@breadcrumbs/server/[id]/layout.tsx
@@ -4,7 +4,7 @@ import { Breadcrumb } from '../../_components/breadcrumb';
 
 import { Separator } from '../../_components/separator';
 import { api } from '@/trpc/server';
-import { decodeHtmlEntities } from '@/lib/utils';
+import { cleanExternalText } from '@/lib/utils';
 import { notFound } from 'next/navigation';
 
 export default async function OriginLayout({
@@ -31,7 +31,7 @@ export default async function OriginLayout({
         image={origin.favicon}
         name={
           origin.title
-            ? decodeHtmlEntities(origin.title)
+            ? cleanExternalText(origin.title)
             : new URL(origin.origin).hostname
         }
         Fallback={Wallet}

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
@@ -22,7 +22,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import { cn, decodeHtmlEntities } from '@/lib/utils';
+import { cleanExternalText, cn } from '@/lib/utils';
 
 import { Favicon } from '@/app/(app)/_components/favicon';
 import { ResourceCard } from '@/app/(app)/_components/resources/resource-card';
@@ -1490,7 +1490,7 @@ function OriginPreviewCard({
                     !origin.title && 'opacity-60'
                   )}
                 >
-                  {origin.title ? decodeHtmlEntities(origin.title) : 'No Title'}
+                  {origin.title ? cleanExternalText(origin.title) : 'No Title'}
                 </h3>
                 <p
                   className={cn(
@@ -1499,7 +1499,7 @@ function OriginPreviewCard({
                   )}
                 >
                   {origin.description
-                    ? decodeHtmlEntities(origin.description)
+                    ? cleanExternalText(origin.description)
                     : 'No Description'}
                 </p>
               </div>
@@ -1512,7 +1512,7 @@ function OriginPreviewCard({
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={origin.ogImages[0]!.url}
-            alt={origin.title ? decodeHtmlEntities(origin.title) : ''}
+            alt={origin.title ? cleanExternalText(origin.title) : ''}
             className="rounded-md max-h-24"
           />
         </div>

--- a/apps/scan/src/app/(app)/_components/origins.tsx
+++ b/apps/scan/src/app/(app)/_components/origins.tsx
@@ -10,7 +10,7 @@ import {
 import { Address, Addresses } from '@/components/ui/address';
 
 import { Favicon } from '@/app/(app)/_components/favicon';
-import { decodeHtmlEntities } from '@/lib/utils';
+import { cleanExternalText } from '@/lib/utils';
 
 import type { ResourceOrigin } from '@x402scan/scan-db/types';
 import type { MixedAddress } from '@/types/address';
@@ -89,7 +89,7 @@ export const Origins: React.FC<Props> = ({
                 {origins.slice(1).map(origin => (
                   <li key={origin.id}>
                     {origin.title
-                      ? decodeHtmlEntities(origin.title)
+                      ? cleanExternalText(origin.title)
                       : new URL(origin.origin).hostname}
                   </li>
                 ))}

--- a/apps/scan/src/app/(app)/_components/resources/origin.tsx
+++ b/apps/scan/src/app/(app)/_components/resources/origin.tsx
@@ -2,7 +2,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
 import { Favicon } from '@/app/(app)/_components/favicon';
 
-import { cn, decodeHtmlEntities } from '@/lib/utils';
+import { cleanExternalText, cn } from '@/lib/utils';
 
 import type { OgImage, ResourceOrigin } from '@x402scan/scan-db/types';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -55,7 +55,7 @@ export const OriginCard: React.FC<Props> = ({
                     !origin.title && 'opacity-60'
                   )}
                 >
-                  {origin.title ? decodeHtmlEntities(origin.title) : 'No Title'}
+                  {origin.title ? cleanExternalText(origin.title) : 'No Title'}
                 </h3>
                 <p
                   className={cn(
@@ -64,7 +64,7 @@ export const OriginCard: React.FC<Props> = ({
                   )}
                 >
                   {origin.description
-                    ? decodeHtmlEntities(origin.description)
+                    ? cleanExternalText(origin.description)
                     : 'No Description'}
                 </p>
               </div>
@@ -79,7 +79,7 @@ export const OriginCard: React.FC<Props> = ({
             src={origin.ogImages[0]!.url}
             alt={
               origin.ogImages[0]!.title
-                ? decodeHtmlEntities(origin.ogImages[0]!.title)
+                ? cleanExternalText(origin.ogImages[0]!.title)
                 : ''
             }
             className="rounded-md max-h-24"

--- a/apps/scan/src/app/(app)/admin/resource-search/_components/table/columns.tsx
+++ b/apps/scan/src/app/(app)/admin/resource-search/_components/table/columns.tsx
@@ -3,7 +3,7 @@ import { Badge } from '@/components/ui/badge';
 import { Avatar } from '@/components/ui/avatar';
 import { Globe, TrendingUp, Zap, CheckCircle, Filter } from 'lucide-react';
 import type { FilteredSearchResult } from '@/services/resource-search/types';
-import { cleanExternalText, decodeHtmlEntities } from '@/lib/utils';
+import { cleanExternalText } from '@/lib/utils';
 import { HeaderCell } from '@/components/ui/data-table/header-cell';
 import { ResourceSearchSortingContext } from '@/app/(app)/_contexts/sorting/resource-search/context';
 
@@ -96,7 +96,7 @@ export const createColumns = (): ExtendedColumnDef<FilteredSearchResult>[] => [
       const origin = row.original.origin;
       const favicon = origin.favicon;
       const title = origin.title
-        ? decodeHtmlEntities(origin.title)
+        ? cleanExternalText(origin.title)
         : origin.origin;
 
       return (

--- a/apps/scan/src/app/(app)/admin/resource-search/_components/table/columns.tsx
+++ b/apps/scan/src/app/(app)/admin/resource-search/_components/table/columns.tsx
@@ -3,7 +3,7 @@ import { Badge } from '@/components/ui/badge';
 import { Avatar } from '@/components/ui/avatar';
 import { Globe, TrendingUp, Zap, CheckCircle, Filter } from 'lucide-react';
 import type { FilteredSearchResult } from '@/services/resource-search/types';
-import { decodeHtmlEntities } from '@/lib/utils';
+import { cleanExternalText, decodeHtmlEntities } from '@/lib/utils';
 import { HeaderCell } from '@/components/ui/data-table/header-cell';
 import { ResourceSearchSortingContext } from '@/app/(app)/_contexts/sorting/resource-search/context';
 
@@ -117,9 +117,10 @@ export const createColumns = (): ExtendedColumnDef<FilteredSearchResult>[] => [
     size: 65,
     cell: ({ row }) => {
       const accepts = row.original.accepts;
-      const description =
+      const description = cleanExternalText(
         accepts.find(accept => accept.description)?.description ??
-        'No description available';
+          'No description available'
+      );
 
       return (
         <div className="min-h-[100px] py-2">

--- a/apps/scan/src/app/(app)/admin/tags/_components/columns.tsx
+++ b/apps/scan/src/app/(app)/admin/tags/_components/columns.tsx
@@ -5,7 +5,7 @@ import { Globe, Hash, Calendar, Tag } from 'lucide-react';
 import { Skeleton } from '@/components/ui/skeleton';
 import { HeaderCell } from '@/components/ui/data-table/header-cell';
 import { Checkbox } from '@/components/ui/checkbox';
-import { formatCompactAgo } from '@/lib/utils';
+import { cleanExternalText, formatCompactAgo } from '@/lib/utils';
 
 import { ResourcesSortingContext } from '@/app/(app)/_contexts/sorting/resource-tags/context';
 
@@ -65,10 +65,11 @@ export const createColumns = (
       <HeaderCell Icon={Hash} label="Description" className="mx-auto" />
     ),
     cell: ({ row }) => {
-      const description =
+      const description = cleanExternalText(
         row.original.accepts.find(
           (accept: { description?: string }) => accept.description
-        )?.description ?? 'N/A';
+        )?.description ?? 'N/A'
+      );
       return (
         <div className="text-center text-xs text-muted-foreground truncate max-w-[200px]">
           {description}

--- a/apps/scan/src/app/(app)/composer/(home)/_components/tools/columns.tsx
+++ b/apps/scan/src/app/(app)/composer/(home)/_components/tools/columns.tsx
@@ -11,7 +11,7 @@ import {
 
 import { Skeleton } from '@/components/ui/skeleton';
 
-import { formatCompactAgo } from '@/lib/utils';
+import { cleanExternalText, formatCompactAgo } from '@/lib/utils';
 
 import { HeaderCell } from '@/components/ui/data-table/header-cell';
 
@@ -40,10 +40,10 @@ export const columns: ExtendedColumnDef<ColumnType>[] = [
             {row.original.resource}
           </p>
           <p className="text-[10px] md:text-xs text-muted-foreground w-full break-words whitespace-normal line-clamp-2">
-            {
+            {cleanExternalText(
               row.original.accepts.find(accept => accept.description)
-                ?.description
-            }
+                ?.description ?? ''
+            )}
           </p>
         </div>
       </div>

--- a/apps/scan/src/app/(app)/composer/agent/[id]/_components/tools/card.tsx
+++ b/apps/scan/src/app/(app)/composer/agent/[id]/_components/tools/card.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/components/ui/card';
 
 import { Favicon } from '@/app/(app)/_components/favicon';
+import { cleanExternalText } from '@/lib/utils';
 
 import { formatTokenAmount } from '@/lib/token';
 
@@ -47,7 +48,10 @@ export const ToolCard: React.FC<Props> = ({ resource }) => {
           </div>
         </div>
         <CardDescription className="line-clamp-2 text-xs md:text-sm">
-          {resource.accepts.find(accept => accept.description)?.description}
+          {cleanExternalText(
+            resource.accepts.find(accept => accept.description)?.description ??
+              ''
+          )}
         </CardDescription>
       </CardHeader>
     </Card>

--- a/apps/scan/src/app/(app)/server/[id]/(overview)/_components/header/agentcash-cta.tsx
+++ b/apps/scan/src/app/(app)/server/[id]/(overview)/_components/header/agentcash-cta.tsx
@@ -4,7 +4,7 @@ import type { RouterOutputs } from '@/trpc/client';
 import { Code } from '@/components/ui/code';
 import { CopyButton } from '@/components/ui/copy-button';
 import { Skeleton } from '@/components/ui/skeleton';
-import { decodeHtmlEntities } from '@/lib/utils';
+import { cleanExternalText } from '@/lib/utils';
 import Image from 'next/image';
 
 interface Props {
@@ -20,7 +20,7 @@ export const AgentCashCTA: React.FC<Props> = ({ origin }) => {
         <span>
           Quickly try{' '}
           {origin.title
-            ? decodeHtmlEntities(origin.title)
+            ? cleanExternalText(origin.title)
             : new URL(origin.origin).hostname}{' '}
           with
         </span>

--- a/apps/scan/src/app/(app)/server/[id]/(overview)/_components/header/agentcash-cta.tsx
+++ b/apps/scan/src/app/(app)/server/[id]/(overview)/_components/header/agentcash-cta.tsx
@@ -4,6 +4,7 @@ import type { RouterOutputs } from '@/trpc/client';
 import { Code } from '@/components/ui/code';
 import { CopyButton } from '@/components/ui/copy-button';
 import { Skeleton } from '@/components/ui/skeleton';
+import { decodeHtmlEntities } from '@/lib/utils';
 import Image from 'next/image';
 
 interface Props {
@@ -17,7 +18,11 @@ export const AgentCashCTA: React.FC<Props> = ({ origin }) => {
     <div className="w-fit max-w-full flex flex-col gap-1.5">
       <p className="flex flex-wrap items-center gap-x-1 gap-y-1 text-sm font-semibold">
         <span>
-          Quickly try {origin.title ?? new URL(origin.origin).hostname} with
+          Quickly try{' '}
+          {origin.title
+            ? decodeHtmlEntities(origin.title)
+            : new URL(origin.origin).hostname}{' '}
+          with
         </span>
         <a
           href="https://agentcash.dev"

--- a/apps/scan/src/app/(app)/server/[id]/(overview)/_components/header/index.tsx
+++ b/apps/scan/src/app/(app)/server/[id]/(overview)/_components/header/index.tsx
@@ -9,7 +9,7 @@ import { Avatar } from '@/components/ui/avatar';
 
 import { OriginStats, LoadingOriginStats } from './stats';
 
-import { cn, decodeHtmlEntities } from '@/lib/utils';
+import { cleanExternalText, cn } from '@/lib/utils';
 
 import { HeaderButtons, LoadingHeaderButtons } from './buttons';
 
@@ -36,7 +36,7 @@ export const HeaderCard: React.FC<Props> = ({ origin }) => {
             <div className="flex items-center gap-2 min-w-0">
               <h1 className="text-xl md:text-3xl font-bold wrap-break-word line-clamp-2 min-w-0">
                 {origin.title
-                  ? decodeHtmlEntities(origin.title)
+                  ? cleanExternalText(origin.title)
                   : new URL(origin.origin).hostname}
               </h1>
               {origin.hasX402V2Resource && (
@@ -62,7 +62,7 @@ export const HeaderCard: React.FC<Props> = ({ origin }) => {
               )}
             >
               {origin.description
-                ? decodeHtmlEntities(origin.description)
+                ? cleanExternalText(origin.description)
                 : 'No Description'}
             </p>
           </div>

--- a/apps/scan/src/app/(app)/server/[id]/layout.tsx
+++ b/apps/scan/src/app/(app)/server/[id]/layout.tsx
@@ -1,6 +1,6 @@
 import { Nav } from '@/app/(app)/_components/layout/nav';
 import { env } from '@/env';
-import { decodeHtmlEntities } from '@/lib/utils';
+import { cleanExternalText } from '@/lib/utils';
 import { api } from '@/trpc/server';
 import type { Metadata } from 'next';
 
@@ -34,9 +34,9 @@ export async function generateMetadata({
     return { title: 'Server not found' };
   }
 
-  const title = origin.title ? decodeHtmlEntities(origin.title) : origin.origin;
+  const title = origin.title ? cleanExternalText(origin.title) : origin.origin;
   const description = origin.description
-    ? decodeHtmlEntities(origin.description)
+    ? cleanExternalText(origin.description)
     : `Explore ${title} on x402scan`;
 
   const imageUrl = origin.ogImages?.[0]?.url

--- a/apps/scan/src/components/ai-elements/tool.tsx
+++ b/apps/scan/src/components/ai-elements/tool.tsx
@@ -12,6 +12,7 @@ import { Loading } from '@/components/ui/loading';
 import { Skeleton } from '@/components/ui/skeleton';
 
 import { Favicon } from '@/app/(app)/_components/favicon';
+import { cleanExternalText } from '@/lib/utils';
 
 import { JsonViewer } from './json-viewer';
 
@@ -94,10 +95,10 @@ const ToolHeader = ({
             isLoading={isResourceLoading ?? state === 'input-streaming'}
             component={resource => (
               <span className="text-[10px] md:text-xs text-muted-foreground text-left">
-                {
+                {cleanExternalText(
                   resource.accepts.find(accept => accept.description)
-                    ?.description
-                }
+                    ?.description ?? ''
+                )}
               </span>
             )}
             loadingComponent={<Skeleton className="h-[12px] my-[2px] w-32" />}

--- a/apps/scan/src/lib/utils.test.ts
+++ b/apps/scan/src/lib/utils.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import {
+  decodeHtmlEntities,
+  repairMojibake,
+  cleanExternalText,
+} from './utils';
+
+describe('decodeHtmlEntities', () => {
+  it('decodes named entities', () => {
+    expect(decodeHtmlEntities('Developers &amp; AI Agents')).toBe(
+      'Developers & AI Agents'
+    );
+    expect(decodeHtmlEntities('&lt;script&gt;')).toBe('<script>');
+    expect(decodeHtmlEntities('He said &quot;hello&quot;')).toBe(
+      'He said "hello"'
+    );
+    expect(decodeHtmlEntities('it&#39;s')).toBe("it's");
+    expect(decodeHtmlEntities('it&apos;s')).toBe("it's");
+  });
+
+  it('decodes numeric decimal entities', () => {
+    expect(decodeHtmlEntities('&#169; 2024')).toBe('© 2024');
+    expect(decodeHtmlEntities('&#8212; dash')).toBe('— dash');
+  });
+
+  it('decodes numeric hex entities', () => {
+    expect(decodeHtmlEntities('&#x27;')).toBe("'");
+    expect(decodeHtmlEntities('&#xA9;')).toBe('©');
+    expect(decodeHtmlEntities('&#x2014;')).toBe('—');
+  });
+
+  it('passes through strings without entities', () => {
+    expect(decodeHtmlEntities('hello world')).toBe('hello world');
+    expect(decodeHtmlEntities('')).toBe('');
+  });
+
+  it('handles multiple entities in one string', () => {
+    expect(
+      decodeHtmlEntities(
+        'Orbis &mdash; API Marketplace for Developers &amp; AI Agents'
+      )
+    ).toBe('Orbis &mdash; API Marketplace for Developers & AI Agents');
+    // Note: &mdash; is not in our entity list, so it stays as-is
+  });
+
+  it('decodes the Orbis title from scraper', () => {
+    expect(
+      decodeHtmlEntities(
+        'Orbis — API Marketplace for Developers &amp; AI Agents'
+      )
+    ).toBe('Orbis — API Marketplace for Developers & AI Agents');
+  });
+});
+
+describe('repairMojibake', () => {
+  it('repairs UTF-8 middle dot decoded as Latin-1', () => {
+    // · (U+00B7) in UTF-8 is 0xC2 0xB7, decoded as Latin-1 gives Â·
+    expect(repairMojibake('\u00c2\u00b7')).toBe('·');
+  });
+
+  it('repairs UTF-8 em dash decoded as Latin-1', () => {
+    // — (U+2014) in UTF-8 is 0xE2 0x80 0x94, decoded as Latin-1 gives â€"
+    expect(repairMojibake('\u00e2\u0080\u0094')).toBe('—');
+  });
+
+  it('repairs UTF-8 en dash decoded as Latin-1', () => {
+    expect(repairMojibake('\u00e2\u0080\u0093')).toBe('–');
+  });
+
+  it('repairs smart quotes', () => {
+    expect(repairMojibake('\u00e2\u0080\u009c')).toBe('\u201c'); // "
+    expect(repairMojibake('\u00e2\u0080\u009d')).toBe('\u201d'); // "
+    expect(repairMojibake('\u00e2\u0080\u0099')).toBe('\u2019'); // '
+  });
+
+  it('repairs the OATP description pattern', () => {
+    // Simulate: original "OATP · token_risk_scan —" got mojibake'd
+    const original = 'OATP \u00b7 token_risk_scan \u2014 Analyze';
+    const mojibake = Buffer.from(original, 'utf-8').toString('latin1');
+    expect(repairMojibake(mojibake)).toBe(original);
+  });
+
+  it('passes through plain ASCII', () => {
+    expect(repairMojibake('hello world')).toBe('hello world');
+    expect(repairMojibake('')).toBe('');
+  });
+
+  it('passes through strings with chars above Latin-1 range', () => {
+    // Strings with codepoints > 0xFF should not be touched
+    const withEmoji = 'hello \ud83d\ude00';
+    expect(repairMojibake(withEmoji)).toBe(withEmoji);
+
+    const withCjk = 'hello \u4e16\u754c';
+    expect(repairMojibake(withCjk)).toBe(withCjk);
+  });
+
+  it('does not corrupt legitimate accented text', () => {
+    // Single high bytes that don't form valid UTF-8 should be left alone
+    expect(repairMojibake('caf\u00e9')).toBe('caf\u00e9');
+    expect(repairMojibake('na\u00efve')).toBe('na\u00efve');
+    expect(repairMojibake('\u00fcber')).toBe('\u00fcber');
+    expect(repairMojibake('r\u00e9sum\u00e9')).toBe('r\u00e9sum\u00e9');
+  });
+
+  it('is idempotent', () => {
+    const original = 'OATP \u00b7 token_risk_scan \u2014';
+    const mojibake = Buffer.from(original, 'utf-8').toString('latin1');
+    const repaired = repairMojibake(mojibake);
+    expect(repairMojibake(repaired)).toBe(repaired);
+  });
+});
+
+describe('cleanExternalText', () => {
+  it('handles mojibake + HTML entities together', () => {
+    // Simulate a description with both issues: mojibake'd unicode AND &amp;
+    const mojibakeWithEntity = Buffer.from(
+      'Token \u00b7 scan \u2014 mint',
+      'utf-8'
+    ).toString('latin1');
+    const input = mojibakeWithEntity + ' &amp; freeze';
+    expect(cleanExternalText(input)).toBe('Token \u00b7 scan \u2014 mint & freeze');
+  });
+
+  it('handles only HTML entities', () => {
+    expect(cleanExternalText('Developers &amp; AI Agents')).toBe(
+      'Developers & AI Agents'
+    );
+  });
+
+  it('handles only mojibake', () => {
+    const mojibake = Buffer.from('hello \u00b7 world', 'utf-8').toString(
+      'latin1'
+    );
+    expect(cleanExternalText(mojibake)).toBe('hello \u00b7 world');
+  });
+
+  it('passes through clean text', () => {
+    expect(cleanExternalText('hello world')).toBe('hello world');
+    expect(cleanExternalText('')).toBe('');
+  });
+});

--- a/apps/scan/src/lib/utils.ts
+++ b/apps/scan/src/lib/utils.ts
@@ -117,6 +117,37 @@ export const decodeHtmlEntities = (str: string): string =>
     return match;
   });
 
+/**
+ * Repairs UTF-8 mojibake — text where UTF-8 bytes were decoded as Latin-1.
+ * e.g. "Â·" → "·", "â€"" → "—"
+ *
+ * Re-encodes the string as Latin-1 bytes and decodes as UTF-8. Falls back
+ * to the original string when the result isn't valid UTF-8 or the input
+ * contains characters outside the Latin-1 range.
+ */
+export const repairMojibake = (str: string): string => {
+  if (!/[\u0080-\u00ff]/.test(str)) return str;
+  try {
+    const bytes = new Uint8Array(str.length);
+    for (let i = 0; i < str.length; i++) {
+      const code = str.charCodeAt(i);
+      if (code > 0xff) return str;
+      bytes[i] = code;
+    }
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    return str;
+  }
+};
+
+/**
+ * Cleans a description from an external source by repairing mojibake
+ * and decoding HTML entities. Use for any user-facing description that
+ * originates from scraped HTML or x402 response data.
+ */
+export const cleanExternalText = (str: string): string =>
+  decodeHtmlEntities(repairMojibake(str));
+
 export const safeParseJson = <T>(
   value: string | null | undefined,
   fallback: T

--- a/apps/scan/src/lib/x402/index.ts
+++ b/apps/scan/src/lib/x402/index.ts
@@ -15,6 +15,7 @@ import type { DiscoveryExtension } from '@x402/extensions/bazaar';
 import { decodePaymentRequiredHeader } from '@x402/core/http';
 import { ChainIdToNetwork } from './chain-mapping';
 import type { ParseResult } from './shared';
+import { cleanExternalText } from '@/lib/utils';
 
 export type OutputSchema = OutputSchemaV1;
 export type InputSchema = OutputSchema['input'];
@@ -265,14 +266,19 @@ export function isV2Response(data: unknown): data is X402ResponseV2 {
  * NOTE(shafu): get description from a parsed x402 response.
  * V1: description is in accepts[].description
  * V2: description is in resource.description
+ *
+ * Applies mojibake repair (UTF-8 bytes misread as Latin-1) and HTML entity
+ * decoding since descriptions come from external servers with inconsistent
+ * encoding.
  */
 export function getDescription(
   response: ParsedX402Response
 ): string | undefined {
-  if (isV2Response(response)) {
-    return response.resource?.description;
-  }
-  return response.accepts?.find(a => a.description)?.description;
+  const raw = isV2Response(response)
+    ? response.resource?.description
+    : response.accepts?.find(a => a.description)?.description;
+  if (!raw) return raw;
+  return cleanExternalText(raw);
 }
 
 export async function extractX402Data(response: Response): Promise<unknown> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1009,6 +1009,8 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
+  packages/internal/databases/scan/generated/client: {}
+
   packages/internal/databases/transfers:
     dependencies:
       '@neondatabase/serverless':
@@ -1054,6 +1056,8 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+
+  packages/internal/databases/transfers/generated/client: {}
 
   packages/internal/neverthrow:
     dependencies:
@@ -2603,183 +2607,155 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -3060,28 +3036,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.6':
     resolution: {integrity: sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.6':
     resolution: {integrity: sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.6':
     resolution: {integrity: sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.6':
     resolution: {integrity: sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==}
@@ -3600,49 +3572,41 @@ packages:
     resolution: {integrity: sha512-xlMh4gNtplNQEwuF5icm69udC7un0WyzT5ywOeHrPMEsghKnLjXok2wZgAA7ocTm9+JsI+nVXIQa5XO1x+HPQg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.16.2':
     resolution: {integrity: sha512-OZs33QTMi0xmHv/4P0+RAKXJTBk7UcMH5tpTaCytWRXls/DGaJ48jOHmriQGK2YwUqXl+oneuNyPOUO0obJ+Hg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.16.2':
     resolution: {integrity: sha512-UVyuhaV32dJGtF6fDofOcBstg9JwB2Jfnjfb8jGlu3xcG+TsubHRhuTwQ6JZ1sColNT1nMxBiu7zdKUEZi1kwg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.16.2':
     resolution: {integrity: sha512-YZZS0yv2q5nE1uL/Fk4Y7m9018DSEmDNSG8oJzy1TJjA1jx5HL52hEPxi98XhU6OYhSO/vC1jdkJeE8TIHugug==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.16.2':
     resolution: {integrity: sha512-9VYuypwtx4kt1lUcwJAH4dPmgJySh4/KxtAPdRoX2BTaZxVm/yEXHq0mnl/8SEarjzMvXKbf7Cm6UBgptm3DZw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.16.2':
     resolution: {integrity: sha512-3gbwQ+xlL5gpyzgSDdC8B4qIM4mZaPDLaFOi3c/GV7CqIdVJc5EZXW4V3T6xwtPBOpXPXfqQLbhTnUD4SqwJtA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.16.2':
     resolution: {integrity: sha512-m0WcK0j54tSwWa+hQaJMScZdWneqE7xixp/vpFqlkbhuKW9dRHykPAFvSYg1YJ3MJgu9ZzVNpYHhPKJiEQq57Q==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.16.2':
     resolution: {integrity: sha512-ZjUm3w96P2t47nWywGwj1A2mAVBI/8IoS7XHhcogWCfXnEI3M6NPIRQPYAZW4s5/u3u6w1uPtgOwffj2XIOb/g==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.16.2':
     resolution: {integrity: sha512-OFVQ2x3VenTp13nIl6HcQ/7dmhFmM9dg2EjKfHcOtYfrVLQdNR6THFU7GkMdmc8DdY1zLUeilHwBIsyxv5hkwQ==}
@@ -4394,67 +4358,56 @@ packages:
     resolution: {integrity: sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.52.5':
     resolution: {integrity: sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.52.5':
     resolution: {integrity: sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.52.5':
     resolution: {integrity: sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.52.5':
     resolution: {integrity: sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.52.5':
     resolution: {integrity: sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.52.5':
     resolution: {integrity: sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.52.5':
     resolution: {integrity: sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.52.5':
     resolution: {integrity: sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.52.5':
     resolution: {integrity: sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.52.5':
     resolution: {integrity: sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.52.5':
     resolution: {integrity: sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==}
@@ -5552,28 +5505,24 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.10':
     resolution: {integrity: sha512-4uAHO3nbfbrTcmO/9YcVweTQdx5fN3l7ewwl5AEK4yoC4wXmoBTEPHAVdKNe4r9+xrTgd4BgyPsy0409OjjlMw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.10':
     resolution: {integrity: sha512-W0h9ONNw1pVIA0cN7wtboOSTl4Jk3tHq+w2cMPQudu9/+3xoCxpFb9ZdehwCAk29IsvdWzGzY6P7dDVTyFwoqg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.10':
     resolution: {integrity: sha512-XQNZlLZB62S8nAbw7pqoqwy91Ldy2RpaMRqdRN3T+tAg6Xg6FywXRKCsLh6IQOadr4p1+lGnqM/Wn35z5a/0Vw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.10':
     resolution: {integrity: sha512-qnAGrRv5Nj/DATxAmCnJQRXXQqnJwR0trxLndhoHoxGci9MuguNIjWahS0gw8YZFjgTinbTxOwzatkoySihnmw==}
@@ -5686,28 +5635,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.16':
     resolution: {integrity: sha512-H81UXMa9hJhWhaAUca6bU2wm5RRFpuHImrwXBUvPbYb+3jo32I9VIwpOX6hms0fPmA6f2pGVlybO6qU8pF4fzQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.16':
     resolution: {integrity: sha512-ZGHQxDtFC2/ruo7t99Qo2TTIvOERULPl5l0K1g0oK6b5PGqjYMga+FcY1wIUnrUxY56h28FxybtDEla+ICOyew==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.16':
     resolution: {integrity: sha512-Oi1tAaa0rcKf1Og9MzKeINZzMLPbhxvm7rno5/zuP1WYmpiG0bEHq4AcRUiG2165/WUzvxkW4XDYCscZWbTLZw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.16':
     resolution: {integrity: sha512-B01u/b8LteGRwucIBmCQ07FVXLzImWESAIMcUU6nvFt/tYsQ6IHz8DmZ5KtvmwxD+iTYBtM1xwoGXswnlu9v0Q==}
@@ -6237,49 +6182,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -9224,28 +9161,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -14271,7 +14204,7 @@ snapshots:
       debug: 4.4.3(supports-color@10.2.2)
       lodash: 4.17.21
       pony-cause: 2.1.11
-      semver: 7.7.4
+      semver: 7.7.3
       uuid: 9.0.1
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1009,8 +1009,6 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
-  packages/internal/databases/scan/generated/client: {}
-
   packages/internal/databases/transfers:
     dependencies:
       '@neondatabase/serverless':
@@ -1056,8 +1054,6 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
-
-  packages/internal/databases/transfers/generated/client: {}
 
   packages/internal/neverthrow:
     dependencies:
@@ -2607,155 +2603,183 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -3036,24 +3060,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.6':
     resolution: {integrity: sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.6':
     resolution: {integrity: sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.6':
     resolution: {integrity: sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.6':
     resolution: {integrity: sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==}
@@ -3572,41 +3600,49 @@ packages:
     resolution: {integrity: sha512-xlMh4gNtplNQEwuF5icm69udC7un0WyzT5ywOeHrPMEsghKnLjXok2wZgAA7ocTm9+JsI+nVXIQa5XO1x+HPQg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.16.2':
     resolution: {integrity: sha512-OZs33QTMi0xmHv/4P0+RAKXJTBk7UcMH5tpTaCytWRXls/DGaJ48jOHmriQGK2YwUqXl+oneuNyPOUO0obJ+Hg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.16.2':
     resolution: {integrity: sha512-UVyuhaV32dJGtF6fDofOcBstg9JwB2Jfnjfb8jGlu3xcG+TsubHRhuTwQ6JZ1sColNT1nMxBiu7zdKUEZi1kwg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.16.2':
     resolution: {integrity: sha512-YZZS0yv2q5nE1uL/Fk4Y7m9018DSEmDNSG8oJzy1TJjA1jx5HL52hEPxi98XhU6OYhSO/vC1jdkJeE8TIHugug==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.16.2':
     resolution: {integrity: sha512-9VYuypwtx4kt1lUcwJAH4dPmgJySh4/KxtAPdRoX2BTaZxVm/yEXHq0mnl/8SEarjzMvXKbf7Cm6UBgptm3DZw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.16.2':
     resolution: {integrity: sha512-3gbwQ+xlL5gpyzgSDdC8B4qIM4mZaPDLaFOi3c/GV7CqIdVJc5EZXW4V3T6xwtPBOpXPXfqQLbhTnUD4SqwJtA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.16.2':
     resolution: {integrity: sha512-m0WcK0j54tSwWa+hQaJMScZdWneqE7xixp/vpFqlkbhuKW9dRHykPAFvSYg1YJ3MJgu9ZzVNpYHhPKJiEQq57Q==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.16.2':
     resolution: {integrity: sha512-ZjUm3w96P2t47nWywGwj1A2mAVBI/8IoS7XHhcogWCfXnEI3M6NPIRQPYAZW4s5/u3u6w1uPtgOwffj2XIOb/g==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.16.2':
     resolution: {integrity: sha512-OFVQ2x3VenTp13nIl6HcQ/7dmhFmM9dg2EjKfHcOtYfrVLQdNR6THFU7GkMdmc8DdY1zLUeilHwBIsyxv5hkwQ==}
@@ -4358,56 +4394,67 @@ packages:
     resolution: {integrity: sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.52.5':
     resolution: {integrity: sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.52.5':
     resolution: {integrity: sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.52.5':
     resolution: {integrity: sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.52.5':
     resolution: {integrity: sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.52.5':
     resolution: {integrity: sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.52.5':
     resolution: {integrity: sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.52.5':
     resolution: {integrity: sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.52.5':
     resolution: {integrity: sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.52.5':
     resolution: {integrity: sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.52.5':
     resolution: {integrity: sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.52.5':
     resolution: {integrity: sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==}
@@ -5505,24 +5552,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.10':
     resolution: {integrity: sha512-4uAHO3nbfbrTcmO/9YcVweTQdx5fN3l7ewwl5AEK4yoC4wXmoBTEPHAVdKNe4r9+xrTgd4BgyPsy0409OjjlMw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.10':
     resolution: {integrity: sha512-W0h9ONNw1pVIA0cN7wtboOSTl4Jk3tHq+w2cMPQudu9/+3xoCxpFb9ZdehwCAk29IsvdWzGzY6P7dDVTyFwoqg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.10':
     resolution: {integrity: sha512-XQNZlLZB62S8nAbw7pqoqwy91Ldy2RpaMRqdRN3T+tAg6Xg6FywXRKCsLh6IQOadr4p1+lGnqM/Wn35z5a/0Vw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.10':
     resolution: {integrity: sha512-qnAGrRv5Nj/DATxAmCnJQRXXQqnJwR0trxLndhoHoxGci9MuguNIjWahS0gw8YZFjgTinbTxOwzatkoySihnmw==}
@@ -5635,24 +5686,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.16':
     resolution: {integrity: sha512-H81UXMa9hJhWhaAUca6bU2wm5RRFpuHImrwXBUvPbYb+3jo32I9VIwpOX6hms0fPmA6f2pGVlybO6qU8pF4fzQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.16':
     resolution: {integrity: sha512-ZGHQxDtFC2/ruo7t99Qo2TTIvOERULPl5l0K1g0oK6b5PGqjYMga+FcY1wIUnrUxY56h28FxybtDEla+ICOyew==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.16':
     resolution: {integrity: sha512-Oi1tAaa0rcKf1Og9MzKeINZzMLPbhxvm7rno5/zuP1WYmpiG0bEHq4AcRUiG2165/WUzvxkW4XDYCscZWbTLZw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.16':
     resolution: {integrity: sha512-B01u/b8LteGRwucIBmCQ07FVXLzImWESAIMcUU6nvFt/tYsQ6IHz8DmZ5KtvmwxD+iTYBtM1xwoGXswnlu9v0Q==}
@@ -6182,41 +6237,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -9161,24 +9224,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -14204,7 +14271,7 @@ snapshots:
       debug: 4.4.3(supports-color@10.2.2)
       lodash: 4.17.21
       pony-cause: 2.1.11
-      semver: 7.7.3
+      semver: 7.7.4
       uuid: 9.0.1
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
## Summary

- **HTML entity decoding** — `origin.title` in the AgentCash CTA was rendered without decoding, showing `&amp;` literally (e.g. "Developers &amp; AI Agents")
- **UTF-8 mojibake repair** — resource descriptions from external 402 responses sometimes contain UTF-8 bytes misread as Latin-1 (e.g. `Â·` instead of `·`, `â€"` instead of `—`). Added `repairMojibake()` that re-encodes as Latin-1 bytes and decodes as UTF-8, with `fatal: true` to prevent false positives on legitimate accented text
- **`cleanExternalText()`** — single helper combining mojibake repair + HTML entity decoding. **All** external text rendering now goes through this one function — origin titles, origin descriptions, OG image titles, resource descriptions, and accepts descriptions

## Files changed

| File | Change |
|---|---|
| `lib/utils.ts` | Added `repairMojibake()` and `cleanExternalText()` |
| `lib/utils.test.ts` | 19 new tests |
| `lib/x402/index.ts` | `getDescription()` now applies `cleanExternalText()` |
| `agentcash-cta.tsx` | Added missing text decoding on `origin.title` |
| `tool.tsx`, `card.tsx`, 3× `columns.tsx` | Wrapped `accepts.description` with `cleanExternalText()` |
| 7 additional render files | Migrated `decodeHtmlEntities()` → `cleanExternalText()` |

All external text rendering (`origin.title`, `origin.description`, `ogImages[].title`, `accepts.description`, `getDescription()`) now goes through the single `cleanExternalText()` helper. `decodeHtmlEntities()` is no longer called directly in any render code.

## Testing

### Unit tests (19 tests, all passing)

**`decodeHtmlEntities`**
- Named entities (`&amp;`, `&lt;`, `&gt;`, `&quot;`, `&#39;`, `&apos;`)
- Numeric decimal entities (`&#169;` → ©, `&#8212;` → —)
- Numeric hex entities (`&#x27;` → ', `&#xA9;` → ©)
- Passthrough for strings without entities
- Multiple entities in one string
- Orbis title from scraper: `"Developers &amp; AI Agents"` → `"Developers & AI Agents"`

**`repairMojibake`**
- Middle dot: `Â·` → `·`
- Em dash: `â€"` → `—`, en dash: `â€"` → `–`
- Smart quotes: `â€œ` → `"`, `â€\x9d` → `"`, `â€™` → `'`
- Full OATP description pattern: `"OATP Â· token_risk_scan â€" Analyze..."` → `"OATP · token_risk_scan — Analyze..."`
- Plain ASCII passthrough
- Chars above Latin-1 range (emoji, CJK) — bails out safely
- Legitimate accented text NOT corrupted: `café`, `naïve`, `über`, `résumé` all unchanged
- Idempotent: calling twice produces same result

**`cleanExternalText`**
- Combined mojibake + HTML entities in same string
- HTML entities only
- Mojibake only
- Clean text passthrough

### Manual verification

Confirmed against real data:
- `curl https://orbisapi.com` returns `<title>Orbis — API Marketplace for Developers &amp; AI Agents</title>` — the `&amp;` is correct HTML that needs decoding
- OATP resource description mojibake (`Â·`, `â€`) matches UTF-8→Latin-1 corruption pattern exactly

### Full test suite
All 83 tests pass (7 test files) including 19 new tests for the parsing utilities.
