### PR TITLE
Filter non-functional origins from featured page

### DIFF
--- a/apps/scan/src/lib/discover/origins.ts
+++ b/apps/scan/src/lib/discover/origins.ts
@@ -45,11 +45,11 @@ const getDiscoverOriginsUncached = async (): Promise<string[]> => {
 };
 
 /**
- * Fetches blacklisted origin URLs for x402 from catalog.blacklisted_origins.
- * This is queried fresh on every call (not cached) so changes in manhog take
- * effect immediately without flushing Redis.
+ * Fetches origin URLs excluded from featured visibility (e.g. non-functional
+ * resources). Queried fresh on every call (not cached) so changes take effect
+ * immediately without flushing the origins Redis cache.
  */
-const getBlacklistedOrigins = async (): Promise<Set<string>> => {
+const getFeaturedExclusions = async (): Promise<Set<string>> => {
   try {
     const sql = getAgentCashSql();
     if (!sql) return new Set();
@@ -58,7 +58,7 @@ const getBlacklistedOrigins = async (): Promise<Set<string>> => {
     `) as { origin_url: string }[];
     return new Set(rows.map(r => String(r.origin_url)));
   } catch (error) {
-    console.warn('[discover] Failed to fetch blacklist, skipping filter:', error);
+    console.warn('[discover] Failed to fetch featured exclusions, skipping filter:', error);
     return new Set();
   }
 };
@@ -66,17 +66,17 @@ const getBlacklistedOrigins = async (): Promise<Set<string>> => {
 /**
  * Fetches x402-supporting, x402-active origins from the AgentCash catalog
  * (catalog.indexed_origins ⨝ catalog.origin_usage_signals). Cached in Redis.
- * Blacklisted origins (catalog.blacklisted_origins) are filtered post-cache
- * so changes take effect immediately. If the blacklist query fails, origins
- * are returned unfiltered.
+ * Origins excluded from featured visibility are filtered post-cache so changes
+ * take effect immediately. If the exclusion query fails, all origins are
+ * returned unfiltered.
  */
 export const getDiscoverOrigins = async (): Promise<string[]> => {
-  const [origins, blacklisted] = await Promise.all([
+  const [origins, excluded] = await Promise.all([
     getDiscoverOriginsFromCache(),
-    getBlacklistedOrigins(),
+    getFeaturedExclusions(),
   ]);
-  return blacklisted.size > 0
-    ? origins.filter(o => !blacklisted.has(o))
+  return excluded.size > 0
+    ? origins.filter(o => !excluded.has(o))
     : origins;
 };
 

--- a/apps/scan/src/lib/discover/origins.ts
+++ b/apps/scan/src/lib/discover/origins.ts
@@ -45,10 +45,42 @@ const getDiscoverOriginsUncached = async (): Promise<string[]> => {
 };
 
 /**
+ * Fetches blacklisted origin URLs for x402 from catalog.blacklisted_origins.
+ * This is queried fresh on every call (not cached) so changes in manhog take
+ * effect immediately without flushing Redis.
+ */
+const getBlacklistedOrigins = async (): Promise<Set<string>> => {
+  try {
+    const sql = getAgentCashSql();
+    if (!sql) return new Set();
+    const rows = (await sql`
+      SELECT origin_url FROM catalog.blacklisted_origins WHERE scanner = 'x402'
+    `) as { origin_url: string }[];
+    return new Set(rows.map(r => String(r.origin_url)));
+  } catch (error) {
+    console.warn('[discover] Failed to fetch blacklist, skipping filter:', error);
+    return new Set();
+  }
+};
+
+/**
  * Fetches x402-supporting, x402-active origins from the AgentCash catalog
  * (catalog.indexed_origins ⨝ catalog.origin_usage_signals). Cached in Redis.
+ * Blacklisted origins (catalog.blacklisted_origins) are filtered post-cache
+ * so changes take effect immediately. If the blacklist query fails, origins
+ * are returned unfiltered.
  */
 export const getDiscoverOrigins = async (): Promise<string[]> => {
+  const [origins, blacklisted] = await Promise.all([
+    getDiscoverOriginsFromCache(),
+    getBlacklistedOrigins(),
+  ]);
+  return blacklisted.size > 0
+    ? origins.filter(o => !blacklisted.has(o))
+    : origins;
+};
+
+const getDiscoverOriginsFromCache = async (): Promise<string[]> => {
   const redis = getRedisClient();
   if (redis) {
     const cached = await redis.get(CACHE_KEY).catch(() => null);


### PR DESCRIPTION
## Summary

Adds featured visibility filtering so origins with non-functional resources are excluded from the featured services page.

## How it works

**Architecture:**
1. On every request, a separate lightweight query checks which origins have been flagged for exclusion from featured visibility
2. Flagged origins are filtered out **after** the cache read, so visibility changes take effect immediately on the next page load — no Redis flush needed
3. If the visibility query fails (DB down, table missing, etc.), origins are returned **unfiltered** — graceful degradation, the featured page never breaks

**Why post-cache filtering?** The origins list is cached in Redis with a TTL and warmed by a cron job. Post-cache filtering means visibility changes are always fresh while the origins list stays efficiently cached.

## Changes

- `apps/scan/src/lib/discover/origins.ts`: Added a function to fetch excluded origins with try-catch for graceful degradation. Refactored `getDiscoverOrigins()` to fetch the origins list and exclusions in parallel, then filter.

## Testing

- Verified locally: flagged an origin with non-functional resources → confirmed it no longer appears on the featured page
- Verified removal: unflagged → confirmed it reappeared
- Verified graceful degradation: query failure returns empty set, featured page loads normally
- Type-checks pass