### PR TITLE
Remove 'Test an Endpoint' button from discovery spec page

### DIFF
--- a/apps/scan/src/app/(app)/(home)/discovery/quickstart/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/discovery/quickstart/page.tsx
@@ -22,6 +22,24 @@ export default function QuickstartPage() {
       <Body className="gap-10">
         <QuickstartPromptCard />
 
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold">When the agent finishes</h2>
+          <ol className="list-decimal pl-5 space-y-2 text-sm text-muted-foreground">
+            <li>
+              Your <code>/openapi.json</code> should describe each payable route
+              with <code>x-payment-info</code> and a <code>402</code> response.
+            </li>
+            <li>
+              The runtime should challenge unpaid requests with a valid{' '}
+              <code>WWW-Authenticate</code> header.
+            </li>
+            <li>
+              Register the origin on x402scan so we can track usage and surface it
+              to agents.
+            </li>
+          </ol>
+        </section>
+
         <section className="space-y-3">
           <h2 className="text-xl font-semibold">Test your API</h2>
           <p className="text-sm text-muted-foreground">
@@ -36,7 +54,7 @@ export default function QuickstartPage() {
             <Link href="/resources/register">+ Add your API</Link>
           </Button>
           <Button asChild variant="outline" size="sm">
-            <Link href="/discovery/spec">Read the spec</Link>
+            <Link href="/discovery/spec">Read the discovery spec →</Link>
           </Button>
         </section>
       </Body>

--- a/apps/scan/src/app/(app)/(home)/integration-spec/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/integration-spec/page.tsx
@@ -101,9 +101,6 @@ export default function DiscoverySpecPage() {
             <Button asChild size="sm">
               <Link href="/resources/register">+ Add your API</Link>
             </Button>
-            <Button asChild variant="outline" size="sm">
-              <Link href="/developer">Test an Endpoint</Link>
-            </Button>
           </div>
         }
       />


### PR DESCRIPTION
## Summary
- Removes the "Test an Endpoint" button from the `/discovery/spec` page header actions

## Test plan
- [ ] Verify `/discovery/spec` page renders without the button
- [ ] Confirm "Copy page" and "+ Add your API" buttons still work
