### PR TITLE
fix(#287): handle OgImage unique constraint conflict

### DIFF
--- a/apps/scan/src/services/db/resources/origin.ts
+++ b/apps/scan/src/services/db/resources/origin.ts
@@ -76,32 +76,21 @@ export const upsertOrigin = async (
     const originId = upsertedOrigin.id;
 
     await Promise.all(
-      origin.ogImages.map(({ url, height, width, title, description }) =>
-        tx.ogImage.upsert({
-          where: {
-            originId_url: {
-              originId,
-              url,
-            },
-          },
-          update: {
-            height,
-            width,
-            title,
-            description,
-          },
-          create: {
-            originId,
-            url,
-            height,
-            width,
-            title,
-            description,
-          },
-        })
-      )
+      origin.ogImages.map(async ({ url, height, width, title, description }) => {
+        const existing = await tx.ogImage.findFirst({
+          where: { originId, url },
+        });
+        if (existing) {
+          return tx.ogImage.update({
+            where: { id: existing.id },
+            data: { height, width, title, description },
+          });
+        }
+        return tx.ogImage.create({
+          data: { originId, url, height, width, title, description },
+        });
+      })
     );
-
     return tx.resourceOrigin.findUnique({
       where: { id: originId },
       include: { ogImages: true },


### PR DESCRIPTION
Fixes #287

When registering a resource whose origin URL already has an OgImage record, the previous upsert approach could fail with a unique constraint violation.

Changed the OgImage handling from raw upsert to findFirst+create pattern: check if a record with the same originId+url exists, update it if found, create if not.

This is safe under the existing transaction since we're within the same $transaction block.