### PR TITLE
Standardize CDP SQL numeric schemas

### DIFF
--- a/apps/scan/src/services/transfers/buyers/list-mv.ts
+++ b/apps/scan/src/services/transfers/buyers/list-mv.ts
@@ -4,7 +4,11 @@ import { Prisma } from '@x402scan/transfers-db';
 import { chainSchema, mixedAddressSchema } from '@/lib/schemas';
 import { toPaginatedResponse } from '@/lib/pagination';
 
-import { baseListQuerySchema } from '../schemas';
+import {
+  baseListQuerySchema,
+  cdpSqlIntegerSchema,
+  cdpSqlNumberSchema,
+} from '../schemas';
 import {
   createCachedPaginatedQuery,
   createStandardCacheKey,
@@ -105,10 +109,10 @@ const listTopBuyersMVUncached = async (
         z.object({
           sender: mixedAddressSchema,
           facilitator_ids: z.array(z.string()),
-          tx_count: z.number(),
-          total_amount: z.number(),
+          tx_count: cdpSqlIntegerSchema,
+          total_amount: cdpSqlNumberSchema,
           latest_block_timestamp: z.date().nullable(),
-          unique_sellers: z.number(),
+          unique_sellers: cdpSqlIntegerSchema,
           chains: z.array(chainSchema),
         })
       )
@@ -131,7 +135,7 @@ const listTopBuyersMVUncached = async (
       `,
         z.array(
           z.object({
-            count: z.number(),
+            count: cdpSqlIntegerSchema,
           })
         )
       );

--- a/apps/scan/src/services/transfers/buyers/sellers/list.ts
+++ b/apps/scan/src/services/transfers/buyers/sellers/list.ts
@@ -4,7 +4,11 @@ import { Prisma } from '@x402scan/transfers-db';
 import { chainSchema, mixedAddressSchema } from '@/lib/schemas';
 import { toPaginatedResponse } from '@/lib/pagination';
 
-import { baseListQuerySchema } from '../../schemas';
+import {
+  baseListQuerySchema,
+  cdpSqlIntegerSchema,
+  cdpSqlNumberSchema,
+} from '../../schemas';
 import {
   createCachedPaginatedQuery,
   createStandardCacheKey,
@@ -74,8 +78,8 @@ const listBuyerSellersUncached = async (
     z.array(
       z.object({
         recipient: mixedAddressSchema,
-        tx_count: z.number(),
-        total_amount: z.number(),
+        tx_count: cdpSqlIntegerSchema,
+        total_amount: cdpSqlNumberSchema,
         latest_block_timestamp: z.date().nullable(),
         chains: z.array(chainSchema),
         facilitator_ids: z.array(z.string()),
@@ -96,7 +100,7 @@ const listBuyerSellersUncached = async (
       `,
       z.array(
         z.object({
-          count: z.number(),
+          count: cdpSqlIntegerSchema,
         })
       )
     );

--- a/apps/scan/src/services/transfers/buyers/stats/bucketed-mv.ts
+++ b/apps/scan/src/services/transfers/buyers/stats/bucketed-mv.ts
@@ -1,7 +1,11 @@
 import z from 'zod';
 import { Prisma } from '@x402scan/transfers-db';
 
-import { baseBucketedQuerySchema } from '../../schemas';
+import {
+  baseBucketedQuerySchema,
+  cdpSqlIntegerSchema,
+  cdpSqlNumberSchema,
+} from '../../schemas';
 import { createCachedArrayQuery, createStandardCacheKey } from '@/lib/cache';
 import { queryRaw } from '@/services/transfers/client';
 import { getMaterializedViewSuffix } from '@/lib/time-range';
@@ -11,11 +15,11 @@ export const bucketedBuyerStatisticsMVInputSchema = baseBucketedQuerySchema;
 const bucketedBuyerResultSchema = z.array(
   z.object({
     bucket_start: z.date(),
-    total_buyers: z.number(),
-    total_transactions: z.number(),
-    total_amount: z.number(),
-    unique_sellers: z.number(),
-    new_buyers: z.number(),
+    total_buyers: cdpSqlIntegerSchema,
+    total_transactions: cdpSqlIntegerSchema,
+    total_amount: cdpSqlNumberSchema,
+    unique_sellers: cdpSqlIntegerSchema,
+    new_buyers: cdpSqlIntegerSchema,
   })
 );
 
@@ -51,7 +55,7 @@ const getBucketedBuyerStatisticsMVUncached = async (
     ' '
   );
 
-  // Query bucketed stats — new_buyers omitted for now (requires sender_first_seen MV)
+  // Query bucketed stats ??new_buyers omitted for now (requires sender_first_seen MV)
   const sql = Prisma.sql`
     SELECT
       ssb.bucket AS bucket_start,

--- a/apps/scan/src/services/transfers/buyers/stats/overall-mv.ts
+++ b/apps/scan/src/services/transfers/buyers/stats/overall-mv.ts
@@ -1,7 +1,11 @@
 import z from 'zod';
 import { Prisma } from '@x402scan/transfers-db';
 
-import { baseQuerySchema } from '../../schemas';
+import {
+  baseQuerySchema,
+  cdpSqlIntegerSchema,
+  cdpSqlNumberSchema,
+} from '../../schemas';
 import { createCachedQuery, createStandardCacheKey } from '@/lib/cache';
 import { queryRaw } from '@/services/transfers/client';
 import { getMaterializedViewSuffix } from '@/lib/time-range';
@@ -68,12 +72,12 @@ const getOverallBuyerStatisticsMVUncached = async (
       sql,
       z.array(
         z.object({
-          total_buyers: z.number(),
-          total_transactions: z.number(),
-          total_amount: z.number(),
-          unique_sellers: z.number(),
+          total_buyers: cdpSqlIntegerSchema,
+          total_transactions: cdpSqlIntegerSchema,
+          total_amount: cdpSqlNumberSchema,
+          unique_sellers: cdpSqlIntegerSchema,
           latest_block_timestamp: z.date().nullable(),
-          new_buyers: z.number(),
+          new_buyers: cdpSqlIntegerSchema,
         })
       )
     );

--- a/apps/scan/src/services/transfers/facilitators/bucketed.ts
+++ b/apps/scan/src/services/transfers/facilitators/bucketed.ts
@@ -2,7 +2,11 @@ import z from 'zod';
 
 import { Prisma } from '@x402scan/transfers-db';
 
-import { baseBucketedQuerySchema } from '../schemas';
+import {
+  baseBucketedQuerySchema,
+  cdpSqlIntegerSchema,
+  cdpSqlNumberSchema,
+} from '../schemas';
 
 import { queryRaw } from '@/services/transfers/client';
 
@@ -131,18 +135,18 @@ const getBucketedFacilitatorsStatisticsUncached = async (
         facilitators: z.record(
           z.string(),
           z.object({
-            total_transactions: z.number(),
-            total_amount: z.number(),
-            unique_buyers: z.number(),
-            unique_sellers: z.number(),
+            total_transactions: cdpSqlIntegerSchema,
+            total_amount: cdpSqlNumberSchema,
+            unique_buyers: cdpSqlIntegerSchema,
+            unique_sellers: cdpSqlIntegerSchema,
           })
         ),
         totals: z
           .record(
             z.string(),
             z.object({
-              totalTransactions: z.number(),
-              totalAmount: z.number(),
+              totalTransactions: cdpSqlIntegerSchema,
+              totalAmount: cdpSqlNumberSchema,
             })
           )
           .nullable(),

--- a/apps/scan/src/services/transfers/facilitators/list.ts
+++ b/apps/scan/src/services/transfers/facilitators/list.ts
@@ -1,6 +1,10 @@
 import z from 'zod';
 
-import { baseListQuerySchema } from '../schemas';
+import {
+  baseListQuerySchema,
+  cdpSqlIntegerSchema,
+  cdpSqlNumberSchema,
+} from '../schemas';
 
 import { queryRaw } from '@/services/transfers/client';
 
@@ -92,11 +96,11 @@ const listTopFacilitatorsUncached = async (
     z.array(
       z.object({
         facilitator_id: z.string(),
-        tx_count: z.number(),
-        total_amount: z.number(),
+        tx_count: cdpSqlIntegerSchema,
+        total_amount: cdpSqlNumberSchema,
         latest_block_timestamp: z.date(),
-        unique_buyers: z.number(),
-        unique_sellers: z.number(),
+        unique_buyers: cdpSqlIntegerSchema,
+        unique_sellers: cdpSqlIntegerSchema,
         chains: z.array(chainSchema),
       })
     )
@@ -114,7 +118,7 @@ const listTopFacilitatorsUncached = async (
         HAVING SUM(total_transactions) > ${Prisma.raw(MIN_FACILITATOR_TRANSACTIONS.toString())}
       ) subquery
     `,
-    z.array(z.object({ count: z.number() }))
+    z.array(z.object({ count: cdpSqlIntegerSchema }))
   );
 
   const count = countResult[0]?.count ?? 0;

--- a/apps/scan/src/services/transfers/networks/bucketed.ts
+++ b/apps/scan/src/services/transfers/networks/bucketed.ts
@@ -1,7 +1,11 @@
 import z from 'zod';
 import { Prisma } from '@x402scan/scan-db';
 
-import { baseBucketedQuerySchema } from '../schemas';
+import {
+  baseBucketedQuerySchema,
+  cdpSqlIntegerSchema,
+  cdpSqlNumberSchema,
+} from '../schemas';
 import { createCachedArrayQuery, createStandardCacheKey } from '@/lib/cache';
 import { queryRaw } from '@/services/transfers/client';
 import { Chain } from '@/types/chain';
@@ -15,11 +19,11 @@ const bucketedNetworkResultSchema = z.array(
     networks: z.record(
       z.string(),
       z.object({
-        total_transactions: z.number(),
-        total_amount: z.number(),
-        unique_buyers: z.number(),
-        unique_sellers: z.number(),
-        unique_facilitators: z.number(),
+        total_transactions: cdpSqlIntegerSchema,
+        total_amount: cdpSqlNumberSchema,
+        unique_buyers: cdpSqlIntegerSchema,
+        unique_sellers: cdpSqlIntegerSchema,
+        unique_facilitators: cdpSqlIntegerSchema,
       })
     ),
   })

--- a/apps/scan/src/services/transfers/networks/list.ts
+++ b/apps/scan/src/services/transfers/networks/list.ts
@@ -1,4 +1,8 @@
-import { baseQuerySchema } from '../schemas';
+import {
+  baseQuerySchema,
+  cdpSqlIntegerSchema,
+  cdpSqlNumberSchema,
+} from '../schemas';
 import z from 'zod';
 import { chainSchema, sortingSchema } from '@/lib/schemas';
 import { createCachedArrayQuery, createStandardCacheKey } from '@/lib/cache';
@@ -91,12 +95,12 @@ const listTopNetworksUncached = async (
     z.array(
       z.object({
         chain: chainSchema,
-        tx_count: z.number(),
-        total_amount: z.number(),
+        tx_count: cdpSqlIntegerSchema,
+        total_amount: cdpSqlNumberSchema,
         latest_block_timestamp: z.date(),
-        unique_buyers: z.number(),
-        unique_sellers: z.number(),
-        unique_facilitators: z.number(),
+        unique_buyers: cdpSqlIntegerSchema,
+        unique_sellers: cdpSqlIntegerSchema,
+        unique_facilitators: cdpSqlIntegerSchema,
       })
     )
   );

--- a/apps/scan/src/services/transfers/origins/stats/bucketed-mv.ts
+++ b/apps/scan/src/services/transfers/origins/stats/bucketed-mv.ts
@@ -5,6 +5,7 @@ import { createCachedArrayQuery, createStandardCacheKey } from '@/lib/cache';
 import { queryRaw } from '@/services/transfers/client';
 import { getMaterializedViewSuffix } from '@/lib/time-range';
 import { chainSchema, timeframeSchema } from '@/lib/schemas';
+import { cdpSqlIntegerSchema, cdpSqlNumberSchema } from '../../schemas';
 
 /**
  * Input schema for bucketed origin statistics queries.
@@ -62,10 +63,10 @@ const getBucketedOriginStatisticsMVUncached = async (
     z.array(
       z.object({
         bucket_start: z.date(),
-        total_origins: z.number(),
-        total_transactions: z.number(),
-        total_amount: z.number(),
-        unique_buyers: z.number(),
+        total_origins: cdpSqlIntegerSchema,
+        total_transactions: cdpSqlIntegerSchema,
+        total_amount: cdpSqlNumberSchema,
+        unique_buyers: cdpSqlIntegerSchema,
       })
     )
   );

--- a/apps/scan/src/services/transfers/origins/stats/overall-mv.ts
+++ b/apps/scan/src/services/transfers/origins/stats/overall-mv.ts
@@ -5,6 +5,7 @@ import { createCachedQuery, createStandardCacheKey } from '@/lib/cache';
 import { queryRaw } from '@/services/transfers/client';
 import { getMaterializedViewSuffix } from '@/lib/time-range';
 import { chainSchema, timeframeSchema } from '@/lib/schemas';
+import { cdpSqlIntegerSchema, cdpSqlNumberSchema } from '../../schemas';
 
 /**
  * Input schema for origin-based statistics queries.
@@ -63,10 +64,10 @@ const getOverallOriginStatisticsMVUncached = async (
     sql,
     z.array(
       z.object({
-        total_origins: z.number(),
-        total_transactions: z.number(),
-        total_amount: z.number(),
-        unique_buyers: z.number(),
+        total_origins: cdpSqlIntegerSchema,
+        total_transactions: cdpSqlIntegerSchema,
+        total_amount: cdpSqlNumberSchema,
+        unique_buyers: cdpSqlIntegerSchema,
         latest_block_timestamp: z.date().nullable(),
       })
     )

--- a/apps/scan/src/services/transfers/schemas.ts
+++ b/apps/scan/src/services/transfers/schemas.ts
@@ -12,6 +12,17 @@ const addressArray = z
   .array(mixedAddressSchema)
   .transform(addresses => [...addresses].sort((a, b) => a.localeCompare(b)));
 
+export const cdpSqlNumberSchema = z.preprocess(value => {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed === '' ? Number.NaN : Number(trimmed);
+  }
+
+  return value;
+}, z.number().finite());
+
+export const cdpSqlIntegerSchema = cdpSqlNumberSchema.pipe(z.number().int());
+
 const addressesSchema = z.object({
   include: addressArray.optional(),
   exclude: addressArray.optional(),

--- a/apps/scan/src/services/transfers/sellers/list-mv.ts
+++ b/apps/scan/src/services/transfers/sellers/list-mv.ts
@@ -4,7 +4,11 @@ import { Prisma } from '@x402scan/transfers-db';
 import { chainSchema, mixedAddressSchema } from '@/lib/schemas';
 import { toPaginatedResponse } from '@/lib/pagination';
 
-import { baseListQuerySchema } from '../schemas';
+import {
+  baseListQuerySchema,
+  cdpSqlIntegerSchema,
+  cdpSqlNumberSchema,
+} from '../schemas';
 import {
   createCachedPaginatedQuery,
   createStandardCacheKey,
@@ -98,10 +102,10 @@ export const listTopSellersMVUncached = async (
       z.object({
         recipient: mixedAddressSchema,
         facilitator_ids: z.array(z.string()),
-        tx_count: z.number(),
-        total_amount: z.number(),
+        tx_count: cdpSqlIntegerSchema,
+        total_amount: cdpSqlNumberSchema,
         latest_block_timestamp: z.date().nullable(),
-        unique_buyers: z.number(),
+        unique_buyers: cdpSqlIntegerSchema,
         chains: z.array(chainSchema),
       })
     )
@@ -124,7 +128,7 @@ export const listTopSellersMVUncached = async (
       `,
       z.array(
         z.object({
-          count: z.number(),
+          count: cdpSqlIntegerSchema,
         })
       )
     );

--- a/apps/scan/src/services/transfers/sellers/stats/bucketed-mv.ts
+++ b/apps/scan/src/services/transfers/sellers/stats/bucketed-mv.ts
@@ -1,7 +1,11 @@
 import z from 'zod';
 import { Prisma } from '@x402scan/transfers-db';
 
-import { baseBucketedQuerySchema } from '../../schemas';
+import {
+  baseBucketedQuerySchema,
+  cdpSqlIntegerSchema,
+  cdpSqlNumberSchema,
+} from '../../schemas';
 import { createCachedArrayQuery, createStandardCacheKey } from '@/lib/cache';
 import { queryRaw } from '@/services/transfers/client';
 import { getMaterializedViewSuffix } from '@/lib/time-range';
@@ -24,11 +28,11 @@ const getBucketInterval = (mvTimeframe: string): string => {
 const bucketedSellerResultSchema = z.array(
   z.object({
     bucket_start: z.date(),
-    total_sellers: z.number(),
-    total_transactions: z.number(),
-    total_amount: z.number(),
-    unique_buyers: z.number(),
-    new_sellers: z.number(),
+    total_sellers: cdpSqlIntegerSchema,
+    total_transactions: cdpSqlIntegerSchema,
+    total_amount: cdpSqlNumberSchema,
+    unique_buyers: cdpSqlIntegerSchema,
+    new_sellers: cdpSqlIntegerSchema,
   })
 );
 

--- a/apps/scan/src/services/transfers/sellers/stats/overall-mv.ts
+++ b/apps/scan/src/services/transfers/sellers/stats/overall-mv.ts
@@ -1,7 +1,11 @@
 import z from 'zod';
 import { Prisma } from '@x402scan/transfers-db';
 
-import { baseQuerySchema } from '../../schemas';
+import {
+  baseQuerySchema,
+  cdpSqlIntegerSchema,
+  cdpSqlNumberSchema,
+} from '../../schemas';
 import { createCachedQuery, createStandardCacheKey } from '@/lib/cache';
 import { queryRaw } from '@/services/transfers/client';
 import { getMaterializedViewSuffix } from '@/lib/time-range';
@@ -103,12 +107,12 @@ const getOverallSellerStatisticsMVUncached = async (
     sql,
     z.array(
       z.object({
-        total_sellers: z.number(),
-        total_transactions: z.number(),
-        total_amount: z.number(),
-        unique_buyers: z.number(),
+        total_sellers: cdpSqlIntegerSchema,
+        total_transactions: cdpSqlIntegerSchema,
+        total_amount: cdpSqlNumberSchema,
+        unique_buyers: cdpSqlIntegerSchema,
         latest_block_timestamp: z.date().nullable(),
-        new_sellers: z.number(),
+        new_sellers: cdpSqlIntegerSchema,
       })
     )
   );

--- a/apps/scan/src/services/transfers/stats/bucketed-mv.ts
+++ b/apps/scan/src/services/transfers/stats/bucketed-mv.ts
@@ -1,7 +1,11 @@
 import z from 'zod';
 import { Prisma } from '@x402scan/transfers-db';
 
-import { baseBucketedQuerySchema } from '../schemas';
+import {
+  baseBucketedQuerySchema,
+  cdpSqlIntegerSchema,
+  cdpSqlNumberSchema,
+} from '../schemas';
 import { createCachedArrayQuery, createStandardCacheKey } from '@/lib/cache';
 import { queryRaw } from '@/services/transfers/client';
 import { getMaterializedViewSuffix } from '@/lib/time-range';
@@ -11,10 +15,10 @@ export const bucketedStatisticsMVInputSchema = baseBucketedQuerySchema;
 const bucketedResultSchema = z.array(
   z.object({
     bucket_start: z.date(),
-    total_transactions: z.number(),
-    total_amount: z.number(),
-    unique_buyers: z.number(),
-    unique_sellers: z.number(),
+    total_transactions: cdpSqlIntegerSchema,
+    total_amount: cdpSqlNumberSchema,
+    unique_buyers: cdpSqlIntegerSchema,
+    unique_sellers: cdpSqlIntegerSchema,
   })
 );
 
@@ -23,7 +27,7 @@ const getBucketedStatisticsMVUncached = async (
 ) => {
   const { timeframe, recipients } = input;
 
-  // An explicitly-empty include list means "include nothing" — short-circuit
+  // An explicitly-empty include list means "include nothing" ??short-circuit
   // before the unfiltered global MV gets queried.
   if (recipients?.include?.length === 0) {
     return [];
@@ -97,17 +101,7 @@ const getBucketedStatisticsMVUncached = async (
       ORDER BY bucket
     `;
 
-  const rawResult = await queryRaw(sql, bucketedResultSchema);
-
-  const transformedResult = rawResult.map(row => ({
-    ...row,
-    total_amount:
-      typeof row.total_amount === 'number'
-        ? row.total_amount
-        : Number(row.total_amount),
-  }));
-
-  return bucketedResultSchema.parse(transformedResult);
+  return queryRaw(sql, bucketedResultSchema);
 };
 
 export const getBucketedStatisticsMV = createCachedArrayQuery({

--- a/apps/scan/src/services/transfers/stats/overall-mv.ts
+++ b/apps/scan/src/services/transfers/stats/overall-mv.ts
@@ -1,7 +1,11 @@
 import z from 'zod';
 import { Prisma } from '@x402scan/transfers-db';
 
-import { baseQuerySchema } from '../schemas';
+import {
+  baseQuerySchema,
+  cdpSqlIntegerSchema,
+  cdpSqlNumberSchema,
+} from '../schemas';
 import { createCachedQuery, createStandardCacheKey } from '@/lib/cache';
 import { queryRaw } from '@/services/transfers/client';
 import { getMaterializedViewSuffix } from '@/lib/time-range';
@@ -13,7 +17,7 @@ const getOverallStatisticsMVUncached = async (
 ) => {
   const { timeframe, recipients } = input;
 
-  // An explicitly-empty include list means "include nothing" — short-circuit
+  // An explicitly-empty include list means "include nothing" ??short-circuit
   // before the unfiltered global MV gets queried.
   if (recipients?.include?.length === 0) {
     return {
@@ -97,10 +101,10 @@ const getOverallStatisticsMVUncached = async (
     sql,
     z.array(
       z.object({
-        total_transactions: z.number(),
-        total_amount: z.number(),
-        unique_buyers: z.number(),
-        unique_sellers: z.number(),
+        total_transactions: cdpSqlIntegerSchema,
+        total_amount: cdpSqlNumberSchema,
+        unique_buyers: cdpSqlIntegerSchema,
+        unique_sellers: cdpSqlIntegerSchema,
         latest_block_timestamp: z.date().nullable(),
       })
     )

--- a/apps/scan/src/services/transfers/wallets/stats.ts
+++ b/apps/scan/src/services/transfers/wallets/stats.ts
@@ -5,6 +5,7 @@ import { queryRaw } from '@/services/transfers/client';
 import { createCachedQuery, createStandardCacheKey } from '@/lib/cache';
 import { chainSchema } from '@/lib/schemas';
 import { getMaterializedViewSuffix } from '@/lib/time-range';
+import { cdpSqlIntegerSchema, cdpSqlNumberSchema } from '../schemas';
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type WalletStatsInput = {
@@ -46,9 +47,9 @@ const getWalletStatsUncached = async (input: WalletStatsInput) => {
       `,
       z.array(
         z.object({
-          total_transactions: z.number(),
-          total_amount: z.number(),
-          unique_recipients: z.number(),
+          total_transactions: cdpSqlIntegerSchema,
+          total_amount: cdpSqlNumberSchema,
+          unique_recipients: cdpSqlIntegerSchema,
           chains: z.array(chainSchema),
         })
       )


### PR DESCRIPTION
Fixes #45.

## Summary

- Add shared `cdpSqlNumberSchema` and `cdpSqlIntegerSchema` helpers for CDP SQL aggregate responses.
- Update transfers aggregate result schemas to accept CDP stringified numerics while returning cache-safe JavaScript `number` values.
- Remove the local one-off `total_amount` conversion in bucketed transfer stats now that the result schema handles the coercion consistently.

## Verification

- `git diff --check`
- `pnpm exec prettier --check <changed transfer service files>`
- `pnpm --filter @x402scan/app types:check` was attempted locally. It currently fails before a clean app check because the local checkout is missing generated Prisma/Next/workspace type artifacts and reports existing project-wide type errors outside this change. I filtered the output for the modified `src/services/transfers` paths and did not find errors from this patch.