### PR TITLE
docs: document resource registry API

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ We're actively seeking contributors to help build x402scan. We believe an ecosys
 
 ### Add Resources
 
-If you know of a resource that is not yet listed, you can add it by visiting [https://www.x402scan.com/resources/register](https://www.x402scan.com/resources/register) and submitting the URL. If the URL returns a valid x402 schema, it will be added to the resources list automatically.
+If you know of a resource that is not yet listed, you can add it by visiting [https://www.x402scan.com/resources/register](https://www.x402scan.com/resources/register) and submitting the URL. If the URL returns a valid x402 schema, it will be added to the resources list automatically. Resource providers can also register or refresh resources programmatically with the [Resource Registry API](./docs/RESOURCE_REGISTRY_API.md).
 
 ### Add Facilitators
 

--- a/apps/scan/src/app/api/x402/registry/register-origin/route.ts
+++ b/apps/scan/src/app/api/x402/registry/register-origin/route.ts
@@ -9,6 +9,8 @@ export const POST = withCors(
     .route('x402/registry/register-origin')
     .siwx()
     .body(registryRegisterOriginBodySchema)
-    .description('Discover and register all x402 resources from an origin')
+    .description(
+      'Discover, register, or refresh all x402 resources from an origin'
+    )
     .handler(({ body }) => handleRegistryRegisterOrigin(body))
 );

--- a/apps/scan/src/app/api/x402/registry/register/route.ts
+++ b/apps/scan/src/app/api/x402/registry/register/route.ts
@@ -9,6 +9,6 @@ export const POST = withCors(
     .route('x402/registry/register')
     .siwx()
     .body(registryRegisterBodySchema)
-    .description('Register an x402-protected resource')
+    .description('Register or refresh an x402-protected resource')
     .handler(({ body }) => handleRegistryRegister(body))
 );

--- a/apps/scan/src/lib/router.ts
+++ b/apps/scan/src/lib/router.ts
@@ -46,8 +46,8 @@ export const router = createRouter({
 - GET /api/x402/registry/origin?url= — all registered resources for an origin
 
 ## Registry endpoints (SIWX, free)
-- POST /api/x402/registry/register — register a single x402 resource by URL
-- POST /api/x402/registry/register-origin — discover and register all resources from an origin via OpenAPI or .well-known/x402
+- POST /api/x402/registry/register — register or refresh a single x402 resource by URL
+- POST /api/x402/registry/register-origin — discover, register, or refresh all resources from an origin via OpenAPI or .well-known/x402
 
 ## Send endpoint (x402, dynamic price)
 - POST /api/x402/send — send USDC to an address on Base or Solana`,

--- a/docs/DISCOVERY.md
+++ b/docs/DISCOVERY.md
@@ -8,6 +8,9 @@ If you want reliable pickup, implement discovery in this order:
 2. `/.well-known/x402` (compatibility)
 
 If you cannot expose discovery yet, endpoint-only manual registration still works.
+For scripts and CI jobs, use the
+[Resource Registry API](./RESOURCE_REGISTRY_API.md) to register or refresh
+resources programmatically.
 
 ## TL;DR
 
@@ -23,6 +26,7 @@ Runtime `402` behavior is authoritative over static metadata.
 ## A) OpenAPI-First Discovery (Recommended)
 
 Supported URLs:
+
 - `https://yourdomain.com/openapi.json`
 
 ### Required top-level fields
@@ -35,6 +39,7 @@ Supported URLs:
 ### Per-paid-operation requirements
 
 For each paid operation:
+
 - declare `x-payment-info`
 - include a `402` response in `responses`
 - include `x-payment-info.protocols` (for example `"x402"`)
@@ -98,16 +103,21 @@ Optional fields:
 Use this when discovery docs are not available yet.
 
 A route is registerable when probing returns `402` with a parseable x402 challenge.
+To register or refresh this URL through the public API, call
+`POST /api/x402/registry/register`.
 
 Accepted challenge transport:
+
 - `Payment-Required` header (x402 v2), or
 - JSON response body (legacy compatibility)
 
 For payable indexing in `x402scan`, challenge data should include:
+
 - non-empty `accepts`
 - Bazaar-style input schema (`extensions.bazaar.info` + schema-derived input)
 
 Compatibility behavior:
+
 - `402` + `accepts: []` + `extensions["sign-in-with-x"]` => SIWX auth-only, marked `skipped`.
 - Missing input schema => strict non-invocable, marked `skipped`.
 
@@ -116,6 +126,7 @@ Compatibility behavior:
 ## Ownership Proofs
 
 Accepted locations:
+
 - OpenAPI `x-discovery.ownershipProofs` (preferred)
 - `/.well-known/x402` `ownershipProofs` (compatibility)
 
@@ -136,6 +147,12 @@ When a user clicks **Register This URL Only**:
 - Skip fan-out.
 - Register only that endpoint.
 - Useful for partial rollouts and rate-limited providers.
+
+Programmatic callers can trigger the same flows through:
+
+- `POST /api/x402/registry/register` for a single endpoint
+- `POST /api/x402/registry/register-origin` for origin discovery and bulk
+  registration
 
 ---
 

--- a/docs/RESOURCE_REGISTRY_API.md
+++ b/docs/RESOURCE_REGISTRY_API.md
@@ -23,7 +23,7 @@ Registry write endpoints require Sign-In With X (SIWX) wallet authentication.
 Send SIWX auth headers with the request. If you use the x402 tooling, call
 these endpoints with `fetch_with_auth`.
 
-Required headers:
+Required headers for write endpoints:
 
 ```http
 Content-Type: application/json
@@ -150,6 +150,8 @@ Example:
 ```bash
 curl 'https://www.x402scan.com/api/x402/registry/origin?url=https%3A%2F%2Fapi.example.com'
 ```
+
+This read endpoint does not require SIWX headers.
 
 ## Registration Requirements
 

--- a/docs/RESOURCE_REGISTRY_API.md
+++ b/docs/RESOURCE_REGISTRY_API.md
@@ -1,0 +1,168 @@
+# x402scan Resource Registry API
+
+Resource providers can register or refresh x402 resources without using the
+website form. The registry API uses the same backend registration flow as the
+manual page and is intended for release scripts, CI jobs, and provider
+dashboards.
+
+Use the production base URL:
+
+```text
+https://www.x402scan.com
+```
+
+The API is also included in the generated OpenAPI document:
+
+```text
+GET https://www.x402scan.com/openapi.json
+```
+
+## Authentication
+
+Registry write endpoints require Sign-In With X (SIWX) wallet authentication.
+Send SIWX auth headers with the request. If you use the x402 tooling, call
+these endpoints with `fetch_with_auth`.
+
+Required headers:
+
+```http
+Content-Type: application/json
+SIGN-IN-WITH-X: <siwx proof>
+```
+
+The endpoints are free to call. x402 payment headers are not required for
+registration writes.
+
+## Register or Refresh a Single Resource
+
+Register one x402-protected endpoint by URL:
+
+```http
+POST /api/x402/registry/register
+```
+
+Request body:
+
+```json
+{
+  "url": "https://api.example.com/paid/tool"
+}
+```
+
+Example:
+
+```bash
+curl -X POST 'https://www.x402scan.com/api/x402/registry/register' \
+  -H 'Content-Type: application/json' \
+  -H 'SIGN-IN-WITH-X: <siwx proof>' \
+  --data '{"url":"https://api.example.com/paid/tool"}'
+```
+
+Calling this endpoint again refreshes the existing registry entry. x402scan
+probes the URL, parses the current 402 challenge, updates resource metadata,
+updates accepted payment requirements, and refreshes origin metadata.
+
+Successful response:
+
+```json
+{
+  "success": true,
+  "resource": {
+    "resource": "https://api.example.com/paid/tool"
+  },
+  "accepts": [],
+  "registrationDetails": {
+    "originMetadata": {
+      "title": "Example API"
+    }
+  }
+}
+```
+
+Validation failure:
+
+```json
+{
+  "success": false,
+  "error": {
+    "type": "no_402",
+    "message": "Endpoint did not return a 402 payment challenge"
+  }
+}
+```
+
+## Register or Refresh an Origin
+
+Discover and register all x402 resources exposed by an origin:
+
+```http
+POST /api/x402/registry/register-origin
+```
+
+Request body:
+
+```json
+{
+  "origin": "https://api.example.com"
+}
+```
+
+Example:
+
+```bash
+curl -X POST 'https://www.x402scan.com/api/x402/registry/register-origin' \
+  -H 'Content-Type: application/json' \
+  -H 'SIGN-IN-WITH-X: <siwx proof>' \
+  --data '{"origin":"https://api.example.com"}'
+```
+
+x402scan discovers resources from the origin by checking OpenAPI first and then
+`/.well-known/x402`. Valid paid resources are registered or refreshed. Resources
+from the same origin that disappear from discovery are deprecated.
+
+Successful response:
+
+```json
+{
+  "success": true,
+  "registered": 2,
+  "siwx": 0,
+  "failed": 0,
+  "skipped": 0,
+  "deprecated": 0,
+  "total": 2,
+  "source": "https://api.example.com/openapi.json"
+}
+```
+
+The response also includes `failedDetails` and `siwxDetails` when relevant.
+
+## Check Registered Resources for an Origin
+
+After registering, list resources x402scan knows about for an origin:
+
+```http
+GET /api/x402/registry/origin?url=https%3A%2F%2Fapi.example.com
+```
+
+Example:
+
+```bash
+curl 'https://www.x402scan.com/api/x402/registry/origin?url=https%3A%2F%2Fapi.example.com'
+```
+
+## Registration Requirements
+
+For single-resource registration, the endpoint must return a parseable x402
+`402 Payment Required` response when probed. For origin registration, expose
+OpenAPI or `/.well-known/x402` discovery so x402scan can find the resource URLs.
+
+For indexed paid resources, the 402 challenge should include:
+
+- at least one x402 payment option on a supported network
+- a schema x402scan can use for Bazaar/tool invocation metadata
+- stable origin metadata, including title, description, and favicon when
+  available
+
+See [DISCOVERY.md](./DISCOVERY.md) for the full discovery and registration
+contract.


### PR DESCRIPTION
Fixes #104.

## Summary
- add provider-facing docs for registering or refreshing x402 resources programmatically
- document the SIWX-protected single-resource and origin registration endpoints with curl examples and response shapes
- link the registry API docs from the README and discovery spec
- update OpenAPI route descriptions to state that calls can refresh existing resources

## Verification
- `git diff --check`
- `pnpm dlx prettier@3.7.4 --check README.md docs/DISCOVERY.md docs/RESOURCE_REGISTRY_API.md apps/scan/src/app/api/x402/registry/register/route.ts apps/scan/src/app/api/x402/registry/register-origin/route.ts apps/scan/src/lib/router.ts`