### PR TITLE
Add programmatic resource registration API coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ pnpm dev:sync
 ## Documentation
 
 - **[x402 Discovery Document Guide](./docs/DISCOVERY.md)** - Learn how to implement discovery for your x402 server to enable automatic resource registration
+- **[Programmatic Registration API](./docs/PROGRAMMATIC_REGISTRATION.md)** - Register or refresh resources through SIWX-authenticated API calls
 
 ## Contributing
 
@@ -59,6 +60,10 @@ We're actively seeking contributors to help build x402scan. We believe an ecosys
 ### Add Resources
 
 If you know of a resource that is not yet listed, you can add it by visiting [https://www.x402scan.com/resources/register](https://www.x402scan.com/resources/register) and submitting the URL. If the URL returns a valid x402 schema, it will be added to the resources list automatically.
+
+Resource providers can also register or refresh resources programmatically with
+the SIWX-authenticated registry endpoints documented in
+[`docs/PROGRAMMATIC_REGISTRATION.md`](./docs/PROGRAMMATIC_REGISTRATION.md).
 
 ### Add Facilitators
 

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -62,10 +62,15 @@ interface ManualRegistrationResult {
 function getErrorMessageFromRegisterResult(result: {
   success: false;
   error: {
-    type: 'parseErrors' | 'no402';
+    type: 'parseErrors' | 'no402' | 'unsupportedUrl';
+    message?: string;
     parseErrors?: string[];
   };
 }): string {
+  if (result.error.type === 'unsupportedUrl') {
+    return result.error.message ?? 'Unsupported URL';
+  }
+
   if (result.error.type === 'parseErrors') {
     const parseErrors = result.error.parseErrors ?? [];
     if (parseErrors.length > 0) {

--- a/apps/scan/src/app/api/x402/_handlers/registry-register-origin.test.ts
+++ b/apps/scan/src/app/api/x402/_handlers/registry-register-origin.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { registerResourcesFromDiscovery } from '@/lib/discovery/register-origin';
+import { fetchDiscoveryDocument } from '@/services/discovery';
+
+import { handleRegistryRegisterOrigin } from './registry-register-origin';
+
+import type { RegisterOriginResult } from '@/lib/discovery/register-origin';
+
+vi.mock('@/services/discovery', () => ({
+  fetchDiscoveryDocument: vi.fn(),
+}));
+
+vi.mock('@/lib/discovery/register-origin', () => ({
+  registerResourcesFromDiscovery: vi.fn(),
+}));
+
+const fetchDiscoveryDocumentMock = vi.mocked(fetchDiscoveryDocument);
+const registerResourcesFromDiscoveryMock = vi.mocked(
+  registerResourcesFromDiscovery
+);
+
+async function responseJson(
+  response: Response
+): Promise<Record<string, unknown>> {
+  return (await response.json()) as Record<string, unknown>;
+}
+
+function originResult(
+  overrides: Partial<RegisterOriginResult> = {}
+): RegisterOriginResult {
+  return {
+    registered: 1,
+    siwx: 0,
+    failed: 0,
+    skipped: 0,
+    deprecated: 0,
+    total: 1,
+    source: 'openapi',
+    failedDetails: [],
+    siwxDetails: [],
+    skippedDetails: [],
+    originId: 'origin-id',
+    ...overrides,
+  };
+}
+
+describe('handleRegistryRegisterOrigin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 404 when discovery is unavailable', async () => {
+    fetchDiscoveryDocumentMock.mockResolvedValue({
+      success: false,
+      resources: [],
+      error: 'No discovery document found',
+    });
+
+    const response = await handleRegistryRegisterOrigin({
+      origin: 'https://example.com',
+    });
+
+    expect(response.status).toBe(404);
+    expect(await responseJson(response)).toEqual({
+      success: false,
+      error: {
+        type: 'no_discovery',
+        message: 'No discovery document found',
+      },
+    });
+    expect(registerResourcesFromDiscoveryMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 422 when discovery has no registerable resources', async () => {
+    fetchDiscoveryDocumentMock.mockResolvedValue({
+      success: true,
+      source: 'openapi',
+      resources: [{ url: 'https://example.com/api/pay' }],
+      ownershipProofs: [],
+    });
+    registerResourcesFromDiscoveryMock.mockResolvedValue(
+      originResult({
+        registered: 0,
+        failed: 1,
+        total: 1,
+        failedDetails: [
+          {
+            url: 'https://example.com/api/pay',
+            error: 'Missing input schema',
+          },
+        ],
+      })
+    );
+
+    const response = await handleRegistryRegisterOrigin({
+      origin: 'https://example.com',
+    });
+
+    expect(response.status).toBe(422);
+    expect(await responseJson(response)).toEqual({
+      success: false,
+      error: {
+        type: 'no_valid_resources',
+        message:
+          'No valid paid x402 resources were found for this origin. Add at least one paid x402 resource that passes validation to complete registration.',
+      },
+      result: {
+        registered: 0,
+        siwx: 0,
+        failed: 1,
+        skipped: 0,
+        deprecated: 0,
+        total: 1,
+        source: 'openapi',
+        failedDetails: [
+          {
+            url: 'https://example.com/api/pay',
+            error: 'Missing input schema',
+          },
+        ],
+        siwxDetails: [],
+        skippedDetails: [],
+        originId: 'origin-id',
+      },
+    });
+  });
+
+  it('returns registration counts and details on success', async () => {
+    fetchDiscoveryDocumentMock.mockResolvedValue({
+      success: true,
+      source: 'well-known',
+      resources: [
+        { url: 'https://example.com/api/pay' },
+        { url: 'https://example.com/api/me', authMode: 'siwx' },
+      ],
+      ownershipProofs: [],
+    });
+    registerResourcesFromDiscoveryMock.mockResolvedValue(
+      originResult({
+        registered: 1,
+        siwx: 1,
+        total: 2,
+        source: 'well-known',
+        siwxDetails: [{ url: 'https://example.com/api/me' }],
+      })
+    );
+
+    const response = await handleRegistryRegisterOrigin({
+      origin: 'https://example.com',
+    });
+
+    expect(response.status).toBe(200);
+    expect(await responseJson(response)).toEqual({
+      success: true,
+      registered: 1,
+      siwx: 1,
+      failed: 0,
+      skipped: 0,
+      deprecated: 0,
+      total: 2,
+      source: 'well-known',
+      siwxDetails: [{ url: 'https://example.com/api/me' }],
+    });
+  });
+});

--- a/apps/scan/src/app/api/x402/_handlers/registry-register.test.ts
+++ b/apps/scan/src/app/api/x402/_handlers/registry-register.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { registerResourceUrl } from '@/lib/registry/register-resource-url';
+
+import { handleRegistryRegister } from './registry-register';
+
+import type { RegisterResourceUrlResult } from '@/lib/registry/register-resource-url';
+
+vi.mock('@/lib/registry/register-resource-url', () => ({
+  registerResourceUrl: vi.fn(),
+}));
+
+const registerResourceUrlMock = vi.mocked(registerResourceUrl);
+
+async function responseJson(
+  response: Response
+): Promise<Record<string, unknown>> {
+  return (await response.json()) as Record<string, unknown>;
+}
+
+describe('handleRegistryRegister', () => {
+  it('returns 422 for unsupported URLs', async () => {
+    registerResourceUrlMock.mockResolvedValue({
+      success: false,
+      error: {
+        type: 'unsupportedUrl',
+        message: 'Local and private network URLs are not supported',
+      },
+    });
+
+    const response = await handleRegistryRegister({
+      url: 'http://127.0.0.1:3000/pay',
+    });
+
+    expect(response.status).toBe(422);
+    expect(await responseJson(response)).toEqual({
+      success: false,
+      error: {
+        type: 'unsupported_url',
+        message: 'Local and private network URLs are not supported',
+      },
+    });
+  });
+
+  it('returns 422 when no x402 challenge is found', async () => {
+    registerResourceUrlMock.mockResolvedValue({
+      success: false,
+      error: {
+        type: 'no402',
+        message: 'Endpoint did not return a 402 payment challenge',
+      },
+    });
+
+    const response = await handleRegistryRegister({
+      url: 'https://example.com/api/free',
+    });
+
+    expect(response.status).toBe(422);
+    expect(await responseJson(response)).toEqual({
+      success: false,
+      error: {
+        type: 'no_402',
+        message: 'Endpoint did not return a 402 payment challenge',
+      },
+    });
+  });
+
+  it('returns parse errors from the shared registration service', async () => {
+    registerResourceUrlMock.mockResolvedValue({
+      success: false,
+      data: { accepts: [] },
+      error: {
+        type: 'parseErrors',
+        parseErrors: ['Missing input schema'],
+      },
+    });
+
+    const response = await handleRegistryRegister({
+      url: 'https://example.com/api/pay',
+    });
+
+    expect(response.status).toBe(422);
+    expect(await responseJson(response)).toEqual({
+      success: false,
+      error: {
+        type: 'parse_error',
+        parseErrors: ['Missing input schema'],
+      },
+      data: { accepts: [] },
+    });
+  });
+
+  it('returns the public registration payload on success', async () => {
+    registerResourceUrlMock.mockResolvedValue({
+      success: true,
+      resource: { resource: { id: 'resource-id' } },
+      accepts: [],
+      response: { accepts: [] },
+      registrationDetails: {
+        providedAccepts: [],
+        supportedAccepts: [],
+        unsupportedAccepts: [],
+        originMetadata: {
+          title: null,
+          description: null,
+          favicon: null,
+          ogImages: [],
+        },
+      },
+      methodUsed: 'POST',
+      discovery: {
+        found: false,
+        otherResourceCount: 0,
+        origin: 'https://example.com',
+      },
+    } as unknown as RegisterResourceUrlResult);
+
+    const response = await handleRegistryRegister({
+      url: 'https://example.com/api/pay',
+    });
+
+    expect(response.status).toBe(200);
+    expect(await responseJson(response)).toEqual({
+      success: true,
+      resource: { resource: { id: 'resource-id' } },
+      accepts: [],
+      registrationDetails: {
+        providedAccepts: [],
+        supportedAccepts: [],
+        unsupportedAccepts: [],
+        originMetadata: {
+          title: null,
+          description: null,
+          favicon: null,
+          ogImages: [],
+        },
+      },
+      methodUsed: 'POST',
+      discovery: {
+        found: false,
+        otherResourceCount: 0,
+        origin: 'https://example.com',
+      },
+    });
+  });
+});

--- a/apps/scan/src/app/api/x402/_handlers/registry-register.ts
+++ b/apps/scan/src/app/api/x402/_handlers/registry-register.ts
@@ -1,8 +1,7 @@
 import type { registryRegisterBodySchema } from '@/app/api/x402/_lib/schemas';
 import { jsonResponse } from '@/app/api/x402/_lib/utils';
-import { registerResource } from '@/lib/resources';
+import { registerResourceUrl } from '@/lib/registry/register-resource-url';
 
-import { probeX402Endpoint } from '@/lib/discovery/probe';
 import type { z } from 'zod';
 
 export async function handleRegistryRegister(
@@ -10,37 +9,43 @@ export async function handleRegistryRegister(
 ) {
   const { url } = body;
 
-  const probeResult = await probeX402Endpoint(
-    url.replaceAll('{', '').replaceAll('}', '')
-  );
-
-  if (!probeResult.success) {
-    return jsonResponse(
-      {
-        success: false,
-        error: { type: 'no_402', message: probeResult.error },
-      },
-      422
-    );
-  }
-
-  const result = await registerResource(url, probeResult.advisory);
+  const result = await registerResourceUrl(url);
 
   if (!result.success) {
-    return jsonResponse(
-      {
-        success: false,
-        error: {
-          type: 'parse_error',
-          parseErrors:
-            result.error.type === 'parseResponse'
-              ? result.error.parseErrors
-              : [JSON.stringify(result.error)],
-        },
-        data: result.data,
-      },
-      422
-    );
+    switch (result.error.type) {
+      case 'unsupportedUrl':
+        return jsonResponse(
+          {
+            success: false,
+            error: { type: 'unsupported_url', message: result.error.message },
+          },
+          422
+        );
+      case 'no402':
+        return jsonResponse(
+          {
+            success: false,
+            error: { type: 'no_402', message: result.error.message },
+          },
+          422
+        );
+      case 'parseErrors':
+        return jsonResponse(
+          {
+            success: false,
+            error: {
+              type: 'parse_error',
+              parseErrors: result.error.parseErrors,
+            },
+            data: result.data,
+          },
+          422
+        );
+      default: {
+        const _exhaustive: never = result.error;
+        return _exhaustive;
+      }
+    }
   }
 
   return jsonResponse(
@@ -51,6 +56,8 @@ export async function handleRegistryRegister(
           resource: result.resource,
           accepts: result.accepts,
           registrationDetails: result.registrationDetails,
+          methodUsed: result.methodUsed,
+          discovery: result.discovery,
         },
         (_k, v: unknown) => (typeof v === 'bigint' ? Number(v) : v)
       )

--- a/apps/scan/src/lib/registry/register-resource-url.test.ts
+++ b/apps/scan/src/lib/registry/register-resource-url.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { probeX402Endpoint } from '@/lib/discovery/probe';
+import { registerResource } from '@/lib/resources';
+import { fetchDiscoveryDocument } from '@/services/discovery';
+
+import { registerResourceUrl } from './register-resource-url';
+
+import type { EndpointMethodAdvisory } from '@agentcash/discovery';
+
+vi.mock('@/lib/discovery/probe', () => ({
+  probeX402Endpoint: vi.fn(),
+}));
+
+vi.mock('@/lib/resources', () => ({
+  registerResource: vi.fn(),
+}));
+
+vi.mock('@/services/discovery', () => ({
+  fetchDiscoveryDocument: vi.fn(),
+}));
+
+const probeX402EndpointMock = vi.mocked(probeX402Endpoint);
+const registerResourceMock = vi.mocked(registerResource);
+const fetchDiscoveryDocumentMock = vi.mocked(fetchDiscoveryDocument);
+
+const advisory = {
+  source: 'probe',
+  method: 'POST',
+  paymentOptions: [{ protocol: 'x402' }],
+  inputSchema: { input: { method: 'POST' } },
+  paymentRequiredBody: { accepts: [] },
+} as unknown as EndpointMethodAdvisory;
+
+type RegisterResourceResult = Awaited<ReturnType<typeof registerResource>>;
+
+function successfulRegistration(): RegisterResourceResult {
+  return {
+    success: true,
+    resource: {
+      resource: { id: 'resource-id', resource: 'https://example.com/api/pay' },
+      origin: { id: 'origin-id' },
+      accepts: [],
+      unsupportedAccepts: [],
+    },
+    accepts: [],
+    response: { accepts: [] },
+    registrationDetails: {
+      providedAccepts: [],
+      supportedAccepts: [],
+      unsupportedAccepts: [],
+      originMetadata: {
+        title: null,
+        description: null,
+        favicon: null,
+        ogImages: [],
+      },
+    },
+  } as unknown as RegisterResourceResult;
+}
+
+describe('registerResourceUrl', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects local and private URLs before probing', async () => {
+    const result = await registerResourceUrl('http://127.0.0.1:3000/pay');
+
+    expect(result).toEqual({
+      success: false,
+      error: {
+        type: 'unsupportedUrl',
+        message: 'Local and private network URLs are not supported',
+      },
+    });
+    expect(probeX402EndpointMock).not.toHaveBeenCalled();
+    expect(registerResourceMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid URLs before probing', async () => {
+    const result = await registerResourceUrl('not a url');
+
+    expect(result).toEqual({
+      success: false,
+      error: {
+        type: 'unsupportedUrl',
+        message: 'Invalid URL',
+      },
+    });
+    expect(probeX402EndpointMock).not.toHaveBeenCalled();
+    expect(registerResourceMock).not.toHaveBeenCalled();
+  });
+
+  it('returns no402 when probing cannot find a payment challenge', async () => {
+    probeX402EndpointMock.mockResolvedValue({
+      success: false,
+      error: 'Endpoint did not return a 402 payment challenge',
+    });
+
+    const result = await registerResourceUrl('https://example.com/api/pay');
+
+    expect(result).toEqual({
+      success: false,
+      error: {
+        type: 'no402',
+        message: 'Endpoint did not return a 402 payment challenge',
+      },
+    });
+    expect(registerResourceMock).not.toHaveBeenCalled();
+  });
+
+  it('probes template URLs safely but preserves the registered URL', async () => {
+    probeX402EndpointMock.mockResolvedValue({
+      success: true,
+      advisory,
+      warnings: [],
+    });
+    registerResourceMock.mockResolvedValue(successfulRegistration());
+    fetchDiscoveryDocumentMock.mockResolvedValue({
+      success: false,
+      resources: [],
+      error: 'No discovery document found',
+    });
+
+    const result = await registerResourceUrl(
+      'https://example.com/api/resource/{id}'
+    );
+
+    expect(result.success).toBe(true);
+    expect(probeX402EndpointMock).toHaveBeenCalledWith(
+      'https://example.com/api/resource/id'
+    );
+    expect(registerResourceMock).toHaveBeenCalledWith(
+      'https://example.com/api/resource/{id}',
+      advisory
+    );
+  });
+
+  it('includes other resources discovered from the same origin', async () => {
+    probeX402EndpointMock.mockResolvedValue({
+      success: true,
+      advisory,
+      warnings: [],
+    });
+    registerResourceMock.mockResolvedValue(successfulRegistration());
+    fetchDiscoveryDocumentMock.mockResolvedValue({
+      success: true,
+      source: 'openapi',
+      resources: [
+        { url: 'https://example.com/api/pay' },
+        { url: 'https://example.com/api/other' },
+      ],
+      ownershipProofs: [],
+    });
+
+    const result = await registerResourceUrl('https://example.com/api/pay');
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(result.methodUsed).toBe('POST');
+    expect(result.discovery).toEqual({
+      found: true,
+      source: 'openapi',
+      otherResourceCount: 1,
+      origin: 'https://example.com',
+      resources: ['https://example.com/api/other'],
+    });
+  });
+
+  it('maps registration parser failures without duplicating parser logic', async () => {
+    probeX402EndpointMock.mockResolvedValue({
+      success: true,
+      advisory,
+      warnings: [],
+    });
+    registerResourceMock.mockResolvedValue({
+      success: false,
+      data: { accepts: [] },
+      error: {
+        type: 'parseResponse',
+        parseErrors: ['Missing input schema'],
+      },
+    });
+
+    const result = await registerResourceUrl('https://example.com/api/pay');
+
+    expect(result).toEqual({
+      success: false,
+      data: { accepts: [] },
+      error: {
+        type: 'parseErrors',
+        parseErrors: ['Missing input schema'],
+      },
+    });
+  });
+});

--- a/apps/scan/src/lib/registry/register-resource-url.ts
+++ b/apps/scan/src/lib/registry/register-resource-url.ts
@@ -1,0 +1,149 @@
+import { probeX402Endpoint } from '@/lib/discovery/probe';
+import { registerResource } from '@/lib/resources';
+import { getOriginFromUrl, normalizeUrl } from '@/lib/url';
+import { isLocalUrl } from '@/lib/url-helpers';
+import { fetchDiscoveryDocument } from '@/services/discovery';
+
+import type { DiscoveryInfo } from '@/types/discovery';
+
+type RegisterResourceSuccess = Extract<
+  Awaited<ReturnType<typeof registerResource>>,
+  { success: true }
+>;
+
+type RegisterResourceUrlFailure =
+  | {
+      success: false;
+      data?: never;
+      error: {
+        type: 'unsupportedUrl';
+        message: string;
+      };
+    }
+  | {
+      success: false;
+      data?: never;
+      error: {
+        type: 'no402';
+        message: string;
+      };
+    }
+  | {
+      success: false;
+      data: unknown;
+      error: {
+        type: 'parseErrors';
+        parseErrors: string[];
+      };
+    };
+
+export type RegisterResourceUrlResult =
+  | (RegisterResourceSuccess & {
+      methodUsed: string;
+      discovery: DiscoveryInfo;
+    })
+  | RegisterResourceUrlFailure;
+
+function validatePublicResourceUrl(url: string): string | undefined {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return 'Invalid URL';
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return 'Only HTTP(S) URLs are supported';
+  }
+
+  if (isLocalUrl(url)) {
+    return 'Local and private network URLs are not supported';
+  }
+
+  return undefined;
+}
+
+async function getDiscoveryInfo(url: string): Promise<DiscoveryInfo> {
+  const origin = getOriginFromUrl(url);
+  const discovery: DiscoveryInfo = {
+    found: false,
+    otherResourceCount: 0,
+    origin,
+  };
+
+  try {
+    const discoveryResult = await fetchDiscoveryDocument(origin);
+    if (!discoveryResult.success || !Array.isArray(discoveryResult.resources)) {
+      return discovery;
+    }
+
+    const normalizedInputUrl = normalizeUrl(url);
+    const otherResources = discoveryResult.resources.filter(resource => {
+      if (
+        !resource ||
+        typeof resource !== 'object' ||
+        !('url' in resource) ||
+        typeof resource.url !== 'string'
+      ) {
+        return false;
+      }
+
+      return normalizeUrl(resource.url) !== normalizedInputUrl;
+    });
+
+    return {
+      found: true,
+      source: discoveryResult.source,
+      otherResourceCount: otherResources.length,
+      origin,
+      resources: otherResources.map(resource => resource.url),
+    };
+  } catch {
+    return discovery;
+  }
+}
+
+export async function registerResourceUrl(
+  url: string
+): Promise<RegisterResourceUrlResult> {
+  const validationError = validatePublicResourceUrl(url);
+  if (validationError) {
+    return {
+      success: false,
+      error: { type: 'unsupportedUrl', message: validationError },
+    };
+  }
+
+  const probeResult = await probeX402Endpoint(
+    url.replaceAll('{', '').replaceAll('}', '')
+  );
+
+  if (!probeResult.success) {
+    return {
+      success: false,
+      error: { type: 'no402', message: probeResult.error },
+    };
+  }
+
+  const result = await registerResource(url, probeResult.advisory);
+
+  if (!result.success) {
+    return {
+      success: false,
+      data: result.data,
+      error: {
+        type: 'parseErrors',
+        parseErrors:
+          result.error.type === 'parseResponse'
+            ? result.error.parseErrors
+            : [JSON.stringify(result.error)],
+      },
+    };
+  }
+
+  return {
+    ...result,
+    methodUsed: probeResult.advisory.method,
+    discovery: await getDiscoveryInfo(url),
+  };
+}

--- a/apps/scan/src/lib/url-helpers.test.ts
+++ b/apps/scan/src/lib/url-helpers.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { isLocalUrl } from './url-helpers';
+
+describe('isLocalUrl', () => {
+  it.each([
+    'http://localhost:3000',
+    'http://app.local',
+    'http://service.localhost',
+    'http://127.10.0.1',
+    'http://0.0.0.0',
+    'http://10.1.2.3',
+    'http://100.64.0.1',
+    'http://169.254.1.1',
+    'http://172.16.0.1',
+    'http://172.31.255.255',
+    'http://192.168.0.1',
+    'http://198.18.0.1',
+    'http://[::1]',
+    'http://[fc00::1]',
+    'http://[fd12::1]',
+    'http://[fe80::1]',
+  ])('returns true for local or private URL %s', url => {
+    expect(isLocalUrl(url)).toBe(true);
+  });
+
+  it.each([
+    'https://example.com',
+    'https://api.x402scan.com',
+    'http://8.8.8.8',
+    'http://172.32.0.1',
+    'http://[2606:4700:4700::1111]',
+  ])('returns false for public URL %s', url => {
+    expect(isLocalUrl(url)).toBe(false);
+  });
+});

--- a/apps/scan/src/lib/url-helpers.ts
+++ b/apps/scan/src/lib/url-helpers.ts
@@ -5,35 +5,47 @@
 export function isLocalUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
-    const hostname = parsed.hostname.toLowerCase();
+    const hostname = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, '');
 
-    // Check for localhost variants
     if (
       hostname === 'localhost' ||
-      hostname === '127.0.0.1' ||
-      hostname === '0.0.0.0' ||
-      hostname.endsWith('.local')
+      hostname === '::1' ||
+      hostname === '::' ||
+      hostname.endsWith('.local') ||
+      hostname.endsWith('.localhost')
     ) {
       return true;
     }
 
-    // Check for private IP ranges
-    // 192.168.0.0/16
-    if (/^192\.168\.\d+\.\d+$/.exec(hostname)) {
+    if (
+      hostname.startsWith('fc') ||
+      hostname.startsWith('fd') ||
+      hostname.startsWith('fe80:')
+    ) {
       return true;
     }
 
-    // 10.0.0.0/8
-    if (/^10\.\d+\.\d+\.\d+$/.exec(hostname)) {
-      return true;
+    const ipv4Parts = hostname.split('.').map(part => Number(part));
+    if (
+      ipv4Parts.length !== 4 ||
+      ipv4Parts.some(part => !Number.isInteger(part) || part < 0 || part > 255)
+    ) {
+      return false;
     }
 
-    // 172.16.0.0/12
-    if (/^172\.(1[6-9]|2\d|3[01])\.\d+\.\d+$/.exec(hostname)) {
-      return true;
-    }
+    const a = ipv4Parts[0]!;
+    const b = ipv4Parts[1]!;
 
-    return false;
+    return (
+      a === 0 ||
+      a === 10 ||
+      a === 127 ||
+      (a === 100 && b >= 64 && b <= 127) ||
+      (a === 169 && b === 254) ||
+      (a === 172 && b >= 16 && b <= 31) ||
+      (a === 192 && b === 168) ||
+      (a === 198 && (b === 18 || b === 19))
+    );
   } catch {
     return false;
   }

--- a/apps/scan/src/trpc/routers/public/resources.ts
+++ b/apps/scan/src/trpc/routers/public/resources.ts
@@ -20,9 +20,7 @@ import { scanDb } from '@x402scan/scan-db';
 
 import { mixedAddressSchema } from '@/lib/schemas';
 
-import { registerResource } from '@/lib/resources';
-
-import { probeX402Endpoint } from '@/lib/discovery/probe';
+import { registerResourceUrl } from '@/lib/registry/register-resource-url';
 import { registerResourcesFromDiscovery } from '@/lib/discovery/register-origin';
 import { TRPCError } from '@trpc/server';
 import {
@@ -33,7 +31,6 @@ import {
 
 import { convertTokenAmount } from '@/lib/token';
 import { usdc } from '@/lib/tokens/usdc';
-import { getOriginFromUrl, normalizeUrl } from '@/lib/url';
 import { fetchDiscoveryDocument } from '@/services/discovery';
 import {
   getResourceVerificationStatus,
@@ -42,7 +39,6 @@ import {
 
 import type { Prisma } from '@x402scan/scan-db';
 import type { SupportedChain } from '@/types/chain';
-import type { DiscoveryInfo } from '@/types/discovery';
 import { verifyAnyOwnershipProof } from '@/lib/ownership-proof';
 
 export const resourcesRouter = createTRPCRouter({
@@ -142,78 +138,40 @@ export const resourcesRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ input }) => {
-      const probeResult = await probeX402Endpoint(
-        input.url.toString().replaceAll('{', '').replaceAll('}', '')
-      );
-
-      if (!probeResult.success) {
-        return { success: false as const, error: { type: 'no402' as const } };
-      }
-
-      const result = await registerResource(
-        input.url.toString(),
-        probeResult.advisory
-      );
+      const result = await registerResourceUrl(input.url.toString());
 
       if (result.success === false) {
-        return {
-          success: false as const,
-          data: result.data,
-          error: {
-            type: 'parseErrors' as const,
-            parseErrors:
-              result.error.type === 'parseResponse'
-                ? result.error.parseErrors
-                : [JSON.stringify(result.error)],
-          },
-        };
-      }
-
-      // Check for additional resources via discovery
-      const origin = getOriginFromUrl(input.url);
-      let discovery: DiscoveryInfo = {
-        found: false,
-        otherResourceCount: 0,
-        origin,
-      };
-
-      try {
-        const discoveryResult = await fetchDiscoveryDocument(origin);
-        if (
-          discoveryResult.success &&
-          Array.isArray(discoveryResult.resources)
-        ) {
-          const inputUrlStr = String(input.url);
-          const normalizedInputUrl = normalizeUrl(inputUrlStr);
-          const otherResources = discoveryResult.resources.filter(r => {
-            if (
-              !r ||
-              typeof r !== 'object' ||
-              !('url' in r) ||
-              typeof r.url !== 'string'
-            ) {
-              return false;
-            }
-            const resourceUrl = String(r.url);
-            return normalizeUrl(resourceUrl) !== normalizedInputUrl;
-          });
-          discovery = {
-            found: true,
-            source: discoveryResult.source,
-            otherResourceCount: otherResources.length,
-            origin,
-            resources: otherResources.map(r => r.url),
-          };
+        switch (result.error.type) {
+          case 'unsupportedUrl':
+            return {
+              success: false as const,
+              error: {
+                type: 'unsupportedUrl' as const,
+                message: result.error.message,
+              },
+            };
+          case 'no402':
+            return {
+              success: false as const,
+              error: { type: 'no402' as const },
+            };
+          case 'parseErrors':
+            return {
+              success: false as const,
+              data: result.data,
+              error: {
+                type: 'parseErrors' as const,
+                parseErrors: result.error.parseErrors,
+              },
+            };
+          default: {
+            const _exhaustive: never = result.error;
+            return _exhaustive;
+          }
         }
-      } catch {
-        // Discovery check failed, continue without discovery info
       }
 
-      return {
-        ...result,
-        methodUsed: probeResult.advisory.method,
-        discovery,
-      };
+      return result;
     }),
 
   /**

--- a/docs/DISCOVERY.md
+++ b/docs/DISCOVERY.md
@@ -23,6 +23,7 @@ Runtime `402` behavior is authoritative over static metadata.
 ## A) OpenAPI-First Discovery (Recommended)
 
 Supported URLs:
+
 - `https://yourdomain.com/openapi.json`
 
 ### Required top-level fields
@@ -35,6 +36,7 @@ Supported URLs:
 ### Per-paid-operation requirements
 
 For each paid operation:
+
 - declare `x-payment-info`
 - include a `402` response in `responses`
 - include `x-payment-info.protocols` (for example `"x402"`)
@@ -100,14 +102,17 @@ Use this when discovery docs are not available yet.
 A route is registerable when probing returns `402` with a parseable x402 challenge.
 
 Accepted challenge transport:
+
 - `Payment-Required` header (x402 v2), or
 - JSON response body (legacy compatibility)
 
 For payable indexing in `x402scan`, challenge data should include:
+
 - non-empty `accepts`
 - Bazaar-style input schema (`extensions.bazaar.info` + schema-derived input)
 
 Compatibility behavior:
+
 - `402` + `accepts: []` + `extensions["sign-in-with-x"]` => SIWX auth-only, marked `skipped`.
 - Missing input schema => strict non-invocable, marked `skipped`.
 
@@ -116,6 +121,7 @@ Compatibility behavior:
 ## Ownership Proofs
 
 Accepted locations:
+
 - OpenAPI `x-discovery.ownershipProofs` (preferred)
 - `/.well-known/x402` `ownershipProofs` (compatibility)
 
@@ -136,6 +142,15 @@ When a user clicks **Register This URL Only**:
 - Skip fan-out.
 - Register only that endpoint.
 - Useful for partial rollouts and rate-limited providers.
+
+The same registration paths are available through the public
+SIWX-authenticated API:
+
+- `POST /api/x402/registry/register`
+- `POST /api/x402/registry/register-origin`
+
+See [`PROGRAMMATIC_REGISTRATION.md`](./PROGRAMMATIC_REGISTRATION.md) for request
+and response contracts.
 
 ---
 

--- a/docs/PROGRAMMATIC_REGISTRATION.md
+++ b/docs/PROGRAMMATIC_REGISTRATION.md
@@ -1,0 +1,181 @@
+# Programmatic Resource Registration
+
+This document describes the public API for registering and refreshing x402
+resources without using the `/resources/register` UI.
+
+The registry endpoints are free to call, but they require SIWX wallet
+authentication. They are intended for resource providers and agents that need
+to refresh x402scan after adding or changing paid resources.
+
+## Authentication
+
+Use a SIWX-capable client and send the wallet proof in the
+`SIGN-IN-WITH-X` header. The endpoint does not require an `X-Payment` header.
+
+If you are using agentcash tooling, call these endpoints with `fetch_with_auth`
+so the wallet proof is generated and attached automatically.
+
+## Single Resource
+
+```text
+POST /api/x402/registry/register
+Content-Type: application/json
+SIGN-IN-WITH-X: <wallet proof>
+```
+
+Request body:
+
+```json
+{
+  "url": "https://example.com/api/paid-route"
+}
+```
+
+Use this when you want to register or refresh one concrete x402 endpoint. The
+URL must be public HTTP(S). Local, loopback, link-local, and private-network
+URLs are rejected before probing.
+
+Success response:
+
+```json
+{
+  "success": true,
+  "resource": {},
+  "accepts": [],
+  "registrationDetails": {},
+  "methodUsed": "POST",
+  "discovery": {
+    "found": true,
+    "source": "openapi",
+    "otherResourceCount": 2,
+    "origin": "https://example.com",
+    "resources": [
+      "https://example.com/api/other-route",
+      "https://example.com/api/search"
+    ]
+  }
+}
+```
+
+Failure responses use HTTP `422` for a reachable but non-registerable resource:
+
+```json
+{
+  "success": false,
+  "error": {
+    "type": "no_402",
+    "message": "Endpoint did not return a 402 payment challenge"
+  }
+}
+```
+
+```json
+{
+  "success": false,
+  "error": {
+    "type": "parse_error",
+    "parseErrors": ["Missing input schema"]
+  },
+  "data": {}
+}
+```
+
+```json
+{
+  "success": false,
+  "error": {
+    "type": "unsupported_url",
+    "message": "Local and private network URLs are not supported"
+  }
+}
+```
+
+## Origin Discovery
+
+```text
+POST /api/x402/registry/register-origin
+Content-Type: application/json
+SIGN-IN-WITH-X: <wallet proof>
+```
+
+Request body:
+
+```json
+{
+  "origin": "https://example.com"
+}
+```
+
+Use this when your origin publishes `/openapi.json` or `/.well-known/x402` and
+you want x402scan to discover and register all paid resources for that origin.
+
+Success response:
+
+```json
+{
+  "success": true,
+  "registered": 3,
+  "siwx": 1,
+  "failed": 0,
+  "skipped": 0,
+  "deprecated": 1,
+  "total": 4,
+  "source": "openapi",
+  "siwxDetails": [
+    {
+      "url": "https://example.com/api/me"
+    }
+  ]
+}
+```
+
+If no discovery document can be resolved, the endpoint returns HTTP `404`:
+
+```json
+{
+  "success": false,
+  "error": {
+    "type": "no_discovery",
+    "message": "No discovery document found"
+  }
+}
+```
+
+If discovery succeeds but no paid x402 resource can be registered, the endpoint
+returns HTTP `422` with the detailed registration result:
+
+```json
+{
+  "success": false,
+  "error": {
+    "type": "no_valid_resources",
+    "message": "No valid paid x402 resources were found for this origin. Add at least one paid x402 resource that passes validation to complete registration."
+  },
+  "result": {
+    "registered": 0,
+    "failed": 1,
+    "skipped": 0,
+    "siwx": 0,
+    "total": 1,
+    "failedDetails": [
+      {
+        "url": "https://example.com/api/paid-route",
+        "error": "Missing input schema"
+      }
+    ]
+  }
+}
+```
+
+## Recommended Flow
+
+1. Publish OpenAPI at `/openapi.json` or publish `/.well-known/x402`.
+2. Validate discovery with `@agentcash/discovery`.
+3. Call `POST /api/x402/registry/register-origin`.
+4. If `failedDetails` or `skippedDetails` are returned, fix those endpoints and
+   call the origin endpoint again.
+5. For partial rollouts, call `POST /api/x402/registry/register` for one URL.
+
+The single-resource endpoint shares the same probe and database registration
+path as the internal resource registration flow. The origin endpoint shares the
+same discovery fan-out path used by the UI.


### PR DESCRIPTION
## Summary

/claim #104

- Extracts single-resource registration into a shared `registerResourceUrl` service used by both the SIWX API route and the existing tRPC registration mutation.
- Preserves the existing probe/register/discovery behavior while returning `methodUsed` and same-origin discovery metadata from the public API.
- Rejects local, private, loopback, link-local, and non-HTTP(S) URLs before probing to keep the public API from becoming an unrestricted URL probe.
- Documents the SIWX-authenticated programmatic API for both single-resource and origin-wide registration.
- Adds focused Vitest coverage for the shared service, registry handlers, origin registration responses, and URL boundary checks.

## Validation

Local validation run on Windows with generated Next route types and workspace build artifacts:

- `corepack pnpm --filter @x402scan/app types:check`
- `corepack pnpm --filter @x402scan/app lint`
- `corepack pnpm --filter @x402scan/app test -- --run` (10 files / 98 tests)
- touched-file Prettier check

Notes:

- The full app test command matches the CI test step for `@x402scan/app`.
- Local setup required running workspace generation/build prerequisites before type-checking: Prisma client generation for scan/transfers DB, Next `typegen`, and builds for internal packages consumed through dist exports.