### PR TITLE
Templatize concrete path keys from OpenAPI discovery

### DIFF
--- a/apps/scan/src/lib/discovery/path-template.test.ts
+++ b/apps/scan/src/lib/discovery/path-template.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest';
+
+import { templatizePath } from './path-template';
+
+/**
+ * Real war-tracker.com `info.x-guidance` snippet — they deliberately use
+ * concrete path keys in `paths` and document the canonical templates here.
+ */
+const WAR_TRACKER_GUIDANCE = `
+3. **Paid resources** (x402-paid for training-crawler UAs):
+   \`/share/{event_id}/{slug}\`, \`/media/{event_id}\`, \`/region/{slug}\`,
+   \`/country/{iso2}\`, \`/event-type/{slug}\`.
+`;
+
+describe('templatizePath', () => {
+  describe('passthrough', () => {
+    it('returns templated paths unchanged', () => {
+      expect(
+        templatizePath('https://example.com/api/v1/events/{event_id}')
+      ).toBe('https://example.com/api/v1/events/{event_id}');
+    });
+
+    it('returns list endpoints unchanged', () => {
+      expect(templatizePath('https://example.com/api/v1/events')).toBe(
+        'https://example.com/api/v1/events'
+      );
+    });
+
+    it('returns invalid urls unchanged', () => {
+      expect(templatizePath('not a url')).toBe('not a url');
+    });
+
+    it('leaves common-noun segments alone when no hint is provided', () => {
+      // No false-positives on `events`, `accounts`, etc.
+      expect(templatizePath('https://example.com/api/v1/events')).toBe(
+        'https://example.com/api/v1/events'
+      );
+    });
+  });
+
+  describe('heuristic templating (no hints)', () => {
+    it('templates numeric id segments', () => {
+      expect(templatizePath('https://example.com/api/v1/events/397003')).toBe(
+        'https://example.com/api/v1/events/{id}'
+      );
+    });
+
+    it('templates UUID segments', () => {
+      expect(
+        templatizePath(
+          'https://example.com/users/550e8400-e29b-41d4-a716-446655440000'
+        )
+      ).toBe('https://example.com/users/{id}');
+    });
+
+    it('templates a slug segment that follows a numeric id', () => {
+      expect(templatizePath('https://example.com/share/397003/strike')).toBe(
+        'https://example.com/share/{id}/{slug}'
+      );
+    });
+
+    it('leaves kebab-case segments alone without a hint', () => {
+      // Conservative: we don't know if `middle-east` is a slug or a literal.
+      expect(templatizePath('https://example.com/region/middle-east')).toBe(
+        'https://example.com/region/middle-east'
+      );
+    });
+  });
+
+  describe('mining hints (war-tracker spec)', () => {
+    it('uses the providers param name from operation summary', () => {
+      expect(
+        templatizePath('https://war-tracker.com/api/v1/events/397003', {
+          operationSummary:
+            'Single event at /api/v1/events/{event_id}. Returns the canonical payload.',
+        })
+      ).toBe('https://war-tracker.com/api/v1/events/{event_id}');
+    });
+
+    it('templates a slug-less share URL using a longer template from the description', () => {
+      expect(
+        templatizePath('https://war-tracker.com/share/397003', {
+          operationSummary:
+            'Slug-less variant of /share/{event_id}/{slug}. Redirects to the canonical URL.',
+        })
+      ).toBe('https://war-tracker.com/share/{event_id}');
+    });
+
+    it('templates the full share/{id}/{slug} pattern', () => {
+      expect(
+        templatizePath('https://war-tracker.com/share/397003/strike', {
+          operationSummary:
+            'Per-event article at /share/{event_id}/{slug}. Default response is the SEO-canonical HTML page.',
+        })
+      ).toBe('https://war-tracker.com/share/{event_id}/{slug}');
+    });
+
+    it('templates /media/{event_id} via operation summary', () => {
+      expect(
+        templatizePath('https://war-tracker.com/media/397003', {
+          operationSummary:
+            'Full media bytes (photo or video) for an event at /media/{event_id}. Flat price.',
+        })
+      ).toBe('https://war-tracker.com/media/{event_id}');
+    });
+
+    it('templates /region/{slug} via doc-level guidance', () => {
+      expect(
+        templatizePath('https://war-tracker.com/region/middle-east', {
+          guidance: WAR_TRACKER_GUIDANCE,
+        })
+      ).toBe('https://war-tracker.com/region/{slug}');
+    });
+
+    it('templates /country/{iso2} via doc-level guidance', () => {
+      expect(
+        templatizePath('https://war-tracker.com/country/UA', {
+          guidance: WAR_TRACKER_GUIDANCE,
+        })
+      ).toBe('https://war-tracker.com/country/{iso2}');
+    });
+
+    it('templates /event-type/{slug} via doc-level guidance', () => {
+      expect(
+        templatizePath('https://war-tracker.com/event-type/drone-strike', {
+          guidance: WAR_TRACKER_GUIDANCE,
+        })
+      ).toBe('https://war-tracker.com/event-type/{slug}');
+    });
+
+    it('falls back to heuristics when hints do not mention the path', () => {
+      // No template for /widgets/* in hints → numeric still becomes {id}.
+      expect(
+        templatizePath('https://example.com/widgets/12345', {
+          guidance: WAR_TRACKER_GUIDANCE,
+        })
+      ).toBe('https://example.com/widgets/{id}');
+    });
+
+    it('prefers the longer template when multiple match the same prefix', () => {
+      // Two share templates in hint text: pick the more specific one.
+      expect(
+        templatizePath('https://example.com/share/397003/strike', {
+          operationSummary:
+            'See /share/{id} for the slug-less variant, or /share/{event_id}/{slug} for the canonical URL.',
+        })
+      ).toBe('https://example.com/share/{event_id}/{slug}');
+    });
+
+    it('preserves query strings on the URL', () => {
+      // The discovery pipeline strips query before storage, but templatize
+      // itself should be a pure path-mutation transform.
+      expect(
+        templatizePath('https://example.com/api/v1/events/397003?foo=bar', {
+          operationSummary: 'Event at /api/v1/events/{event_id}',
+        })
+      ).toBe('https://example.com/api/v1/events/{event_id}?foo=bar');
+    });
+  });
+
+  describe('full war-tracker resource set', () => {
+    // The combined hint text — guidance for hub-page routes,
+    // descriptions for the others. Matches the real OpenAPI spec.
+    const cases: { input: string; summary?: string; expected: string }[] = [
+      {
+        input: 'https://war-tracker.com/api/v1/events',
+        expected: 'https://war-tracker.com/api/v1/events',
+      },
+      {
+        input: 'https://war-tracker.com/api/v1/events/397003',
+        summary:
+          'Single event at /api/v1/events/{event_id}. Returns the canonical machine-readable event payload.',
+        expected: 'https://war-tracker.com/api/v1/events/{event_id}',
+      },
+      {
+        input: 'https://war-tracker.com/share/397003',
+        summary:
+          'Slug-less variant of /share/{event_id}/{slug}. The server redirects to the canonical URL.',
+        expected: 'https://war-tracker.com/share/{event_id}',
+      },
+      {
+        input: 'https://war-tracker.com/share/397003/strike',
+        summary:
+          'Per-event article at /share/{event_id}/{slug}. Default response is the SEO-canonical HTML page.',
+        expected: 'https://war-tracker.com/share/{event_id}/{slug}',
+      },
+      {
+        input: 'https://war-tracker.com/media/397003',
+        summary: 'Full media bytes for an event at /media/{event_id}.',
+        expected: 'https://war-tracker.com/media/{event_id}',
+      },
+      {
+        input: 'https://war-tracker.com/region/middle-east',
+        expected: 'https://war-tracker.com/region/{slug}',
+      },
+      {
+        input: 'https://war-tracker.com/country/UA',
+        expected: 'https://war-tracker.com/country/{iso2}',
+      },
+      {
+        input: 'https://war-tracker.com/event-type/drone-strike',
+        expected: 'https://war-tracker.com/event-type/{slug}',
+      },
+    ];
+
+    it.each(cases)(
+      'templatizes $input → $expected',
+      ({ input, summary, expected }) => {
+        const result = templatizePath(input, {
+          operationSummary: summary,
+          guidance: WAR_TRACKER_GUIDANCE,
+        });
+        expect(result).toBe(expected);
+      }
+    );
+  });
+});

--- a/apps/scan/src/lib/discovery/path-template.ts
+++ b/apps/scan/src/lib/discovery/path-template.ts
@@ -1,0 +1,219 @@
+/**
+ * Templatize a concrete URL into its canonical templated form.
+ *
+ * Some OpenAPI providers (e.g. war-tracker.com) deliberately use concrete
+ * path keys like `/api/v1/events/397003` instead of `/api/v1/events/{event_id}`
+ * so that discovery probes hit a real URL. Their canonical templates are
+ * documented either in the operation's summary/description or in the
+ * doc-level `info.x-guidance` text.
+ *
+ * Resolution order:
+ *   1. URL already contains `{...}` segments  → return as-is.
+ *   2. Mine the hint text for templated paths that share a prefix with
+ *      our URL; pick the strongest match and substitute the templated
+ *      segment names at concrete positions.
+ *   3. For any remaining concrete-looking segments, apply heuristics:
+ *        - numeric, UUID, long hex   → `{id}`
+ *        - any segment immediately
+ *          after an `{id}` segment   → `{slug}`
+ *      Ambiguous segments are left untouched (avoids false-positives on
+ *      common nouns like `events`, `accounts`).
+ *
+ * Heuristics only run when the hint mining doesn't supply a name. This
+ * lets providers control the param names they expose (e.g. `{event_id}`,
+ * `{iso2}`) instead of getting our generic `{id}` / `{code}`.
+ */
+
+const TEMPLATE_PARAM_REGEX = /^\{[^/{}]+\}$/;
+
+/** Pattern for path-like strings, possibly containing `{param}` placeholders. */
+const PATH_PATTERN_REGEX = /\/[A-Za-z0-9_{}\-.]+(?:\/[A-Za-z0-9_{}\-.]+)*/g;
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export interface TemplatizeHints {
+  /** Operation `summary` (which already falls back to `description` upstream). */
+  operationSummary?: string;
+  /** Doc-level `info.x-guidance` text. */
+  guidance?: string;
+}
+
+export function templatizePath(url: string, hints: TemplatizeHints = {}): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+
+  // `URL.pathname` percent-encodes `{` / `}` on parse, so decode each
+  // segment before inspection. (Real-world OpenAPI templates use the
+  // literal `{param}` form.)
+  const segments = parsed.pathname
+    .split('/')
+    .filter(Boolean)
+    .map((s) => {
+      try {
+        return decodeURIComponent(s);
+      } catch {
+        return s;
+      }
+    });
+  if (segments.length === 0) return url;
+
+  // Already templated — preserve as-is (with decoded braces).
+  if (segments.some((s) => TEMPLATE_PARAM_REGEX.test(s))) {
+    const newPath = '/' + segments.join('/');
+    return `${parsed.origin}${newPath}${parsed.search}${parsed.hash}`;
+  }
+
+  const templates = mineTemplates(
+    [hints.operationSummary, hints.guidance].filter(Boolean).join('\n')
+  );
+
+  const result = segments.map((segment, i) => {
+    if (!looksConcrete(segment, segments, i)) return segment;
+
+    const mined = findTemplateSegment(templates, segments, i);
+    if (mined) return mined;
+
+    return heuristicReplace(segment, segments, i) ?? segment;
+  });
+
+  // Rebuild by hand — the URL.pathname setter percent-encodes `{`/`}`,
+  // which would mangle our template params back to `%7B...%7D`.
+  const newPath = '/' + result.join('/');
+  const trailing = `${parsed.search}${parsed.hash}`;
+  return `${parsed.origin}${newPath}${trailing}`;
+}
+
+/**
+ * Whether a segment "looks like" a concrete identifier that should
+ * potentially be templated. We use a permissive definition here — we
+ * let the mining + heuristic stages make the final call. The point of
+ * this gate is to avoid invoking the (expensive) mining search on every
+ * segment of every path.
+ */
+function looksConcrete(
+  segment: string,
+  segments: string[],
+  position: number
+): boolean {
+  // Numeric or hex-ish → almost certainly an id.
+  if (/^\d+$/.test(segment)) return true;
+  if (UUID_REGEX.test(segment)) return true;
+  if (/^[0-9a-f]{16,}$/i.test(segment)) return true;
+
+  // ALL-CAPS short codes (e.g. country codes UA, US, GBR).
+  if (/^[A-Z]{2,3}$/.test(segment)) return true;
+
+  // A segment immediately after a {id}-shaped segment usually is a slug.
+  const prev = position > 0 ? segments[position - 1] : undefined;
+  if (prev && (/^\d+$/.test(prev) || UUID_REGEX.test(prev))) return true;
+
+  // Kebab-case multi-word segment (e.g. `middle-east`, `drone-strike`) —
+  // only flagged when there are templates available to mine, since
+  // otherwise we'd over-templatize segments like `event-types`.
+  if (segment.includes('-')) return true;
+
+  return false;
+}
+
+/**
+ * Extracts every `path-like` substring from the hint text and keeps the
+ * ones containing at least one `{param}` placeholder.
+ */
+function mineTemplates(text: string): string[][] {
+  if (!text) return [];
+  const matches = text.match(PATH_PATTERN_REGEX) ?? [];
+  const templates: string[][] = [];
+  const seen = new Set<string>();
+  for (const raw of matches) {
+    // Strip trailing sentence/list punctuation that the regex greedily
+    // pulled in (e.g. `/media/{event_id}.`, `/share/{event_id}/{slug},`).
+    const path = raw.replace(/[.,;:!?)\]]+$/g, '');
+    const segs = path.split('/').filter(Boolean);
+    if (segs.length === 0) continue;
+    if (!segs.some((s) => TEMPLATE_PARAM_REGEX.test(s))) continue;
+    const key = segs.join('/');
+    if (seen.has(key)) continue;
+    seen.add(key);
+    templates.push(segs);
+  }
+  return templates;
+}
+
+/**
+ * Finds the best templated segment to use at `position` in `urlSegments`,
+ * scanning all mined templates. A template is eligible iff:
+ *   - It has a `{param}` at the requested position.
+ *   - All preceding positions are prefix-compatible (literal segments
+ *     match, template params are wildcards).
+ *
+ * Among eligible templates, we pick the one with the most literal-prefix
+ * matches (ties broken by overall template length to prefer longer,
+ * more-specific templates).
+ */
+function findTemplateSegment(
+  templates: string[][],
+  urlSegments: string[],
+  position: number
+): string | null {
+  let best: { segment: string; literalMatches: number; length: number } | null =
+    null;
+
+  for (const template of templates) {
+    if (position >= template.length) continue;
+    const candidate = template[position];
+    if (!candidate || !TEMPLATE_PARAM_REGEX.test(candidate)) continue;
+
+    let literalMatches = 0;
+    let compatible = true;
+    for (let i = 0; i < position; i++) {
+      const tSeg = template[i];
+      const uSeg = urlSegments[i];
+      if (!tSeg || !uSeg) {
+        compatible = false;
+        break;
+      }
+      if (TEMPLATE_PARAM_REGEX.test(tSeg)) continue;
+      if (tSeg === uSeg) {
+        literalMatches++;
+        continue;
+      }
+      compatible = false;
+      break;
+    }
+    if (!compatible) continue;
+
+    if (
+      !best ||
+      literalMatches > best.literalMatches ||
+      (literalMatches === best.literalMatches && template.length > best.length)
+    ) {
+      best = { segment: candidate, literalMatches, length: template.length };
+    }
+  }
+
+  return best?.segment ?? null;
+}
+
+function heuristicReplace(
+  segment: string,
+  segments: string[],
+  position: number
+): string | null {
+  if (/^\d+$/.test(segment)) return '{id}';
+  if (UUID_REGEX.test(segment)) return '{id}';
+  if (/^[0-9a-f]{16,}$/i.test(segment)) return '{id}';
+
+  const prev = position > 0 ? segments[position - 1] : undefined;
+  if (prev && (/^\d+$/.test(prev) || UUID_REGEX.test(prev))) return '{slug}';
+
+  // ALL-CAPS short codes only when there's a categorical prev segment
+  // — refuse without context to avoid false-positives like `/api/UA`.
+  // Without mining, leave them alone.
+
+  return null;
+}

--- a/apps/scan/src/lib/discovery/register-origin.ts
+++ b/apps/scan/src/lib/discovery/register-origin.ts
@@ -76,7 +76,7 @@ export interface RegisterOriginResult {
  * Deprecates resources from the same origin that are no longer in the list.
  */
 export async function registerResourcesFromDiscovery(
-  resources: { url: string; authMode?: AuthMode }[],
+  resources: { url: string; canonicalUrl?: string; authMode?: AuthMode }[],
   source: string | undefined
 ): Promise<RegisterOriginResult> {
   const originResourceCounts = new Map(
@@ -91,6 +91,7 @@ export async function registerResourcesFromDiscovery(
 
   const results = await mapSettledWithConcurrency(resources, async resource => {
     const resourceUrl = resource.url;
+    const canonicalUrl = resource.canonicalUrl;
 
     if (resource.authMode === 'siwx') {
       return {
@@ -133,6 +134,7 @@ export async function registerResourcesFromDiscovery(
 
     const result = await registerResource(resourceUrl, advisory, {
       notifyNewServer: false,
+      ...(canonicalUrl ? { canonicalUrl } : {}),
     });
 
     if (result.success) return result;
@@ -209,7 +211,9 @@ export async function registerResourcesFromDiscovery(
 
   let deprecated = 0;
   if (originId) {
-    const activeResourceUrls = resources.map(r => r.url);
+    // Compare against the same form that gets stored — the canonical
+    // (templated) URL when present, falling back to the concrete URL.
+    const activeResourceUrls = resources.map(r => r.canonicalUrl ?? r.url);
     deprecated = await deprecateStaleResources(originId, activeResourceUrls);
   }
 

--- a/apps/scan/src/lib/resources.ts
+++ b/apps/scan/src/lib/resources.ts
@@ -31,14 +31,16 @@ import { notifyNewServer } from '@/lib/discord-notifications';
 export const registerResource = async (
   url: string,
   advisory: EndpointMethodAdvisory,
-  options: { notifyNewServer?: boolean } = {}
+  options: { notifyNewServer?: boolean; canonicalUrl?: string } = {}
 ) => {
   const x402Options = (advisory.paymentOptions ?? []).filter(
     isX402PaymentOption
   );
   const urlObj = new URL(url);
   urlObj.search = '';
-  const cleanUrl = urlObj.toString();
+  // Store the canonical (templated) URL when the caller provides one
+  // — concrete probe URLs like `/events/397003` become `/events/{event_id}`.
+  const cleanUrl = options.canonicalUrl ?? urlObj.toString();
   const origin = getOriginFromUrl(cleanUrl);
   const shouldNotifyNewServer = options.notifyNewServer ?? true;
 

--- a/apps/scan/src/services/discovery/fetch-discovery.ts
+++ b/apps/scan/src/services/discovery/fetch-discovery.ts
@@ -1,7 +1,8 @@
-import { discoverOriginSchema } from '@agentcash/discovery';
+import { discoverOriginSchema, GuidanceMode } from '@agentcash/discovery';
 
 import { getOriginFromUrl } from '@/lib/url';
 import { isLocalUrl } from '@/lib/url-helpers';
+import { templatizePath } from '@/lib/discovery/path-template';
 
 import type {
   DiscoveredResource,
@@ -47,10 +48,13 @@ export async function fetchDiscoveryDocument(
     ? { 'Cache-Control': 'no-cache, no-store' }
     : {};
 
+  // Always request the doc-level guidance text — we mine it for canonical
+  // path templates (e.g. war-tracker's `/region/{slug}`, `/country/{iso2}`).
   const discovered = await discoverOriginSchema({
     target: origin,
     headers,
     signal,
+    guidance: GuidanceMode.Always,
   });
 
   if (!discovered.found) {
@@ -62,13 +66,19 @@ export async function fetchDiscoveryDocument(
     };
   }
 
+  const guidance = discovered.guidance;
   const resources: DiscoveredResource[] = discovered.endpoints.flatMap(
     endpoint => {
       try {
         const url = new URL(endpoint.path, discovered.origin).toString();
+        const canonicalUrl = templatizePath(url, {
+          operationSummary: endpoint.summary,
+          ...(guidance ? { guidance } : {}),
+        });
         return [
           {
             url,
+            ...(canonicalUrl !== url ? { canonicalUrl } : {}),
             method: endpoint.method,
             ...(endpoint.authMode ? { authMode: endpoint.authMode } : {}),
           },

--- a/apps/scan/src/types/discovery.ts
+++ b/apps/scan/src/types/discovery.ts
@@ -9,7 +9,14 @@ import type { AuthMode } from '@agentcash/discovery';
  * Method is specified in discovery doc like "POST /api/resource"
  */
 export interface DiscoveredResource {
+  /** Concrete URL used for probing (may include real IDs like `/events/397003`). */
   url: string;
+  /**
+   * Canonical templated URL stored in the DB
+   * (e.g. `/events/{event_id}`). Falls back to `url` when no template
+   * could be derived from the OpenAPI document.
+   */
+  canonicalUrl?: string;
   method?:
     | 'GET'
     | 'POST'


### PR DESCRIPTION
## Summary

Some OpenAPI providers (notably [war-tracker.com](https://war-tracker.com/openapi.json)) deliberately use **concrete path keys** like `/api/v1/events/397003` instead of `/api/v1/events/{event_id}` so their discovery probes hit a real URL. Their canonical templates live in the operation's `description` or in `info.x-guidance`. We previously stored those concrete keys verbatim, producing ugly resource rows with real IDs baked into them (see image in the kickoff message).

## What changed

- New `templatizePath(url, hints)` utility (`apps/scan/src/lib/discovery/path-template.ts`) with three-tier resolution:
  1. **Passthrough** — URLs that already contain `{...}` segments are left alone.
  2. **Mining** — scans the operation `summary`/`description` and the doc-level `info.x-guidance` for templated path patterns. When one matches our concrete URL's prefix, we adopt **the provider's own parameter names** (e.g. `{event_id}`, `{iso2}`, `{slug}`).
  3. **Heuristic fallback** — for unmatched concrete-looking segments: numeric / UUID / long hex → `{id}`; a segment immediately following an `{id}` → `{slug}`. Ambiguous segments (e.g. `events`, `accounts`) are left alone to avoid false positives.
- Plumbed `canonicalUrl` through `DiscoveredResource` → `registerResourcesFromDiscovery` → `registerResource`. The DB stores `canonicalUrl` when present, falls back to the concrete probe URL otherwise.
- `deprecateStaleResources` now compares against the same form that gets stored.
- `fetchDiscoveryDocument` requests `GuidanceMode.Always` so the mining step has the full guidance text regardless of length.
- 26 unit tests, including a parametrized run across the full war-tracker resource set.

## Why this design

- **Provider-preferred names**: war-tracker uses `{event_id}` and `{iso2}` — by mining their spec we adopt those names verbatim, rather than rewriting everything to our generic `{id}` / `{code}`.
- **No breakage of the standard case**: specs that already use `{param}` templates pass through untouched.
- **Conservative heuristics**: we only auto-template segments that strongly look like identifiers. A new provider with `/api/v1/widgets/123` works out of the box; a provider with `/api/v1/widgets/blue` won't get `blue` falsely turned into `{slug}`.
- **Future-proof**: any provider that documents canonical templates anywhere in their spec text gets handled automatically.

## Examples (war-tracker)

| Before | After |
| --- | --- |
| `/api/v1/events/397003` | `/api/v1/events/{event_id}` |
| `/share/397003` | `/share/{event_id}` |
| `/share/397003/strike` | `/share/{event_id}/{slug}` |
| `/media/397003` | `/media/{event_id}` |
| `/region/middle-east` | `/region/{slug}` |
| `/country/UA` | `/country/{iso2}` |
| `/event-type/drone-strike` | `/event-type/{slug}` |

## Test plan

- [x] `pnpm test:run` — 115 tests pass (26 new for `templatizePath`)
- [x] `pnpm types:check` — clean
- [x] `pnpm lint` — clean
- [ ] Re-run war-tracker discovery in staging and verify resource rows show templated paths
- [ ] Confirm that an existing standard-OpenAPI origin (already-templated keys) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)