### PR TITLE
Add programmatic resource registration options

### DIFF
--- a/apps/scan/src/app/api/x402/_handlers/registry-register.ts
+++ b/apps/scan/src/app/api/x402/_handlers/registry-register.ts
@@ -8,10 +8,15 @@ import type { z } from 'zod';
 export async function handleRegistryRegister(
   body: z.infer<typeof registryRegisterBodySchema>
 ) {
-  const { url } = body;
+  const { url, method, headers, body: probeBody } = body;
 
   const probeResult = await probeX402Endpoint(
-    url.replaceAll('{', '').replaceAll('}', '')
+    url.replaceAll('{', '').replaceAll('}', ''),
+    {
+      preferredMethod: method,
+      headers,
+      sampleInputBody: probeBody,
+    }
   );
 
   if (!probeResult.success) {
@@ -50,6 +55,8 @@ export async function handleRegistryRegister(
           success: true,
           resource: result.resource,
           accepts: result.accepts,
+          methodUsed: probeResult.advisory.method,
+          warnings: probeResult.warnings,
           registrationDetails: result.registrationDetails,
         },
         (_k, v: unknown) => (typeof v === 'bigint' ? Number(v) : v)

--- a/apps/scan/src/app/api/x402/_lib/schemas.test.ts
+++ b/apps/scan/src/app/api/x402/_lib/schemas.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { registryRegisterBodySchema } from './schemas';
+
+describe('registryRegisterBodySchema', () => {
+  it('accepts programmatic probe options for resource registration', () => {
+    const result = registryRegisterBodySchema.safeParse({
+      url: 'https://api.example.com/paid-resource',
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+      body: { prompt: 'hello' },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects non-string header values', () => {
+    const result = registryRegisterBodySchema.safeParse({
+      url: 'https://api.example.com/paid-resource',
+      headers: { 'X-Retry': 3 },
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/scan/src/app/api/x402/_lib/schemas.ts
+++ b/apps/scan/src/app/api/x402/_lib/schemas.ts
@@ -112,6 +112,18 @@ export const registryRegisterBodySchema = z.object({
     .string()
     .url()
     .describe('URL of the x402-protected resource to register'),
+  method: z
+    .enum(['GET', 'POST', 'PUT', 'PATCH', 'DELETE'])
+    .optional()
+    .describe('Preferred HTTP method when probing the resource'),
+  headers: z
+    .record(z.string(), z.string())
+    .optional()
+    .describe('Optional headers to include when probing the resource'),
+  body: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe('Optional JSON body to use when probing the resource'),
 });
 
 export const registryRegisterOriginBodySchema = z.object({

--- a/apps/scan/src/lib/discovery/probe.test.ts
+++ b/apps/scan/src/lib/discovery/probe.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  checkEndpointSchema: vi.fn(),
+  getWarningsForL3: vi.fn(() => []),
+}));
+
+vi.mock('@agentcash/discovery', () => mocks);
+
+import { probeX402Endpoint } from './probe';
+
+const x402Advisory = {
+  method: 'POST',
+  paymentOptions: [{ protocol: 'x402' }],
+  inputSchema: { type: 'object' },
+  paymentRequiredBody: { accepts: [] },
+};
+
+describe('probeX402Endpoint', () => {
+  beforeEach(() => {
+    mocks.checkEndpointSchema.mockReset();
+    mocks.getWarningsForL3.mockReset();
+    mocks.getWarningsForL3.mockReturnValue([]);
+  });
+
+  it('passes custom headers and sample body to the direct probe', async () => {
+    mocks.checkEndpointSchema.mockResolvedValueOnce({
+      found: true,
+      advisories: [x402Advisory],
+    });
+
+    const result = await probeX402Endpoint('https://api.example.com/pay', {
+      preferredMethod: 'POST',
+      headers: { 'X-Api-Key': 'secret' },
+      sampleInputBody: { prompt: 'hello' },
+    });
+
+    expect(result.success).toBe(true);
+    expect(mocks.checkEndpointSchema).toHaveBeenCalledTimes(1);
+    expect(mocks.checkEndpointSchema).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'https://api.example.com/pay',
+        headers: { 'X-Api-Key': 'secret' },
+        probe: true,
+        sampleInputBody: { prompt: 'hello' },
+      })
+    );
+  });
+
+  it('keeps the string preferredMethod overload for existing callers', async () => {
+    mocks.checkEndpointSchema.mockResolvedValueOnce({
+      found: true,
+      advisories: [{ ...x402Advisory, method: 'GET' }],
+    });
+
+    const result = await probeX402Endpoint(
+      'https://api.example.com/pay',
+      'POST'
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.advisory.method).toBe('POST');
+    }
+  });
+
+  it('uses OpenAPI-derived fallback body when an empty probe misses x402', async () => {
+    mocks.checkEndpointSchema
+      .mockResolvedValueOnce({
+        found: false,
+        origin: 'https://api.example.com',
+        path: '/pay',
+        cause: 'not_found',
+      })
+      .mockResolvedValueOnce({
+        found: true,
+        advisories: [
+          {
+            method: 'POST',
+            paymentOptions: [{ protocol: 'x402' }],
+            inputSchema: {
+              type: 'object',
+              properties: { q: { type: 'string' } },
+              required: ['q'],
+            },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        found: true,
+        advisories: [x402Advisory],
+      });
+
+    const result = await probeX402Endpoint('https://api.example.com/pay');
+
+    expect(result.success).toBe(true);
+    expect(mocks.checkEndpointSchema).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        probe: true,
+        sampleInputBody: { q: 'sample' },
+      })
+    );
+  });
+});

--- a/apps/scan/src/lib/discovery/probe.ts
+++ b/apps/scan/src/lib/discovery/probe.ts
@@ -16,6 +16,19 @@ export type ProbeX402Result =
 
 const METHOD_PREFERENCE = ['POST', 'GET', 'PUT', 'PATCH', 'DELETE'] as const;
 
+export interface ProbeX402EndpointOptions {
+  preferredMethod?: string;
+  headers?: Record<string, string>;
+  sampleInputBody?: Record<string, unknown>;
+}
+
+function normalizeProbeOptions(
+  options?: string | ProbeX402EndpointOptions
+): ProbeX402EndpointOptions {
+  if (typeof options === 'string') return { preferredMethod: options };
+  return options ?? {};
+}
+
 function pickX402Advisory(
   result: CheckEndpointResult,
   preferredMethod?: string
@@ -70,24 +83,32 @@ function pickInputSchemaFromSpec(
  * Probes a URL and returns the first advisory that carries x402 payment options.
  *
  * Strategy:
- *   1. Probe with no body (works for servers whose paywall fires before
- *      request validation).
+ *   1. Probe directly, using a caller-provided sample body when present
+ *      (works for servers whose paywall fires before request validation, and
+ *      for programmatic registration where the caller knows the required body).
  *   2. If that yields no x402 advisory, fetch the OpenAPI advisory, build a
  *      minimum-valid sample body from its inputSchema, and re-probe with
  *      `sampleInputBody`. This handles servers (e.g. honcho) that validate
  *      input before the paywall and would otherwise return 400 to a probe.
  *
- * @param preferredMethod - HTTP method from OpenAPI discovery. When provided
- *   it is preferred over what the probe lands on so probe-method drift
- *   (PATCH/PUT vs declared POST) does not corrupt the registered method.
+ * @param options - Optional preferred method, probe headers, and sample body.
+ *   The legacy string form still supplies just the preferred method. When a
+ *   preferred method is provided, it is preferred over what the probe lands on
+ *   so probe-method drift (PATCH/PUT vs declared POST) does not corrupt the
+ *   registered method.
  */
 export async function probeX402Endpoint(
   url: string,
-  preferredMethod?: string
+  options?: string | ProbeX402EndpointOptions
 ): Promise<ProbeX402Result> {
+  const { preferredMethod, headers, sampleInputBody } =
+    normalizeProbeOptions(options);
+
   const noBody = await checkEndpointSchema({
     url,
+    headers,
     probe: true,
+    ...(sampleInputBody ? { sampleInputBody } : {}),
     signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
   });
 
@@ -103,11 +124,12 @@ export async function probeX402Endpoint(
   // Fallback: use OpenAPI inputSchema to build a sample body and re-probe.
   const spec = await checkEndpointSchema({
     url,
+    headers,
     signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
   });
   const inputSchema = pickInputSchemaFromSpec(spec, preferredMethod);
-  const sampleInputBody = buildSampleBodyFromInputSchema(inputSchema);
-  if (!sampleInputBody) {
+  const fallbackInputBody = buildSampleBodyFromInputSchema(inputSchema);
+  if (!fallbackInputBody) {
     return {
       success: false,
       error: noBodyError(noBody),
@@ -116,8 +138,9 @@ export async function probeX402Endpoint(
 
   const withBody = await checkEndpointSchema({
     url,
+    headers,
     probe: true,
-    sampleInputBody,
+    sampleInputBody: fallbackInputBody,
     signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
   });
   const bodiedAdvisory = pickX402Advisory(withBody, preferredMethod);

--- a/apps/scan/src/trpc/routers/public/resources.ts
+++ b/apps/scan/src/trpc/routers/public/resources.ts
@@ -137,13 +137,19 @@ export const resourcesRouter = createTRPCRouter({
     .input(
       z.object({
         url: z.url(),
+        method: z.enum(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']).optional(),
         headers: z.record(z.string(), z.string()).optional(),
-        body: z.object().optional(),
+        body: z.record(z.string(), z.unknown()).optional(),
       })
     )
     .mutation(async ({ input }) => {
       const probeResult = await probeX402Endpoint(
-        input.url.toString().replaceAll('{', '').replaceAll('}', '')
+        input.url.toString().replaceAll('{', '').replaceAll('}', ''),
+        {
+          preferredMethod: input.method,
+          headers: input.headers,
+          sampleInputBody: input.body,
+        }
       );
 
       if (!probeResult.success) {

--- a/docs/DISCOVERY.md
+++ b/docs/DISCOVERY.md
@@ -23,6 +23,7 @@ Runtime `402` behavior is authoritative over static metadata.
 ## A) OpenAPI-First Discovery (Recommended)
 
 Supported URLs:
+
 - `https://yourdomain.com/openapi.json`
 
 ### Required top-level fields
@@ -35,6 +36,7 @@ Supported URLs:
 ### Per-paid-operation requirements
 
 For each paid operation:
+
 - declare `x-payment-info`
 - include a `402` response in `responses`
 - include `x-payment-info.protocols` (for example `"x402"`)
@@ -100,14 +102,17 @@ Use this when discovery docs are not available yet.
 A route is registerable when probing returns `402` with a parseable x402 challenge.
 
 Accepted challenge transport:
+
 - `Payment-Required` header (x402 v2), or
 - JSON response body (legacy compatibility)
 
 For payable indexing in `x402scan`, challenge data should include:
+
 - non-empty `accepts`
 - Bazaar-style input schema (`extensions.bazaar.info` + schema-derived input)
 
 Compatibility behavior:
+
 - `402` + `accepts: []` + `extensions["sign-in-with-x"]` => SIWX auth-only, marked `skipped`.
 - Missing input schema => strict non-invocable, marked `skipped`.
 
@@ -116,6 +121,7 @@ Compatibility behavior:
 ## Ownership Proofs
 
 Accepted locations:
+
 - OpenAPI `x-discovery.ownershipProofs` (preferred)
 - `/.well-known/x402` `ownershipProofs` (compatibility)
 
@@ -136,6 +142,59 @@ When a user clicks **Register This URL Only**:
 - Skip fan-out.
 - Register only that endpoint.
 - Useful for partial rollouts and rate-limited providers.
+
+## Programmatic Registration API
+
+Registry write endpoints are free and require SIWX authentication. Use
+`fetch_with_auth` from the x402scan MCP client, or send a signed
+`SIGN-IN-WITH-X` header.
+
+Register or refresh one known endpoint:
+
+```bash
+curl -X POST https://www.x402scan.com/api/x402/registry/register \
+  -H "Content-Type: application/json" \
+  -H "SIGN-IN-WITH-X: <signed-siwx-proof>" \
+  -d '{
+    "url": "https://api.example.com/paid-resource"
+  }'
+```
+
+The endpoint probes the URL for a valid x402 `402 Payment Required` response,
+then upserts the resource. Calling it again refreshes the stored resource.
+
+For endpoints that require a representative request before they return their
+x402 challenge, include probe options:
+
+```json
+{
+  "url": "https://api.example.com/paid-resource",
+  "method": "POST",
+  "headers": {
+    "X-Api-Key": "provider-probe-token"
+  },
+  "body": {
+    "prompt": "hello"
+  }
+}
+```
+
+Register or refresh all discoverable resources for an origin:
+
+```bash
+curl -X POST https://www.x402scan.com/api/x402/registry/register-origin \
+  -H "Content-Type: application/json" \
+  -H "SIGN-IN-WITH-X: <signed-siwx-proof>" \
+  -d '{
+    "origin": "https://api.example.com"
+  }'
+```
+
+Single-resource registration returns `success: true` with the registered
+resource, accepted payment options, the method used, warnings, and registration
+details. Invalid URLs or request shapes return `400` from request validation.
+Resources that do not produce a valid x402 challenge return `422` with a
+parseable error payload.
 
 ---
 


### PR DESCRIPTION
Summary
- Added method, headers, and body support to programmatic single-resource registration.
- Reused the existing probe and registration flow for both API and tRPC registration paths.
- Documented authenticated programmatic registration and probe options in the discovery guide.
- Added focused tests for schema validation and probe option forwarding.

Validation
- pnpm --filter @x402scan/app test:run src/lib/discovery/probe.test.ts src/app/api/x402/_lib/schemas.test.ts
- pnpm -w format:check:dir apps/scan/src/lib/discovery/probe.ts apps/scan/src/lib/discovery/probe.test.ts apps/scan/src/app/api/x402/_lib/schemas.ts apps/scan/src/app/api/x402/_lib/schemas.test.ts apps/scan/src/app/api/x402/_handlers/registry-register.ts apps/scan/src/trpc/routers/public/resources.ts docs/DISCOVERY.md

Notes
- Full app typecheck was not used as final validation because this checkout reports broad pre-existing/generated type errors unrelated to these files.

Closes #104
/claim #104
