### PR TITLE
Fix resource card row heights and bazaar sort ordering

### DIFF
--- a/apps/scan/instrumentation.ts
+++ b/apps/scan/instrumentation.ts
@@ -47,11 +47,13 @@ export async function register() {
       }
     }
 
-    const { Laminar } = await import('@lmnr-ai/lmnr');
+    if (process.env.LMNR_PROJECT_API_KEY) {
+      const { Laminar } = await import('@lmnr-ai/lmnr');
 
-    Laminar.initialize({
-      projectApiKey: process.env.LMNR_PROJECT_API_KEY,
-    });
+      Laminar.initialize({
+        projectApiKey: process.env.LMNR_PROJECT_API_KEY,
+      });
+    }
   }
 }
 

--- a/apps/scan/src/app/(app)/(home)/(overview)/_components/sellers/featured-columns.tsx
+++ b/apps/scan/src/app/(app)/(home)/(overview)/_components/sellers/featured-columns.tsx
@@ -262,8 +262,6 @@ const ServerCell: React.FC<{ item: FeaturedServiceItem }> = ({ item }) => {
   const description = rawDescription
     ? cleanExternalText(rawDescription)
     : null;
-  const showHostnameLine = title !== hostname;
-
   const recipients = item.recipients;
   const endpoint = item.searchEndpoint;
   const otherOrigins = item.origins.slice(1);
@@ -290,16 +288,12 @@ const ServerCell: React.FC<{ item: FeaturedServiceItem }> = ({ item }) => {
             </span>
           ) : null}
         </div>
-        {description ? (
-          <div className="truncate text-xs text-muted-foreground mt-0.5">
-            {description}
-          </div>
-        ) : null}
-        {showHostnameLine ? (
-          <div className="truncate text-[11px] font-mono text-muted-foreground/70 mt-0.5">
-            {hostname}
-          </div>
-        ) : null}
+        <div className="truncate text-xs text-muted-foreground mt-0.5">
+          {description ?? 'No description available.'}
+        </div>
+        <div className="truncate text-[11px] font-mono text-muted-foreground/70 mt-0.5">
+          {hostname}
+        </div>
       </div>
     </>
   );

--- a/apps/scan/src/services/db/bazaar/origins.ts
+++ b/apps/scan/src/services/db/bazaar/origins.ts
@@ -136,19 +136,40 @@ const listBazaarOriginsUncached = async (
     chains: Array.from(item.chains),
   }));
 
-  // Editorial sort preserves the curated order of `originUrls` (search-ranked
-  // by AgentCash). The MV doesn't know about this ordering, so we resort here.
+  // Re-sort after grouping. The MV sorts per-recipient, but aggregation
+  // changes the totals so we need to re-sort the grouped results.
+  const sortableNumericKeys = [
+    'tx_count',
+    'total_amount',
+    'unique_buyers',
+  ] as const;
+  type SortableNumericKey = (typeof sortableNumericKeys)[number];
+
+  const direction = input.sorting.desc ? -1 : 1;
+
   if (input.sorting.id === 'editorial' && input.originUrls) {
     const editorialIndex = new Map(
       input.originUrls.map((url, index) => [url, index])
     );
     const fallback = editorialIndex.size;
-    const direction = input.sorting.desc ? -1 : 1;
     groupedItems.sort((a, b) => {
       const aRank = editorialIndex.get(a.origins[0]?.origin ?? '') ?? fallback;
       const bRank = editorialIndex.get(b.origins[0]?.origin ?? '') ?? fallback;
       return (aRank - bRank) * direction;
     });
+  } else if (input.sorting.id === 'latest_block_timestamp') {
+    groupedItems.sort((a, b) => {
+      const aTime = a.latest_block_timestamp?.getTime() ?? 0;
+      const bTime = b.latest_block_timestamp?.getTime() ?? 0;
+      return (aTime - bTime) * direction;
+    });
+  } else if (
+    sortableNumericKeys.includes(
+      input.sorting.id as SortableNumericKey
+    )
+  ) {
+    const key = input.sorting.id as SortableNumericKey;
+    groupedItems.sort((a, b) => (a[key] - b[key]) * direction);
   }
 
   const response = toPaginatedResponse({


### PR DESCRIPTION
## Summary
- **Consistent row heights**: ServerCell now always renders description (falls back to "No description available.") and hostname lines, ensuring uniform row height in Discover and All tabs
- **Fix bazaar sort**: Re-sort grouped results after origin aggregation — the MV sorts per-recipient but grouping changes totals, breaking tx_count/volume/buyers/timestamp ordering
