### PR TITLE
feat(facilitators): add AlgoVoi multi-chain payment gateway

### DIFF
--- a/apps/scan/public/algovoi.svg
+++ b/apps/scan/public/algovoi.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <defs>
+    <linearGradient id="av-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#6366F1"/>
+      <stop offset="100%" style="stop-color:#8B5CF6"/>
+    </linearGradient>
+  </defs>
+  <!-- Rounded square background -->
+  <rect width="64" height="64" rx="14" fill="url(#av-grad)"/>
+  <!-- Stylised "A" lettermark -->
+  <path d="M32 10 L50 50 H42 L38 40 H26 L22 50 H14 Z M32 22 L28.5 36 H35.5 Z"
+        fill="white" fill-rule="evenodd"/>
+  <!-- Multi-chain dots -->
+  <circle cx="12" cy="54" r="3" fill="rgba(255,255,255,0.55)"/>
+  <circle cx="22" cy="57" r="3" fill="rgba(255,255,255,0.55)"/>
+  <circle cx="32" cy="58" r="3" fill="rgba(255,255,255,0.55)"/>
+  <circle cx="42" cy="57" r="3" fill="rgba(255,255,255,0.55)"/>
+  <circle cx="52" cy="54" r="3" fill="rgba(255,255,255,0.55)"/>
+</svg>

--- a/packages/external/facilitators/src/facilitators/algovoi.ts
+++ b/packages/external/facilitators/src/facilitators/algovoi.ts
@@ -1,0 +1,35 @@
+import { Network } from '../types';
+import { USDC_BASE_TOKEN, USDC_SOLANA_TOKEN } from '../constants';
+
+import type { Facilitator, FacilitatorConfig } from '../types';
+
+export const algovoi: FacilitatorConfig = {
+  url: 'https://api.algovoi.co.uk',
+};
+
+export const algovoiFacilitator = {
+  id: 'algovoi',
+  metadata: {
+    name: 'AlgoVoi',
+    image: 'https://x402scan.com/algovoi.svg',
+    docsUrl: 'https://api.algovoi.co.uk',
+    color: '#6366F1',
+  },
+  config: algovoi,
+  addresses: {
+    [Network.BASE]: [
+      {
+        address: '0x7D01d268636c835d9E56164A24A9587D82B8B186',
+        tokens: [USDC_BASE_TOKEN],
+        dateOfFirstTransaction: new Date('2026-05-14'),
+      },
+    ],
+    [Network.SOLANA]: [
+      {
+        address: 'GFir5uY6Rrgk3MRSUKSXp2Z5v7x8pum9vn7xjpr8TAGy',
+        tokens: [USDC_SOLANA_TOKEN],
+        dateOfFirstTransaction: new Date('2026-05-14'),
+      },
+    ],
+  },
+} as const satisfies Facilitator;

--- a/packages/external/facilitators/src/facilitators/index.ts
+++ b/packages/external/facilitators/src/facilitators/index.ts
@@ -1,3 +1,4 @@
+export { algovoi, algovoiFacilitator } from './algovoi';
 export { auto, autoFacilitator } from './auto';
 export { coinbase, coinbaseFacilitator } from './coinbase';
 export { aurracloud, aurracloudFacilitator } from './aurracloud';

--- a/packages/external/facilitators/src/lists/all.ts
+++ b/packages/external/facilitators/src/lists/all.ts
@@ -1,4 +1,5 @@
 import {
+  algovoiFacilitator,
   aurracloudFacilitator,
   coinbaseFacilitator,
   thirdwebFacilitator,
@@ -35,6 +36,7 @@ import { validateUniqueFacilitators } from './validate';
 import type { Facilitator } from '../types';
 
 const FACILITATORS = validateUniqueFacilitators([
+  algovoiFacilitator,
   coinbaseFacilitator,
   aurracloudFacilitator,
   thirdwebFacilitator,


### PR DESCRIPTION
## What this adds

A single entry under **Facilitators** for AlgoVoi — a compliance-aware multi-chain payment gateway supporting x402, MPP, AP2, and A2A protocols across 8 chains: Base, Tempo, ARC, Solana, Algorand, VOI, Hedera, and Stellar.

## Live verification

```sh
# 402 probe with multi-chain accepts[]
curl -sI https://api.algovoi.co.uk/mpp/probe | grep -i payment-required

# x402 discovery card
curl -s https://api.algovoi.co.uk/.well-known/x402.json | jq '.networks | length'
# → 8 networks
```

## Supported networks

| Network | Asset | Facilitator payout address |
|---|---|---|
| Base mainnet | USDC `0x833589fC...` | `0x7D01d268636c835d9E56164A24A9587D82B8B186` |
| Solana mainnet | USDC `EPjFWdd5...` | `GFir5uY6Rrgk3MRSUKSXp2Z5v7x8pum9vn7xjpr8TAGy` |
| Algorand mainnet | USDC ASA 31566704 | `GHSRL2SAY247LWE7HLUGEYKHC5JMDOGWECW5TMN6PTP73FT2Z5AWMADMWI` |
| VOI mainnet | aUSDC ASA 2200000 | via AlgoVoi facilitator |
| Hedera mainnet | USDC | via AlgoVoi facilitator |
| Stellar mainnet | USDC `GA5ZSEJ...` | via AlgoVoi facilitator |
| Tempo (EVM L2) | USDC | `0x7D01d268636c835d9E56164A24A9587D82B8B186` |
| ARC testnet | tUSDC | test only |

## Cross-chain bridge support

Agents holding USDC on any of 7 EVM source chains (Base, Arbitrum, Polygon, Optimism, Ethereum, BNB, Avalanche) can pay AlgoVoi-protected resources from MetaMask without installing a destination-chain wallet. Solana routes via Circle CCTP V2 (~50s); Stellar routes via Allbridge Core to canonical Circle USDC.

## Compliance

AlgoVoi runs an open compliance attestation endpoint (`GET /compliance/attestation`) and implements pre-payment screening via `POST /compliance/screen` — the first Bazaar facilitator with built-in AML compliance gates.

Happy to address any review feedback.