### PR TITLE
Add programmatic resource registration API

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ pnpm dev:sync
 ## Documentation
 
 - **[x402 Discovery Document Guide](./docs/DISCOVERY.md)** - Learn how to implement discovery for your x402 server to enable automatic resource registration
+- **[Programmatic Resource Registration](./docs/PROGRAMMATIC-REGISTRATION.md)** - Add or refresh resources from scripts, CI, or provider backends without using the web form
 
 ## Contributing
 
@@ -59,6 +60,8 @@ We're actively seeking contributors to help build x402scan. We believe an ecosys
 ### Add Resources
 
 If you know of a resource that is not yet listed, you can add it by visiting [https://www.x402scan.com/resources/register](https://www.x402scan.com/resources/register) and submitting the URL. If the URL returns a valid x402 schema, it will be added to the resources list automatically.
+
+Resource providers can also register or refresh resources programmatically with `POST /api/v1/resources/register` or `POST /api/v1/resources/register-origin`; see the [programmatic registration guide](./docs/PROGRAMMATIC-REGISTRATION.md).
 
 ### Add Facilitators
 

--- a/apps/scan/src/app/api/resources/register-origin/route.ts
+++ b/apps/scan/src/app/api/resources/register-origin/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import z from 'zod';
+
+import {
+  registerOrigin,
+  registerOriginRequestSchema,
+} from '@/lib/resource-registration-api';
+
+function errorStatus(errorType: string) {
+  switch (errorType) {
+    case 'invalidRequest':
+      return 400;
+    case 'noDiscovery':
+    case 'noValidResources':
+      return 422;
+    default:
+      return 500;
+  }
+}
+
+export const POST = async (request: NextRequest) => {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      {
+        success: false as const,
+        error: {
+          type: 'invalidRequest' as const,
+          message: 'Request body must be valid JSON',
+        },
+      },
+      { status: 400 }
+    );
+  }
+
+  const parsed = registerOriginRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        success: false as const,
+        error: {
+          type: 'invalidRequest' as const,
+          issues: z.treeifyError(parsed.error),
+        },
+      },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const result = await registerOrigin(parsed.data);
+    return NextResponse.json(result, {
+      status: result.success ? 200 : errorStatus(result.error.type),
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false as const,
+        error: {
+          type: 'serverError' as const,
+          message: error instanceof Error ? error.message : 'Unknown error',
+        },
+      },
+      { status: 500 }
+    );
+  }
+};
+

--- a/apps/scan/src/app/api/resources/register/route.ts
+++ b/apps/scan/src/app/api/resources/register/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import z from 'zod';
+
+import {
+  registerResourceUrl,
+  registerResourceUrlRequestSchema,
+} from '@/lib/resource-registration-api';
+
+function errorStatus(errorType: string) {
+  switch (errorType) {
+    case 'invalidRequest':
+      return 400;
+    case 'no402':
+    case 'parseErrors':
+      return 422;
+    default:
+      return 500;
+  }
+}
+
+export const POST = async (request: NextRequest) => {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      {
+        success: false as const,
+        error: {
+          type: 'invalidRequest' as const,
+          message: 'Request body must be valid JSON',
+        },
+      },
+      { status: 400 }
+    );
+  }
+
+  const parsed = registerResourceUrlRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        success: false as const,
+        error: {
+          type: 'invalidRequest' as const,
+          issues: z.treeifyError(parsed.error),
+        },
+      },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const result = await registerResourceUrl(parsed.data);
+    return NextResponse.json(result, {
+      status: result.success ? 200 : errorStatus(result.error.type),
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false as const,
+        error: {
+          type: 'serverError' as const,
+          message: error instanceof Error ? error.message : 'Unknown error',
+        },
+      },
+      { status: 500 }
+    );
+  }
+};
+

--- a/apps/scan/src/app/api/v1/resources/register-origin/route.ts
+++ b/apps/scan/src/app/api/v1/resources/register-origin/route.ts
@@ -1,0 +1,2 @@
+export { POST } from '@/app/api/resources/register-origin/route';
+

--- a/apps/scan/src/app/api/v1/resources/register/route.ts
+++ b/apps/scan/src/app/api/v1/resources/register/route.ts
@@ -1,0 +1,2 @@
+export { POST } from '@/app/api/resources/register/route';
+

--- a/apps/scan/src/lib/resource-registration-api.test.ts
+++ b/apps/scan/src/lib/resource-registration-api.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { probeX402Endpoint } from '@/lib/discovery/probe';
+import { registerResourcesFromDiscovery } from '@/lib/discovery/register-origin';
+import { registerResource } from '@/lib/resources';
+import { fetchDiscoveryDocument } from '@/services/discovery';
+
+import { registerOrigin, registerResourceUrl } from './resource-registration-api';
+
+vi.mock('@/lib/discovery/probe', () => ({
+  probeX402Endpoint: vi.fn(),
+}));
+
+vi.mock('@/lib/discovery/register-origin', () => ({
+  registerResourcesFromDiscovery: vi.fn(),
+}));
+
+vi.mock('@/lib/resources', () => ({
+  registerResource: vi.fn(),
+}));
+
+vi.mock('@/services/discovery', () => ({
+  fetchDiscoveryDocument: vi.fn(),
+}));
+
+const mockProbeX402Endpoint = vi.mocked(probeX402Endpoint);
+const mockRegisterResource = vi.mocked(registerResource);
+const mockFetchDiscoveryDocument = vi.mocked(fetchDiscoveryDocument);
+const mockRegisterResourcesFromDiscovery = vi.mocked(
+  registerResourcesFromDiscovery
+);
+
+describe('registerResourceUrl', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('probes, registers, and reports related discovery resources', async () => {
+    mockProbeX402Endpoint.mockResolvedValue({
+      success: true,
+      advisory: {
+        method: 'POST',
+        paymentOptions: [],
+      },
+    } as never);
+    mockRegisterResource.mockResolvedValue({
+      success: true,
+      resource: { resource: { id: 'resource-id' } },
+      accepts: [],
+    } as never);
+    mockFetchDiscoveryDocument.mockResolvedValue({
+      success: true,
+      source: 'well-known',
+      resources: [
+        { url: 'https://seller.example/api/price' },
+        { url: 'https://seller.example/api/quote' },
+      ],
+    } as never);
+
+    const result = await registerResourceUrl({
+      url: 'https://seller.example/api/price',
+    });
+
+    expect(mockProbeX402Endpoint).toHaveBeenCalledWith(
+      'https://seller.example/api/price'
+    );
+    expect(mockRegisterResource).toHaveBeenCalledWith(
+      'https://seller.example/api/price',
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect(result).toMatchObject({
+      success: true,
+      methodUsed: 'POST',
+      discovery: {
+        found: true,
+        otherResourceCount: 1,
+        resources: ['https://seller.example/api/quote'],
+      },
+    });
+  });
+
+  it('returns a no402 error without writing when probing fails', async () => {
+    mockProbeX402Endpoint.mockResolvedValue({
+      success: false,
+      error: 'Expected 402, got 200',
+    } as never);
+
+    const result = await registerResourceUrl({
+      url: 'https://seller.example/free',
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: { type: 'no402' },
+    });
+    expect(mockRegisterResource).not.toHaveBeenCalled();
+  });
+});
+
+describe('registerOrigin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('registers all resources from an origin discovery document', async () => {
+    mockFetchDiscoveryDocument.mockResolvedValue({
+      success: true,
+      source: 'openapi',
+      resources: [{ url: 'https://seller.example/api/price' }],
+    } as never);
+    mockRegisterResourcesFromDiscovery.mockResolvedValue({
+      registered: 1,
+      failed: [],
+      skipped: [],
+    } as never);
+
+    const result = await registerOrigin({
+      origin: 'https://seller.example',
+    });
+
+    expect(mockRegisterResourcesFromDiscovery).toHaveBeenCalledWith(
+      [{ url: 'https://seller.example/api/price' }],
+      'openapi'
+    );
+    expect(result).toMatchObject({ success: true, registered: 1 });
+  });
+
+  it('returns noDiscovery when the origin has no discovery document', async () => {
+    mockFetchDiscoveryDocument.mockResolvedValue({
+      success: false,
+      error: 'No discovery document found',
+    } as never);
+
+    const result = await registerOrigin({
+      origin: 'https://seller.example',
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: {
+        type: 'noDiscovery',
+        message: 'No discovery document found',
+      },
+    });
+    expect(mockRegisterResourcesFromDiscovery).not.toHaveBeenCalled();
+  });
+});
+

--- a/apps/scan/src/lib/resource-registration-api.ts
+++ b/apps/scan/src/lib/resource-registration-api.ts
@@ -1,0 +1,123 @@
+import z from 'zod';
+
+import { probeX402Endpoint } from '@/lib/discovery/probe';
+import { registerResourcesFromDiscovery } from '@/lib/discovery/register-origin';
+import { registerResource } from '@/lib/resources';
+import { fetchDiscoveryDocument } from '@/services/discovery';
+import { getOriginFromUrl, normalizeUrl } from '@/lib/url';
+
+import type { DiscoveryInfo } from '@/types/discovery';
+
+export const registerResourceUrlRequestSchema = z.object({
+  url: z.url(),
+});
+
+export const registerOriginRequestSchema = z.object({
+  origin: z.url(),
+});
+
+export type RegisterResourceUrlRequest = z.infer<
+  typeof registerResourceUrlRequestSchema
+>;
+export type RegisterOriginRequest = z.infer<typeof registerOriginRequestSchema>;
+
+export async function registerResourceUrl(input: RegisterResourceUrlRequest) {
+  const url = input.url.toString();
+  const probeUrl = url.replaceAll('{', '').replaceAll('}', '');
+  const probeResult = await probeX402Endpoint(probeUrl);
+
+  if (!probeResult.success) {
+    return { success: false as const, error: { type: 'no402' as const } };
+  }
+
+  const result = await registerResource(url, probeResult.advisory);
+
+  if (result.success === false) {
+    return {
+      success: false as const,
+      data: result.data,
+      error: {
+        type: 'parseErrors' as const,
+        parseErrors:
+          result.error.type === 'parseResponse'
+            ? result.error.parseErrors
+            : [JSON.stringify(result.error)],
+      },
+    };
+  }
+
+  const origin = getOriginFromUrl(url);
+  let discovery: DiscoveryInfo = {
+    found: false,
+    otherResourceCount: 0,
+    origin,
+  };
+
+  try {
+    const discoveryResult = await fetchDiscoveryDocument(origin);
+    if (discoveryResult.success && Array.isArray(discoveryResult.resources)) {
+      const normalizedInputUrl = normalizeUrl(url);
+      const otherResources = discoveryResult.resources.filter(resource => {
+        if (
+          !resource ||
+          typeof resource !== 'object' ||
+          !('url' in resource) ||
+          typeof resource.url !== 'string'
+        ) {
+          return false;
+        }
+        return normalizeUrl(resource.url) !== normalizedInputUrl;
+      });
+
+      discovery = {
+        found: true,
+        source: discoveryResult.source,
+        otherResourceCount: otherResources.length,
+        origin,
+        resources: otherResources.map(resource => resource.url),
+      };
+    }
+  } catch {
+    // Registration should not fail just because optional discovery lookup failed.
+  }
+
+  return {
+    ...result,
+    methodUsed: probeResult.advisory.method,
+    discovery,
+  };
+}
+
+export async function registerOrigin(input: RegisterOriginRequest) {
+  const discoveryResult = await fetchDiscoveryDocument(input.origin);
+
+  if (!discoveryResult.success) {
+    return {
+      success: false as const,
+      error: {
+        type: 'noDiscovery' as const,
+        message: discoveryResult.error ?? 'No discovery document found',
+      },
+    };
+  }
+
+  const result = await registerResourcesFromDiscovery(
+    discoveryResult.resources,
+    discoveryResult.source
+  );
+
+  if (result.registered === 0) {
+    return {
+      success: false as const,
+      error: {
+        type: 'noValidResources' as const,
+        message:
+          'No valid paid x402 resources were found for this origin. Add at least one paid x402 resource that passes validation to complete registration.',
+      },
+      result,
+    };
+  }
+
+  return { success: true as const, ...result };
+}
+

--- a/docs/PROGRAMMATIC-REGISTRATION.md
+++ b/docs/PROGRAMMATIC-REGISTRATION.md
@@ -1,0 +1,68 @@
+# Programmatic Resource Registration
+
+Providers can register resources without using the web form by calling the public registration API. These endpoints perform the same validation as the in-app registration flow: x402scan probes the endpoint, requires a parseable `402` challenge for endpoint registration, and stores valid paid resources.
+
+## Register One Resource
+
+Use this when you want to add or refresh a specific resource URL.
+
+```bash
+curl -sS -X POST https://x402scan.com/api/v1/resources/register \
+  -H "Content-Type: application/json" \
+  -d '{"url":"https://yourdomain.com/api/paid-route"}'
+```
+
+Successful responses include the registered resource, the HTTP method that produced the x402 challenge, and discovery hints for other resources on the same origin.
+
+```json
+{
+  "success": true,
+  "methodUsed": "POST",
+  "discovery": {
+    "found": true,
+    "otherResourceCount": 1,
+    "origin": "https://yourdomain.com",
+    "resources": ["https://yourdomain.com/api/other-paid-route"]
+  }
+}
+```
+
+If the URL does not return a valid x402 challenge, the API returns `422` with `success: false`.
+
+## Register an Origin
+
+Use this when your origin exposes OpenAPI discovery or `/.well-known/x402` and you want x402scan to register every discovered paid resource.
+
+```bash
+curl -sS -X POST https://x402scan.com/api/v1/resources/register-origin \
+  -H "Content-Type: application/json" \
+  -d '{"origin":"https://yourdomain.com"}'
+```
+
+The response reports how many discovered resources were registered, failed, or skipped.
+
+## Request Schema
+
+`POST /api/v1/resources/register`
+
+```json
+{
+  "url": "https://yourdomain.com/api/paid-route"
+}
+```
+
+`POST /api/v1/resources/register-origin`
+
+```json
+{
+  "origin": "https://yourdomain.com"
+}
+```
+
+Both endpoints accept JSON only. Invalid request bodies return `400`.
+
+## Expected Resource Behavior
+
+For endpoint registration, the target URL must return `402 Payment Required` with a parseable x402 challenge. Challenge data should include non-empty payment requirements and an input schema so x402scan can render the resource for users and agents.
+
+For origin registration, publish discovery metadata using the [x402 Discovery Document Guide](./DISCOVERY.md). OpenAPI discovery is preferred; `/.well-known/x402` remains supported for compatibility.


### PR DESCRIPTION
## Summary
- add public JSON endpoints for registering a single resource URL and registering all resources discovered from an origin
- expose stable `/api/v1/resources/register` and `/api/v1/resources/register-origin` aliases while preserving unversioned app routes
- reuse the existing probe/register/discovery flow so programmatic calls behave like the web form
- document curl examples and response/error behavior for resource providers

/claim #104

## Test plan
- `git diff --check`
- Attempted `pnpm --filter @x402scan/app test:run src/lib/resource-registration-api.test.ts`; blocked because this fresh clone has no `node_modules` and the machine has very low free disk (~2 GB), so Vitest is not installed locally.

## Notes
- This replaces the stale closed PR #110 against the current `apps/scan` layout.
- I kept the implementation thin by sharing the existing registration logic instead of forking a second resource ingestion path.