### PR TITLE
[codex] Add FluxA facilitator backup address pool

### DIFF
--- a/packages/external/facilitators/src/facilitators/fluxa.ts
+++ b/packages/external/facilitators/src/facilitators/fluxa.ts
@@ -53,6 +53,26 @@ export const fluxaFacilitator = {
         tokens: [USDC_BASE_TOKEN],
         dateOfFirstTransaction: new Date('2025-10-28'),
       },
+      {
+        address: '0x10aa4205354c3d51bbebe2b3731ec8233e744b7b',
+        tokens: [USDC_BASE_TOKEN],
+        dateOfFirstTransaction: new Date('2026-05-15'),
+      },
+      {
+        address: '0x17bc08fac74a151103098f6060382cde2d10269a',
+        tokens: [USDC_BASE_TOKEN],
+        dateOfFirstTransaction: new Date('2026-05-15'),
+      },
+      {
+        address: '0x11898322b9da697a62aa1203472ffb3deb76ffce',
+        tokens: [USDC_BASE_TOKEN],
+        dateOfFirstTransaction: new Date('2026-05-15'),
+      },
+      {
+        address: '0xfd7fe552064f11b4dfb7a4932b6c363a7b42a081',
+        tokens: [USDC_BASE_TOKEN],
+        dateOfFirstTransaction: new Date('2026-05-15'),
+      },
     ],
   },
 } as const satisfies Facilitator;


### PR DESCRIPTION
## Summary
- Add four FluxA Base facilitator backup wallet addresses for concurrent fallback transaction submission.
- Set the first transaction date for the new backup address pool to 2026-05-15.

## Impact
- x402scan can attribute transfers submitted through the expanded FluxA facilitator backup address pool.

## Validation
- Ran `git diff --check` successfully.
- `pnpm --filter facilitators format:check`, `types:check`, and `lint` could not run because this checkout is missing installed dependencies/tools such as `prettier`, `eslint`, and package type dependencies.