### PR TITLE
Discovery docs polish

### DIFF
--- a/apps/scan/src/app/(app)/(home)/discovery/_components/hub-actions.tsx
+++ b/apps/scan/src/app/(app)/(home)/discovery/_components/hub-actions.tsx
@@ -27,7 +27,7 @@ export function DiscoveryHubActions() {
         {isCopied ? 'Copied' : 'Copy Prompt for Agents'}
       </Button>
       <Button asChild variant="outline" size="sm">
-        <Link href="/resources/register">Add your API</Link>
+        <Link href="/resources/register">+ Add your API</Link>
       </Button>
     </div>
   );

--- a/apps/scan/src/app/(app)/(home)/discovery/architecture/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/discovery/architecture/page.tsx
@@ -32,16 +32,16 @@ export default function ArchitecturePage() {
   return (
     <div>
       <Heading
-        title="Architecture patterns"
+        title="Suggested architecture"
         description="High-level architectures for building agent-payable services."
         actions={
           <div className="flex items-center gap-2">
             <CopyPageButton />
             <Button asChild size="sm">
-              <Link href="/resources/register">Add your API</Link>
+              <Link href="/resources/register">+ Add your API</Link>
             </Button>
             <Button asChild variant="outline" size="sm">
-              <Link href="/discovery/spec">Read the spec</Link>
+              <Link href="/discovery/spec">Read the discovery spec</Link>
             </Button>
           </div>
         }
@@ -116,14 +116,14 @@ export default function ArchitecturePage() {
                 <TableBody>
                   {(
                     [
-                      [<>Payment verification (x402)</>, '✅', '—'],
-                      [<>Wallet identity</>, '✅', '—'],
-                      [<>Per-wallet authorization</>, '✅', '—'],
-                      [<>Per-wallet rate limiting</>, '✅', '—'],
-                      [<>Discovery document (<code>/openapi.json</code>)</>, '✅', '—'],
-                      [<>Business logic</>, '—', '✅'],
-                      [<>User records, billing, quotas</>, '—', '✅'],
-                      [<>Long-term data storage</>, '—', '✅'],
+                      [<>Payment verification (x402)</>, 'Yes', '—'],
+                      [<>Wallet identity</>, 'Yes', '—'],
+                      [<>Per-wallet authorization</>, 'Yes', '—'],
+                      [<>Per-wallet rate limiting</>, 'Yes', '—'],
+                      [<>Discovery document (<code>/openapi.json</code>)</>, 'Yes', '—'],
+                      [<>Business logic</>, '—', 'Yes'],
+                      [<>User records, billing, quotas</>, '—', 'Yes'],
+                      [<>Long-term data storage</>, '—', 'Yes'],
                     ] as [React.ReactNode, string, string][]
                   ).map(([concern, proxy, prod], i) => (
                     <TableRow key={i}>
@@ -170,8 +170,25 @@ export default function ArchitecturePage() {
               can see. It&apos;s the proxy&apos;s job to filter.
             </p>
             <p>
-              Any endpoint that takes a resource ID must verify that the calling
-              wallet owns that resource before proxying through.
+              For example, if your API exposes <code>list_jobs()</code>:
+            </p>
+            <ul className="list-disc pl-5 space-y-2">
+              <li>
+                <strong>Wrong:</strong> the proxy calls{' '}
+                <code>list_jobs()</code> and returns the full response. This
+                leaks every wallet&apos;s jobs to every caller.
+              </li>
+              <li>
+                <strong>Right:</strong> the proxy looks up which job IDs belong
+                to the calling wallet in its own database, fetches only those
+                from the production API, and returns the filtered set.
+              </li>
+            </ul>
+            <p>
+              The same rule applies to <code>get_job</code>,{' '}
+              <code>update_job</code>, and delete operations. Any endpoint that
+              takes a resource ID must verify that the calling wallet owns that
+              resource before proxying through.
             </p>
           </div>
         </section>
@@ -245,6 +262,29 @@ export default function ArchitecturePage() {
         </section>
 
         <section className="space-y-3">
+          <h2 className="text-xl font-semibold">Exposing discovery</h2>
+          <div className="space-y-4 text-sm text-muted-foreground">
+            <p>
+              The proxy is also where you serve your discovery document. Publish{' '}
+              <code>/openapi.json</code> on the proxy origin with{' '}
+              <code>x-payment-info</code> and <code>402</code> responses on each
+              payable operation. Agents discover and call the proxy and never the
+              production API directly.
+            </p>
+            <p>
+              See{' '}
+              <Link
+                href="/discovery/spec"
+                className="underline hover:no-underline font-medium text-foreground"
+              >
+                Server Discovery
+              </Link>{' '}
+              for the full OpenAPI contract.
+            </p>
+          </div>
+        </section>
+
+        <section className="space-y-3">
           <h2 className="text-xl font-semibold">When this pattern fits</h2>
           <ul className="list-disc pl-5 space-y-1 text-sm text-muted-foreground">
             <li>
@@ -263,12 +303,23 @@ export default function ArchitecturePage() {
 
         <section className="flex items-center gap-2">
           <Button asChild size="sm">
-            <Link href="/resources/register">Add your API</Link>
+            <Link href="/resources/register">+ Add your API</Link>
           </Button>
           <Button asChild variant="outline" size="sm">
-            <Link href="/discovery/spec">Read the spec</Link>
+            <Link href="/discovery/spec">Read the discovery spec</Link>
           </Button>
         </section>
+
+        <p className="text-sm text-muted-foreground">
+          For further questions, contact us at{' '}
+          <a
+            href="mailto:merchants@merit.systems"
+            className="underline hover:no-underline font-medium text-foreground"
+          >
+            merchants@merit.systems
+          </a>
+          .
+        </p>
       </Body>
     </div>
   );

--- a/apps/scan/src/app/(app)/(home)/discovery/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/discovery/page.tsx
@@ -96,7 +96,7 @@ export default function DiscoveryPage() {
             <NavCard
               href="/discovery/architecture"
               icon={<Layers className="size-5" />}
-              title="Architecture patterns"
+              title="Suggested architecture"
               description="Proxy architecture for wrapping existing APIs without touching your production backend."
             />
           </div>

--- a/apps/scan/src/app/(app)/(home)/discovery/quickstart/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/discovery/quickstart/page.tsx
@@ -33,7 +33,7 @@ export default function QuickstartPage() {
 
         <section className="flex items-center gap-2">
           <Button asChild size="sm">
-            <Link href="/resources/register">Add your API</Link>
+            <Link href="/resources/register">+ Add your API</Link>
           </Button>
           <Button asChild variant="outline" size="sm">
             <Link href="/discovery/spec">Read the spec</Link>

--- a/apps/scan/src/app/(app)/(home)/integration-spec/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/integration-spec/page.tsx
@@ -99,7 +99,7 @@ export default function DiscoverySpecPage() {
           <div className="flex items-center gap-2">
             <CopyPageButton />
             <Button asChild size="sm">
-              <Link href="/resources/register">Add your API</Link>
+              <Link href="/resources/register">+ Add your API</Link>
             </Button>
             <Button asChild variant="outline" size="sm">
               <Link href="/developer">Test an Endpoint</Link>
@@ -156,10 +156,23 @@ export default function DiscoverySpecPage() {
 
         <section className="space-y-3">
           <h2 className="text-xl font-semibold">Discovery Strategy</h2>
-          <div className="space-y-2 text-sm text-muted-foreground">
+          <div className="space-y-4 text-sm text-muted-foreground">
             <p>
               OpenAPI is the canonical discovery format. Use it for the cleanest
               machine-readable contract and best agent compatibility.
+            </p>
+            <p>
+              The <code>x-payment-info</code> fields are a superset of the{' '}
+              <a
+                href="https://paymentauth.org/draft-payment-discovery-00.txt"
+                className="underline hover:no-underline font-medium text-foreground"
+                target="_blank"
+                rel="noreferrer"
+              >
+                IETF API payment spec
+              </a>
+              . The fields do not collide, so your service is still compatible
+              if you already follow the IETF standard.
             </p>
             <p>
               Expected location: <code>GET /openapi.json</code>
@@ -496,6 +509,17 @@ export default function DiscoverySpecPage() {
             </Link>
           </Button>
         </section>
+
+        <p className="text-sm text-muted-foreground">
+          For further questions, contact us at{' '}
+          <a
+            href="mailto:merchants@merit.systems"
+            className="underline hover:no-underline font-medium text-foreground"
+          >
+            merchants@merit.systems
+          </a>
+          .
+        </p>
       </Body>
     </div>
   );


### PR DESCRIPTION
## Summary

- Rename "Architecture patterns" to "Suggested architecture" on hub card and page title
- Add wallet-aware authorization example (`list_jobs`, `get_job`, `update_job`) to /architecture
- Add "Exposing discovery" section to /architecture with link to /discovery/spec
- Add IETF API payment spec reference to /discovery/spec Discovery Strategy section
- Add contact line (merchants@merit.systems) to /spec and /architecture
- Add "+ Add your API" and "Suggested architecture →" bottom CTAs to /spec
- Prefix all "Add your API" buttons with "+"
- Change "Read the spec" to "Read the discovery spec" on /architecture
- Replace emoji checkmarks with "Yes" in responsibility table
