### PR TITLE
feat(facilitators): add EZ Path Base mainnet facilitator

### DIFF
--- a/packages/external/facilitators/src/facilitators/ezpath.ts
+++ b/packages/external/facilitators/src/facilitators/ezpath.ts
@@ -1,0 +1,28 @@
+import { Network } from '../types';
+import { USDC_BASE_TOKEN } from '../constants';
+
+import type { Facilitator, FacilitatorConfig } from '../types';
+
+export const ezpath: FacilitatorConfig = {
+  url: 'https://ezpath.myezverse.xyz/facilitator',
+};
+
+export const ezpathFacilitator = {
+  id: 'ezpath',
+  metadata: {
+    name: 'EZ Path',
+    image: 'https://ezpath.myezverse.xyz/og.webp',
+    docsUrl: 'https://ezpath.myezverse.xyz',
+    color: '#2563EB',
+  },
+  config: ezpath,
+  addresses: {
+    [Network.BASE]: [
+      {
+        address: '0x13dDE704389b1118B20d2BCc6D3Ace749600e2ad',
+        tokens: [USDC_BASE_TOKEN],
+        dateOfFirstTransaction: new Date('2026-05-17'),
+      },
+    ],
+  },
+} as const satisfies Facilitator;

--- a/packages/external/facilitators/src/facilitators/index.ts
+++ b/packages/external/facilitators/src/facilitators/index.ts
@@ -28,3 +28,4 @@ export { relai, relaiFacilitator } from './relai';
 export { bitrefill, bitrefillFacilitator } from './bitrefill';
 export { cascade, cascadeFacilitator } from './cascade';
 export { fluxa, fluxaFacilitator } from './fluxa';
+export { ezpath, ezpathFacilitator } from './ezpath';


### PR DESCRIPTION
## Summary

Adds EZ Path as a facilitator on Base mainnet (eip155:8453).

- **Facilitator URL:** https://ezpath.myezverse.xyz/facilitator
- **Toll address:** 0x13dDE704389b1118B20d2BCc6D3Ace749600e2ad
- **Network:** Base mainnet
- **Asset:** USDC
- **Supports:** `/verify`, `/settle`, `/supported`
- **First transaction:** 2026-05-17

EZ Path is a DEX aggregator that races 0x, ParaSwap, Aerodrome, and Uniswap V3 simultaneously and returns the best buyAmount. It runs its own self-hosted facilitator for Base mainnet since the public CDP facilitator only supports Base Sepolia.