### PR TITLE
Standardize CDP SQL aggregate numeric parsing

### DIFF
--- a/apps/scan/src/services/transfers/buyers/list-mv.ts
+++ b/apps/scan/src/services/transfers/buyers/list-mv.ts
@@ -4,7 +4,11 @@ import { Prisma } from '@x402scan/transfers-db';
 import { chainSchema, mixedAddressSchema } from '@/lib/schemas';
 import { toPaginatedResponse } from '@/lib/pagination';
 
-import { baseListQuerySchema } from '../schemas';
+import {
+  baseListQuerySchema,
+  cdpSqlIntegerSchema,
+  cdpSqlNumberSchema,
+} from '../schemas';
 import {
   createCachedPaginatedQuery,
   createStandardCacheKey,
@@ -105,10 +109,10 @@ const listTopBuyersMVUncached = async (
         z.object({
           sender: mixedAddressSchema,
           facilitator_ids: z.array(z.string()),
-          tx_count: z.number(),
-          total_amount: z.number(),
+          tx_count: cdpSqlIntegerSchema,
+          total_amount: cdpSqlNumberSchema,
           latest_block_timestamp: z.date().nullable(),
-          unique_sellers: z.number(),
+          unique_sellers: cdpSqlIntegerSchema,
           chains: z.array(chainSchema),
         })
       )
@@ -131,7 +135,7 @@ const listTopBuyersMVUncached = async (
       `,
         z.array(
           z.object({
-            count: z.number(),
+            count: cdpSqlIntegerSchema,
           })
         )
       );

--- a/apps/scan/src/services/transfers/buyers/sellers/list.ts
+++ b/apps/scan/src/services/transfers/buyers/sellers/list.ts
@@ -4,7 +4,11 @@ import { Prisma } from '@x402scan/transfers-db';
 import { chainSchema, mixedAddressSchema } from '@/lib/schemas';
 import { toPaginatedResponse } from '@/lib/pagination';
 
-import { baseListQuerySchema } from '../../schemas';
+import {
+  baseListQuerySchema,
+  cdpSqlIntegerSchema,
+  cdpSqlNumberSchema,
+} from '../../schemas';
 import {
   createCachedPaginatedQuery,
   createStandardCacheKey,
@@ -74,8 +78,8 @@ const listBuyerSellersUncached = async (
     z.array(
       z.object({
         recipient: mixedAddressSchema,
-        tx_count: z.number(),
-        total_amount: z.number(),
+        tx_count: cdpSqlIntegerSchema,
+        total_amount: cdpSqlNumberSchema,
         latest_block_timestamp: z.date().nullable(),
         chains: z.array(chainSchema),
         facilitator_ids: z.array(z.string()),
@@ -96,7 +100,7 @@ const listBuyerSellersUncached = async (
       `,
       z.array(
         z.object({
-          count: z.number(),
+          count: cdpSqlIntegerSchema,
         })
       )
     );

--- a/apps/scan/src/services/transfers/buyers/stats/bucketed-mv.ts
+++ b/apps/scan/src/services/transfers/buyers/stats/bucketed-mv.ts
@@ -1,7 +1,11 @@
 import z from 'zod';
 import { Prisma } from '@x402scan/transfers-db';
 
-import { baseBucketedQuerySchema } from '../../schemas';
+import {
+  baseBucketedQuerySchema,
+  cdpSqlIntegerSchema,
+  cdpSqlNumberSchema,
+} from '../../schemas';
 import { createCachedArrayQuery, createStandardCacheKey } from '@/lib/cache';
 import { queryRaw } from '@/services/transfers/client';
 import { getMaterializedViewSuffix } from '@/lib/time-range';
@@ -11,11 +15,11 @@ export const bucketedBuyerStatisticsMVInputSchema = baseBucketedQuerySchema;
 const bucketedBuyerResultSchema = z.array(
   z.object({
     bucket_start: z.date(),
-    total_buyers: z.number(),
-    total_transactions: z.number(),
-    total_amount: z.number(),
-    unique_sellers: z.number(),
-    new_buyers: z.number(),
+    total_buyers: cdpSqlIntegerSchema,
+    total_transactions: cdpSqlIntegerSchema,
+    total_amount: cdpSqlNumberSchema,
+    unique_sellers: cdpSqlIntegerSchema,
+    new_buyers: cdpSqlIntegerSchema,
   })
 );
 

--- a/apps/scan/src/services/transfers/buyers/stats/overall-mv.ts
+++ b/apps/scan/src/services/transfers/buyers/stats/overall-mv.ts
@@ -1,7 +1,11 @@
 import z from 'zod';
 import { Prisma } from '@x402scan/transfers-db';
 
-import { baseQuerySchema } from '../../schemas';
+import {
+  baseQuerySchema,
+  cdpSqlIntegerSchema,
+  cdpSqlNumberSchema,
+} from '../../schemas';
 import { createCachedQuery, createStandardCacheKey } from '@/lib/cache';
 import { queryRaw } from '@/services/transfers/client';
 import { getMaterializedViewSuffix } from '@/lib/time-range';
@@ -68,12 +72,12 @@ const getOverallBuyerStatisticsMVUncached = async (
       sql,
       z.array(
         z.object({
-          total_buyers: z.number(),
-          total_transactions: z.number(),
-          total_amount: z.number(),
-          unique_sellers: z.number(),
+          total_buyers: cdpSqlIntegerSchema,
+          total_transactions: cdpSqlIntegerSchema,
+          total_amount: cdpSqlNumberSchema,
+          unique_sellers: cdpSqlIntegerSchema,
           latest_block_timestamp: z.date().nullable(),
-          new_buyers: z.number(),
+          new_buyers: cdpSqlIntegerSchema,
         })
       )
     );

--- a/apps/scan/src/services/transfers/facilitators/bucketed.ts
+++ b/apps/scan/src/services/transfers/facilitators/bucketed.ts
@@ -2,7 +2,11 @@ import z from 'zod';
 
 import { Prisma } from '@x402scan/transfers-db';
 
-import { baseBucketedQuerySchema } from '../schemas';
+import {
+  baseBucketedQuerySchema,
+  cdpSqlIntegerSchema,
+  cdpSqlNumberSchema,
+} from '../schemas';
 
 import { queryRaw } from '@/services/transfers/client';
 
@@ -131,18 +135,18 @@ const getBucketedFacilitatorsStatisticsUncached = async (
         facilitators: z.record(
           z.string(),
           z.object({
-            total_transactions: z.number(),
-            total_amount: z.number(),
-            unique_buyers: z.number(),
-            unique_sellers: z.number(),
+            total_transactions: cdpSqlIntegerSchema,
+            total_amount: cdpSqlNumberSchema,
+            unique_buyers: cdpSqlIntegerSchema,
+            unique_sellers: cdpSqlIntegerSchema,
           })
         ),
         totals: z
           .record(
             z.string(),
             z.object({
-              totalTransactions: z.number(),
-              totalAmount: z.number(),
+              totalTransactions: cdpSqlIntegerSchema,
+              totalAmount: cdpSqlNumberSchema,
             })
           )
           .nullable(),

--- a/apps/scan/src/services/transfers/facilitators/list.ts
+++ b/apps/scan/src/services/transfers/facilitators/list.ts
@@ -1,6 +1,10 @@
 import z from 'zod';
 
-import { baseListQuerySchema } from '../schemas';
+import {
+  baseListQuerySchema,
+  cdpSqlIntegerSchema,
+  cdpSqlNumberSchema,
+} from '../schemas';
 
 import { queryRaw } from '@/services/transfers/client';
 
@@ -92,11 +96,11 @@ const listTopFacilitatorsUncached = async (
     z.array(
       z.object({
         facilitator_id: z.string(),
-        tx_count: z.number(),
-        total_amount: z.number(),
+        tx_count: cdpSqlIntegerSchema,
+        total_amount: cdpSqlNumberSchema,
         latest_block_timestamp: z.date(),
-        unique_buyers: z.number(),
-        unique_sellers: z.number(),
+        unique_buyers: cdpSqlIntegerSchema,
+        unique_sellers: cdpSqlIntegerSchema,
         chains: z.array(chainSchema),
       })
     )
@@ -114,7 +118,7 @@ const listTopFacilitatorsUncached = async (
         HAVING SUM(total_transactions) > ${Prisma.raw(MIN_FACILITATOR_TRANSACTIONS.toString())}
       ) subquery
     `,
-    z.array(z.object({ count: z.number() }))
+    z.array(z.object({ count: cdpSqlIntegerSchema }))
   );
 
   const count = countResult[0]?.count ?? 0;

--- a/apps/scan/src/services/transfers/networks/bucketed.ts
+++ b/apps/scan/src/services/transfers/networks/bucketed.ts
@@ -1,7 +1,11 @@
 import z from 'zod';
 import { Prisma } from '@x402scan/scan-db';
 
-import { baseBucketedQuerySchema } from '../schemas';
+import {
+  baseBucketedQuerySchema,
+  cdpSqlIntegerSchema,
+  cdpSqlNumberSchema,
+} from '../schemas';
 import { createCachedArrayQuery, createStandardCacheKey } from '@/lib/cache';
 import { queryRaw } from '@/services/transfers/client';
 import { Chain } from '@/types/chain';
@@ -15,11 +19,11 @@ const bucketedNetworkResultSchema = z.array(
     networks: z.record(
       z.string(),
       z.object({
-        total_transactions: z.number(),
-        total_amount: z.number(),
-        unique_buyers: z.number(),
-        unique_sellers: z.number(),
-        unique_facilitators: z.number(),
+        total_transactions: cdpSqlIntegerSchema,
+        total_amount: cdpSqlNumberSchema,
+        unique_buyers: cdpSqlIntegerSchema,
+        unique_sellers: cdpSqlIntegerSchema,
+        unique_facilitators: cdpSqlIntegerSchema,
       })
     ),
   })

--- a/apps/scan/src/services/transfers/networks/list.ts
+++ b/apps/scan/src/services/transfers/networks/list.ts
@@ -1,4 +1,8 @@
-import { baseQuerySchema } from '../schemas';
+import {
+  baseQuerySchema,
+  cdpSqlIntegerSchema,
+  cdpSqlNumberSchema,
+} from '../schemas';
 import z from 'zod';
 import { chainSchema, sortingSchema } from '@/lib/schemas';
 import { createCachedArrayQuery, createStandardCacheKey } from '@/lib/cache';
@@ -91,12 +95,12 @@ const listTopNetworksUncached = async (
     z.array(
       z.object({
         chain: chainSchema,
-        tx_count: z.number(),
-        total_amount: z.number(),
+        tx_count: cdpSqlIntegerSchema,
+        total_amount: cdpSqlNumberSchema,
         latest_block_timestamp: z.date(),
-        unique_buyers: z.number(),
-        unique_sellers: z.number(),
-        unique_facilitators: z.number(),
+        unique_buyers: cdpSqlIntegerSchema,
+        unique_sellers: cdpSqlIntegerSchema,
+        unique_facilitators: cdpSqlIntegerSchema,
       })
     )
   );

--- a/apps/scan/src/services/transfers/origins/stats/bucketed-mv.ts
+++ b/apps/scan/src/services/transfers/origins/stats/bucketed-mv.ts
@@ -5,6 +5,7 @@ import { createCachedArrayQuery, createStandardCacheKey } from '@/lib/cache';
 import { queryRaw } from '@/services/transfers/client';
 import { getMaterializedViewSuffix } from '@/lib/time-range';
 import { chainSchema, timeframeSchema } from '@/lib/schemas';
+import { cdpSqlIntegerSchema, cdpSqlNumberSchema } from '../../schemas';
 
 /**
  * Input schema for bucketed origin statistics queries.
@@ -62,10 +63,10 @@ const getBucketedOriginStatisticsMVUncached = async (
     z.array(
       z.object({
         bucket_start: z.date(),
-        total_origins: z.number(),
-        total_transactions: z.number(),
-        total_amount: z.number(),
-        unique_buyers: z.number(),
+        total_origins: cdpSqlIntegerSchema,
+        total_transactions: cdpSqlIntegerSchema,
+        total_amount: cdpSqlNumberSchema,
+        unique_buyers: cdpSqlIntegerSchema,
       })
     )
   );

--- a/apps/scan/src/services/transfers/origins/stats/overall-mv.ts
+++ b/apps/scan/src/services/transfers/origins/stats/overall-mv.ts
@@ -5,6 +5,7 @@ import { createCachedQuery, createStandardCacheKey } from '@/lib/cache';
 import { queryRaw } from '@/services/transfers/client';
 import { getMaterializedViewSuffix } from '@/lib/time-range';
 import { chainSchema, timeframeSchema } from '@/lib/schemas';
+import { cdpSqlIntegerSchema, cdpSqlNumberSchema } from '../../schemas';
 
 /**
  * Input schema for origin-based statistics queries.
@@ -63,10 +64,10 @@ const getOverallOriginStatisticsMVUncached = async (
     sql,
     z.array(
       z.object({
-        total_origins: z.number(),
-        total_transactions: z.number(),
-        total_amount: z.number(),
-        unique_buyers: z.number(),
+        total_origins: cdpSqlIntegerSchema,
+        total_transactions: cdpSqlIntegerSchema,
+        total_amount: cdpSqlNumberSchema,
+        unique_buyers: cdpSqlIntegerSchema,
         latest_block_timestamp: z.date().nullable(),
       })
     )

--- a/apps/scan/src/services/transfers/schemas.test.ts
+++ b/apps/scan/src/services/transfers/schemas.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { cdpSqlIntegerSchema, cdpSqlNumberSchema } from './schemas';
+
+describe('cdpSqlNumberSchema', () => {
+  it('keeps numbers as numbers', () => {
+    expect(cdpSqlNumberSchema.parse(123.45)).toBe(123.45);
+  });
+
+  it('converts numeric strings from raw SQL drivers', () => {
+    expect(cdpSqlNumberSchema.parse('123.45')).toBe(123.45);
+    expect(cdpSqlNumberSchema.parse(' 0 ')).toBe(0);
+  });
+
+  it('converts BigInt values before cached results are serialized', () => {
+    const value = cdpSqlNumberSchema.parse(BigInt(42));
+
+    expect(value).toBe(42);
+    expect(JSON.stringify({ value })).toBe('{"value":42}');
+  });
+
+  it('rejects non-finite and non-numeric values', () => {
+    expect(cdpSqlNumberSchema.safeParse('').success).toBe(false);
+    expect(cdpSqlNumberSchema.safeParse('not-a-number').success).toBe(false);
+    expect(cdpSqlNumberSchema.safeParse(Number.POSITIVE_INFINITY).success).toBe(
+      false
+    );
+  });
+});
+
+describe('cdpSqlIntegerSchema', () => {
+  it('accepts integer strings and BigInts', () => {
+    expect(cdpSqlIntegerSchema.parse('123')).toBe(123);
+    expect(cdpSqlIntegerSchema.parse(BigInt(123))).toBe(123);
+  });
+
+  it('rejects fractional values', () => {
+    expect(cdpSqlIntegerSchema.safeParse('1.25').success).toBe(false);
+    expect(cdpSqlIntegerSchema.safeParse(1.25).success).toBe(false);
+  });
+});

--- a/apps/scan/src/services/transfers/schemas.ts
+++ b/apps/scan/src/services/transfers/schemas.ts
@@ -12,6 +12,21 @@ const addressArray = z
   .array(mixedAddressSchema)
   .transform(addresses => [...addresses].sort((a, b) => a.localeCompare(b)));
 
+export const cdpSqlNumberSchema = z.preprocess(value => {
+  if (typeof value === 'bigint') {
+    return Number(value);
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length === 0 ? Number.NaN : Number(trimmed);
+  }
+
+  return value;
+}, z.number().finite());
+
+export const cdpSqlIntegerSchema = cdpSqlNumberSchema.pipe(z.number().int());
+
 const addressesSchema = z.object({
   include: addressArray.optional(),
   exclude: addressArray.optional(),

--- a/apps/scan/src/services/transfers/sellers/list-mv.ts
+++ b/apps/scan/src/services/transfers/sellers/list-mv.ts
@@ -4,7 +4,11 @@ import { Prisma } from '@x402scan/transfers-db';
 import { chainSchema, mixedAddressSchema } from '@/lib/schemas';
 import { toPaginatedResponse } from '@/lib/pagination';
 
-import { baseListQuerySchema } from '../schemas';
+import {
+  baseListQuerySchema,
+  cdpSqlIntegerSchema,
+  cdpSqlNumberSchema,
+} from '../schemas';
 import {
   createCachedPaginatedQuery,
   createStandardCacheKey,
@@ -98,10 +102,10 @@ export const listTopSellersMVUncached = async (
       z.object({
         recipient: mixedAddressSchema,
         facilitator_ids: z.array(z.string()),
-        tx_count: z.number(),
-        total_amount: z.number(),
+        tx_count: cdpSqlIntegerSchema,
+        total_amount: cdpSqlNumberSchema,
         latest_block_timestamp: z.date().nullable(),
-        unique_buyers: z.number(),
+        unique_buyers: cdpSqlIntegerSchema,
         chains: z.array(chainSchema),
       })
     )
@@ -124,7 +128,7 @@ export const listTopSellersMVUncached = async (
       `,
       z.array(
         z.object({
-          count: z.number(),
+          count: cdpSqlIntegerSchema,
         })
       )
     );

--- a/apps/scan/src/services/transfers/sellers/stats/bucketed-mv.ts
+++ b/apps/scan/src/services/transfers/sellers/stats/bucketed-mv.ts
@@ -1,7 +1,11 @@
 import z from 'zod';
 import { Prisma } from '@x402scan/transfers-db';
 
-import { baseBucketedQuerySchema } from '../../schemas';
+import {
+  baseBucketedQuerySchema,
+  cdpSqlIntegerSchema,
+  cdpSqlNumberSchema,
+} from '../../schemas';
 import { createCachedArrayQuery, createStandardCacheKey } from '@/lib/cache';
 import { queryRaw } from '@/services/transfers/client';
 import { getMaterializedViewSuffix } from '@/lib/time-range';
@@ -24,11 +28,11 @@ const getBucketInterval = (mvTimeframe: string): string => {
 const bucketedSellerResultSchema = z.array(
   z.object({
     bucket_start: z.date(),
-    total_sellers: z.number(),
-    total_transactions: z.number(),
-    total_amount: z.number(),
-    unique_buyers: z.number(),
-    new_sellers: z.number(),
+    total_sellers: cdpSqlIntegerSchema,
+    total_transactions: cdpSqlIntegerSchema,
+    total_amount: cdpSqlNumberSchema,
+    unique_buyers: cdpSqlIntegerSchema,
+    new_sellers: cdpSqlIntegerSchema,
   })
 );
 

--- a/apps/scan/src/services/transfers/sellers/stats/overall-mv.ts
+++ b/apps/scan/src/services/transfers/sellers/stats/overall-mv.ts
@@ -1,7 +1,11 @@
 import z from 'zod';
 import { Prisma } from '@x402scan/transfers-db';
 
-import { baseQuerySchema } from '../../schemas';
+import {
+  baseQuerySchema,
+  cdpSqlIntegerSchema,
+  cdpSqlNumberSchema,
+} from '../../schemas';
 import { createCachedQuery, createStandardCacheKey } from '@/lib/cache';
 import { queryRaw } from '@/services/transfers/client';
 import { getMaterializedViewSuffix } from '@/lib/time-range';
@@ -103,12 +107,12 @@ const getOverallSellerStatisticsMVUncached = async (
     sql,
     z.array(
       z.object({
-        total_sellers: z.number(),
-        total_transactions: z.number(),
-        total_amount: z.number(),
-        unique_buyers: z.number(),
+        total_sellers: cdpSqlIntegerSchema,
+        total_transactions: cdpSqlIntegerSchema,
+        total_amount: cdpSqlNumberSchema,
+        unique_buyers: cdpSqlIntegerSchema,
         latest_block_timestamp: z.date().nullable(),
-        new_sellers: z.number(),
+        new_sellers: cdpSqlIntegerSchema,
       })
     )
   );

--- a/apps/scan/src/services/transfers/stats/bucketed-mv.ts
+++ b/apps/scan/src/services/transfers/stats/bucketed-mv.ts
@@ -1,7 +1,11 @@
 import z from 'zod';
 import { Prisma } from '@x402scan/transfers-db';
 
-import { baseBucketedQuerySchema } from '../schemas';
+import {
+  baseBucketedQuerySchema,
+  cdpSqlIntegerSchema,
+  cdpSqlNumberSchema,
+} from '../schemas';
 import { createCachedArrayQuery, createStandardCacheKey } from '@/lib/cache';
 import { queryRaw } from '@/services/transfers/client';
 import { getMaterializedViewSuffix } from '@/lib/time-range';
@@ -11,10 +15,10 @@ export const bucketedStatisticsMVInputSchema = baseBucketedQuerySchema;
 const bucketedResultSchema = z.array(
   z.object({
     bucket_start: z.date(),
-    total_transactions: z.number(),
-    total_amount: z.number(),
-    unique_buyers: z.number(),
-    unique_sellers: z.number(),
+    total_transactions: cdpSqlIntegerSchema,
+    total_amount: cdpSqlNumberSchema,
+    unique_buyers: cdpSqlIntegerSchema,
+    unique_sellers: cdpSqlIntegerSchema,
   })
 );
 

--- a/apps/scan/src/services/transfers/stats/overall-mv.ts
+++ b/apps/scan/src/services/transfers/stats/overall-mv.ts
@@ -1,7 +1,11 @@
 import z from 'zod';
 import { Prisma } from '@x402scan/transfers-db';
 
-import { baseQuerySchema } from '../schemas';
+import {
+  baseQuerySchema,
+  cdpSqlIntegerSchema,
+  cdpSqlNumberSchema,
+} from '../schemas';
 import { createCachedQuery, createStandardCacheKey } from '@/lib/cache';
 import { queryRaw } from '@/services/transfers/client';
 import { getMaterializedViewSuffix } from '@/lib/time-range';
@@ -97,10 +101,10 @@ const getOverallStatisticsMVUncached = async (
     sql,
     z.array(
       z.object({
-        total_transactions: z.number(),
-        total_amount: z.number(),
-        unique_buyers: z.number(),
-        unique_sellers: z.number(),
+        total_transactions: cdpSqlIntegerSchema,
+        total_amount: cdpSqlNumberSchema,
+        unique_buyers: cdpSqlIntegerSchema,
+        unique_sellers: cdpSqlIntegerSchema,
         latest_block_timestamp: z.date().nullable(),
       })
     )

--- a/apps/scan/src/services/transfers/wallets/stats.ts
+++ b/apps/scan/src/services/transfers/wallets/stats.ts
@@ -5,6 +5,7 @@ import { queryRaw } from '@/services/transfers/client';
 import { createCachedQuery, createStandardCacheKey } from '@/lib/cache';
 import { chainSchema } from '@/lib/schemas';
 import { getMaterializedViewSuffix } from '@/lib/time-range';
+import { cdpSqlIntegerSchema, cdpSqlNumberSchema } from '../schemas';
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type WalletStatsInput = {
@@ -46,9 +47,9 @@ const getWalletStatsUncached = async (input: WalletStatsInput) => {
       `,
       z.array(
         z.object({
-          total_transactions: z.number(),
-          total_amount: z.number(),
-          unique_recipients: z.number(),
+          total_transactions: cdpSqlIntegerSchema,
+          total_amount: cdpSqlNumberSchema,
+          unique_recipients: cdpSqlIntegerSchema,
           chains: z.array(chainSchema),
         })
       )


### PR DESCRIPTION
Fixes #45.

This adds a shared parser for CDP/Postgres aggregate numeric values and applies it across the transfer statistics services, so raw SQL results can consistently accept `number`, numeric `string`, and `bigint` values while returning JSON-serializable numbers to callers.

What changed:
- Added `cdpSqlNumberSchema` and `cdpSqlIntegerSchema` in the transfer service schemas module.
- Replaced ad hoc `z.number()` aggregate result fields across overall, bucketed, buyer, seller, origin, facilitator, network, and wallet transfer services.
- Added unit coverage for number, numeric-string, BigInt, integer, fractional, non-numeric, and JSON serialization behavior.

Verification:
- `corepack pnpm --filter @x402scan/app test:run src/services/transfers/schemas.test.ts`
- `corepack pnpm --filter @x402scan/app exec prettier --check ...changed transfer files...`
- `corepack pnpm --filter @x402scan/app exec eslint ...changed transfer files...`
- `corepack pnpm --filter @x402scan/app types:check`

Local setup note: on Windows, the workspace `postinstall` script fails because `apps/scan` uses a Unix `cp ... || true` command. I generated Prisma clients and Next route types manually before type-checking.