### PR TITLE
Use OpenAPI info as a fallback for origin title/description

### DIFF
--- a/apps/scan/src/app/(app)/(home)/discovery/architecture/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/discovery/architecture/page.tsx
@@ -89,8 +89,8 @@ export default function ArchitecturePage() {
               choice, but any HTTP framework works). Provision a single API key
               from your production backend with broad permissions. The proxy
               acts as a pure consumer of your production API, wrapping each
-              endpoint you want to expose over x402 with a corresponding
-              payable endpoint on the proxy.
+              endpoint you want to expose over x402 with a corresponding payable
+              endpoint on the proxy.
             </p>
             <p>
               All agentic traffic to your production backend appears under a
@@ -120,7 +120,13 @@ export default function ArchitecturePage() {
                       [<>Wallet identity</>, 'Yes', '—'],
                       [<>Per-wallet authorization</>, 'Yes', '—'],
                       [<>Per-wallet rate limiting</>, 'Yes', '—'],
-                      [<>Discovery document (<code>/openapi.json</code>)</>, 'Yes', '—'],
+                      [
+                        <>
+                          Discovery document (<code>/openapi.json</code>)
+                        </>,
+                        'Yes',
+                        '—',
+                      ],
                       [<>Business logic</>, '—', 'Yes'],
                       [<>User records, billing, quotas</>, '—', 'Yes'],
                       [<>Long-term data storage</>, '—', 'Yes'],
@@ -174,9 +180,9 @@ export default function ArchitecturePage() {
             </p>
             <ul className="list-disc pl-5 space-y-2">
               <li>
-                <strong>Wrong:</strong> the proxy calls{' '}
-                <code>list_jobs()</code> and returns the full response. This
-                leaks every wallet&apos;s jobs to every caller.
+                <strong>Wrong:</strong> the proxy calls <code>list_jobs()</code>{' '}
+                and returns the full response. This leaks every wallet&apos;s
+                jobs to every caller.
               </li>
               <li>
                 <strong>Right:</strong> the proxy looks up which job IDs belong
@@ -198,9 +204,9 @@ export default function ArchitecturePage() {
           <p className="text-sm text-muted-foreground">
             The god-key is intentionally provisioned with loose or absent rate
             limits so that legitimate agent traffic isn&apos;t throttled. The
-            tradeoff is that the proxy is now the only thing standing between
-            an abusive wallet and your production backend. Apply per-wallet
-            rate limits at the proxy by request count, by spend, or both.
+            tradeoff is that the proxy is now the only thing standing between an
+            abusive wallet and your production backend. Apply per-wallet rate
+            limits at the proxy by request count, by spend, or both.
           </p>
         </section>
 
@@ -236,8 +242,8 @@ export default function ArchitecturePage() {
           <div className="space-y-4 text-sm text-muted-foreground">
             <p>
               If you need to track which wallets own which resources, a
-              lightweight database alongside the proxy is usually enough.
-              Common tables:
+              lightweight database alongside the proxy is usually enough. Common
+              tables:
             </p>
             <ul className="list-disc pl-5 space-y-1">
               <li>
@@ -268,8 +274,8 @@ export default function ArchitecturePage() {
               The proxy is also where you serve your discovery document. Publish{' '}
               <code>/openapi.json</code> on the proxy origin with{' '}
               <code>x-payment-info</code> and <code>402</code> responses on each
-              payable operation. Agents discover and call the proxy and never the
-              production API directly.
+              payable operation. Agents discover and call the proxy and never
+              the production API directly.
             </p>
             <p>
               See{' '}

--- a/apps/scan/src/app/(app)/(home)/discovery/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/discovery/page.tsx
@@ -9,8 +9,7 @@ import type { Route } from 'next';
 
 export const metadata: Metadata = {
   title: 'Sell to Agents',
-  description:
-    'Start onboarding agents as customers with x402 payments.',
+  description: 'Start onboarding agents as customers with x402 payments.',
 };
 
 export default function DiscoveryPage() {

--- a/apps/scan/src/app/(app)/(home)/discovery/quickstart/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/discovery/quickstart/page.tsx
@@ -34,8 +34,8 @@ export default function QuickstartPage() {
               <code>WWW-Authenticate</code> header.
             </li>
             <li>
-              Register the origin on x402scan so we can track usage and surface it
-              to agents.
+              Register the origin on x402scan so we can track usage and surface
+              it to agents.
             </li>
           </ol>
         </section>

--- a/apps/scan/src/app/(app)/(home)/integration-spec/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/integration-spec/page.tsx
@@ -209,13 +209,17 @@ export default function DiscoverySpecPage() {
                 <li>
                   Fixed:{' '}
                   <code>
-                    {'{ price: { mode: "fixed", currency: "USD", amount: "<amount>" } }'}
+                    {
+                      '{ price: { mode: "fixed", currency: "USD", amount: "<amount>" } }'
+                    }
                   </code>
                 </li>
                 <li>
                   Dynamic:{' '}
                   <code>
-                    {'{ price: { mode: "dynamic", currency: "USD", min: "<min>", max: "<max>" } }'}
+                    {
+                      '{ price: { mode: "dynamic", currency: "USD", min: "<min>", max: "<max>" } }'
+                    }
                   </code>
                 </li>
               </ul>
@@ -306,8 +310,12 @@ export default function DiscoverySpecPage() {
                   </TableRow>
                   <TableRow>
                     <TableCell>2</TableCell>
-                    <TableCell><code>402</code> API Response</TableCell>
-                    <TableCell>Correct <code>402</code> header response</TableCell>
+                    <TableCell>
+                      <code>402</code> API Response
+                    </TableCell>
+                    <TableCell>
+                      Correct <code>402</code> header response
+                    </TableCell>
                   </TableRow>
                 </TableBody>
               </Table>
@@ -411,11 +419,25 @@ export default function DiscoverySpecPage() {
           <Card>
             <CardContent className="px-0 pb-0">
               {(() => {
-                const rows: { error: string; cause: React.ReactNode; fix: React.ReactNode }[] = [
+                const rows: {
+                  error: string;
+                  cause: React.ReactNode;
+                  fix: React.ReactNode;
+                }[] = [
                   {
                     error: 'Not Found',
-                    cause: <><span>OpenAPI not found at </span><code>{'{origin}'}/openapi.json</code></>,
-                    fix: <><span>Add an OpenAPI document at </span><code>{'{origin}'}/openapi.json</code></>,
+                    cause: (
+                      <>
+                        <span>OpenAPI not found at </span>
+                        <code>{'{origin}'}/openapi.json</code>
+                      </>
+                    ),
+                    fix: (
+                      <>
+                        <span>Add an OpenAPI document at </span>
+                        <code>{'{origin}'}/openapi.json</code>
+                      </>
+                    ),
                   },
                   {
                     error: 'Input/Output Schema Missing',
@@ -496,14 +518,10 @@ export default function DiscoverySpecPage() {
 
         <section className="flex items-center gap-2">
           <Button asChild size="sm">
-            <Link href="/resources/register">
-              + Add your API
-            </Link>
+            <Link href="/resources/register">+ Add your API</Link>
           </Button>
           <Button asChild variant="outline" size="sm">
-            <Link href="/discovery/architecture">
-              Suggested architecture →
-            </Link>
+            <Link href="/discovery/architecture">Suggested architecture →</Link>
           </Button>
         </section>
 

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/discovery-actions.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/discovery-actions.tsx
@@ -11,7 +11,13 @@ import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard';
 const AGENT_PROMPT =
   "Read https://agentcash.dev/merchants.md and follow the guide to make my API discoverable and payable by agents. Do everything automatically. Only ask me if you need input you can't determine yourself.";
 
-export function DiscoveryActions({ iconOnly, label }: { iconOnly?: boolean; label?: string }) {
+export function DiscoveryActions({
+  iconOnly,
+  label,
+}: {
+  iconOnly?: boolean;
+  label?: string;
+}) {
   const { isCopied, copyToClipboard } = useCopyToClipboard(() => {
     toast.success('Copied prompt for agents');
   });

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -349,7 +349,9 @@ export const RegisterResourceForm = () => {
       <div className="space-y-3">
         <div className="space-y-1.5">
           <div className="flex items-center h-12 rounded-md border bg-background focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2">
-            <span className="pl-3 text-base text-muted-foreground select-none">https://</span>
+            <span className="pl-3 text-base text-muted-foreground select-none">
+              https://
+            </span>
             <input
               type="text"
               placeholder="api.example.com"
@@ -411,9 +413,7 @@ export const RegisterResourceForm = () => {
         ) : (
           <Button
             variant="turbo"
-            disabled={
-              manualTargets.length === 0 || isLoading || !isValidUrl
-            }
+            disabled={manualTargets.length === 0 || isLoading || !isValidUrl}
             onClick={() => {
               void handleRegisterManual();
             }}
@@ -433,81 +433,86 @@ export const RegisterResourceForm = () => {
             )}
           </Button>
         )}
-
       </div>
 
       {/* Probe result — inline, no separate card */}
-      {url.trim().length > 0 && (() => {
-        const strippedDomain = url.replace(/^https?:\/\//, '').trim();
-        const hasTld = strippedDomain.includes('.');
-        const showInvalidDomain = strippedDomain.length > 0 && !hasTld;
+      {url.trim().length > 0 &&
+        (() => {
+          const strippedDomain = url.replace(/^https?:\/\//, '').trim();
+          const hasTld = strippedDomain.includes('.');
+          const showInvalidDomain = strippedDomain.length > 0 && !hasTld;
 
-        return (
-        <div className="space-y-4">
-          {showInvalidDomain && (
-              <p className="text-sm text-red-600">
-                Enter a valid domain (e.g. example.com).
-              </p>
-          )}
-
-          {!showInvalidDomain && isValidUrl && isDiscoveryLoading && (
-            <div className="flex items-center gap-2 text-sm text-muted-foreground py-2">
-              <Loader2 className="size-4 animate-spin" />
-              Checking for discoverable endpoints...
-            </div>
-          )}
-
-          {!showInvalidDomain && isValidUrl && !isDiscoveryLoading && hasDiscoveryResources && (
-            <ProbeResult
-              preview={preview}
-              urlOrigin={urlOrigin}
-              resources={actualDiscoveredResources}
-            />
-          )}
-
-          {!showInvalidDomain && isValidUrl &&
-            !isDiscoveryLoading &&
-            !hasDiscoveryResources &&
-            isOriginOnly && (
-              <div className="text-sm space-y-1">
-                <p className="text-red-600">
-                  {discoveryError?.includes('TypeError')
-                    ? "Couldn't reach this URL."
-                    : (discoveryError ??
-                      'No discovery document found at this origin.')}
+          return (
+            <div className="space-y-4">
+              {showInvalidDomain && (
+                <p className="text-sm text-red-600">
+                  Enter a valid domain (e.g. example.com).
                 </p>
-                {!discoveryError?.includes('TypeError') && (
-                  <DiscoveryActions label="Let your agent figure out the issue" />
-                )}
-              </div>
-            )}
+              )}
 
-          {!showInvalidDomain && isValidUrl &&
-            !isDiscoveryLoading &&
-            !hasDiscoveryResources &&
-            !isOriginOnly && (
-              <div className="text-xs text-muted-foreground space-y-1">
-                {isBatchTestLoading ? (
-                  <div className="flex items-center gap-2">
-                    <Loader2 className="size-3 animate-spin" />
-                    Testing endpoint...
+              {!showInvalidDomain && isValidUrl && isDiscoveryLoading && (
+                <div className="flex items-center gap-2 text-sm text-muted-foreground py-2">
+                  <Loader2 className="size-4 animate-spin" />
+                  Checking for discoverable endpoints...
+                </div>
+              )}
+
+              {!showInvalidDomain &&
+                isValidUrl &&
+                !isDiscoveryLoading &&
+                hasDiscoveryResources && (
+                  <ProbeResult
+                    preview={preview}
+                    urlOrigin={urlOrigin}
+                    resources={actualDiscoveredResources}
+                  />
+                )}
+
+              {!showInvalidDomain &&
+                isValidUrl &&
+                !isDiscoveryLoading &&
+                !hasDiscoveryResources &&
+                isOriginOnly && (
+                  <div className="text-sm space-y-1">
+                    <p className="text-red-600">
+                      {discoveryError?.includes('TypeError')
+                        ? "Couldn't reach this URL."
+                        : (discoveryError ??
+                          'No discovery document found at this origin.')}
+                    </p>
+                    {!discoveryError?.includes('TypeError') && (
+                      <DiscoveryActions label="Let your agent figure out the issue" />
+                    )}
                   </div>
-                ) : currentManualTested ? (
-                  <div className="flex items-center gap-2 text-green-700">
-                    <CheckCircle2 className="size-3" />
-                    Valid 402 response.
+                )}
+
+              {!showInvalidDomain &&
+                isValidUrl &&
+                !isDiscoveryLoading &&
+                !hasDiscoveryResources &&
+                !isOriginOnly && (
+                  <div className="text-xs text-muted-foreground space-y-1">
+                    {isBatchTestLoading ? (
+                      <div className="flex items-center gap-2">
+                        <Loader2 className="size-3 animate-spin" />
+                        Testing endpoint...
+                      </div>
+                    ) : currentManualTested ? (
+                      <div className="flex items-center gap-2 text-green-700">
+                        <CheckCircle2 className="size-3" />
+                        Valid 402 response.
+                      </div>
+                    ) : currentManualFailed ? (
+                      <div className="flex items-center gap-2 text-red-700">
+                        <XCircle className="size-3" />
+                        {getPrimaryProbeError(currentManualFailed)}
+                      </div>
+                    ) : null}
                   </div>
-                ) : currentManualFailed ? (
-                  <div className="flex items-center gap-2 text-red-700">
-                    <XCircle className="size-3" />
-                    {getPrimaryProbeError(currentManualFailed)}
-                  </div>
-                ) : null}
-              </div>
-            )}
-        </div>
-        );
-      })()}
+                )}
+            </div>
+          );
+        })()}
 
       {/* Advanced — only when relevant */}
       {showAdvanced && (
@@ -530,10 +535,7 @@ export const RegisterResourceForm = () => {
                   variant="ghost"
                   size="xs"
                   onClick={() =>
-                    setHeaders(current => [
-                      ...current,
-                      { name: '', value: '' },
-                    ])
+                    setHeaders(current => [...current, { name: '', value: '' }])
                   }
                   className="size-fit px-1 text-xs"
                 >
@@ -709,9 +711,7 @@ export const RegisterResourceForm = () => {
       {bulkError && <p className="text-sm text-red-600">{bulkError}</p>}
 
       {registerMutation.error && (
-        <p className="text-sm text-red-600">
-          {registerMutation.error.message}
-        </p>
+        <p className="text-sm text-red-600">{registerMutation.error.message}</p>
       )}
     </div>
   );
@@ -722,7 +722,11 @@ function ProbeResult({
   urlOrigin,
   resources,
 }: {
-  preview: { favicon: string | null; title?: string | null; description?: string | null } | null;
+  preview: {
+    favicon: string | null;
+    title?: string | null;
+    description?: string | null;
+  } | null;
   urlOrigin: string | null;
   resources: string[];
 }) {

--- a/apps/scan/src/app/(app)/(home)/resources/register/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/page.tsx
@@ -17,7 +17,9 @@ export default function RegisterResourcePage() {
     <div>
       <Body className="max-w-2xl">
         <div className="space-y-1">
-          <h1 className="text-2xl md:text-4xl font-bold font-mono">Add your API</h1>
+          <h1 className="text-2xl md:text-4xl font-bold font-mono">
+            Add your API
+          </h1>
           <p className="text-muted-foreground/80 text-sm md:text-base">
             List your API so agents can find and pay for it.
           </p>

--- a/apps/scan/src/app/_components/layout/footer.tsx
+++ b/apps/scan/src/app/_components/layout/footer.tsx
@@ -9,17 +9,50 @@ const MERIT_ICON_SVG = (
     fill="currentColor"
     aria-hidden="true"
   >
-    <polygon opacity="0.7" points="59.23 99.45 59.23 161.55 113.02 192.61 113.02 130.5 59.23 99.45" />
-    <polygon opacity="0.5" points="113.02 68.39 59.23 99.45 113.02 130.5 166.8 99.45 113.02 68.39" />
-    <polygon opacity="0.9" points="166.8 99.45 113.02 130.5 113.02 192.61 166.8 161.55 166.8 99.45" />
+    <polygon
+      opacity="0.7"
+      points="59.23 99.45 59.23 161.55 113.02 192.61 113.02 130.5 59.23 99.45"
+    />
+    <polygon
+      opacity="0.5"
+      points="113.02 68.39 59.23 99.45 113.02 130.5 166.8 99.45 113.02 68.39"
+    />
+    <polygon
+      opacity="0.9"
+      points="166.8 99.45 113.02 130.5 113.02 192.61 166.8 161.55 166.8 99.45"
+    />
     <path d="M113.02,196.41l-57.08-32.95v-65.91l57.08-32.95,57.08,32.95v65.91l-57.08,32.95ZM60.49,160.83l52.53,30.33,52.53-30.33v-60.66l-52.53-30.33-52.53,30.33v60.66Z" />
     <path d="M113.02,261L0,195.75V65.25L113.02,0l113.02,65.25v130.5l-113.02,65.25ZM6.82,191.81l106.2,61.31,106.2-61.31v-122.62L113.02,7.88,6.82,69.19v122.62Z" />
     <rect x="111.88" y="3.94" width="2.27" height="63.28" />
-    <rect x="-.83" y="176.82" width="63.28" height="2.27" transform="translate(-84.84 39.24) rotate(-29.99)" />
-    <rect x="194.08" y="146.32" width="2.27" height="63.28" transform="translate(-56.51 258.05) rotate(-60)" />
+    <rect
+      x="-.83"
+      y="176.82"
+      width="63.28"
+      height="2.27"
+      transform="translate(-84.84 39.24) rotate(-29.99)"
+    />
+    <rect
+      x="194.08"
+      y="146.32"
+      width="2.27"
+      height="63.28"
+      transform="translate(-56.51 258.05) rotate(-60)"
+    />
     <rect x="111.88" y="130.5" width="2.27" height="126.56" />
-    <rect x="104.54" y="97.72" width="126.56" height="2.27" transform="translate(-26.95 97.14) rotate(-29.99)" />
-    <rect x="57.08" y="35.58" width="2.27" height="126.56" transform="translate(-56.51 99.84) rotate(-60)" />
+    <rect
+      x="104.54"
+      y="97.72"
+      width="126.56"
+      height="2.27"
+      transform="translate(-26.95 97.14) rotate(-29.99)"
+    />
+    <rect
+      x="57.08"
+      y="35.58"
+      width="2.27"
+      height="126.56"
+      transform="translate(-56.51 99.84) rotate(-60)"
+    />
   </svg>
 );
 

--- a/apps/scan/src/app/api/x402/_handlers/registry-register-origin.ts
+++ b/apps/scan/src/app/api/x402/_handlers/registry-register-origin.ts
@@ -26,7 +26,8 @@ export async function handleRegistryRegisterOrigin(
 
   const result = await registerResourcesFromDiscovery(
     discoveryResult.resources,
-    discoveryResult.source
+    discoveryResult.source,
+    discoveryResult.info
   );
 
   if (result.registered === 0) {

--- a/apps/scan/src/lib/discovery/register-origin.ts
+++ b/apps/scan/src/lib/discovery/register-origin.ts
@@ -74,10 +74,15 @@ export interface RegisterOriginResult {
  * schema support lands). Endpoints missing an input schema are reported
  * as skipped.
  * Deprecates resources from the same origin that are no longer in the list.
+ *
+ * `originInfo` is the OpenAPI `info` block (title/description/version) when
+ * discovery sourced it from /openapi.json. It backstops origin metadata for
+ * APIs whose homepage isn't HTML, so the scraper has nothing to extract.
  */
 export async function registerResourcesFromDiscovery(
   resources: { url: string; authMode?: AuthMode }[],
-  source: string | undefined
+  source: string | undefined,
+  originInfo?: { title: string; description?: string }
 ): Promise<RegisterOriginResult> {
   const originResourceCounts = new Map(
     await Promise.all(
@@ -133,6 +138,7 @@ export async function registerResourcesFromDiscovery(
 
     const result = await registerResource(resourceUrl, advisory, {
       notifyNewServer: false,
+      originMetadataFallback: originInfo,
     });
 
     if (result.success) return result;

--- a/apps/scan/src/lib/resources.ts
+++ b/apps/scan/src/lib/resources.ts
@@ -31,7 +31,15 @@ import { notifyNewServer } from '@/lib/discord-notifications';
 export const registerResource = async (
   url: string,
   advisory: EndpointMethodAdvisory,
-  options: { notifyNewServer?: boolean } = {}
+  options: {
+    notifyNewServer?: boolean;
+    /**
+     * Title/description to fall back to when the origin's homepage isn't HTML
+     * (so the scraper finds no <title>/meta/OG tags). Typically the OpenAPI
+     * `info` block from discovery.
+     */
+    originMetadataFallback?: { title?: string; description?: string };
+  } = {}
 ) => {
   const x402Options = (advisory.paymentOptions ?? []).filter(
     isX402PaymentOption
@@ -172,8 +180,16 @@ export const registerResource = async (
 
   const { og, metadata, favicon } = await scrapeOriginData(origin);
 
-  const title = metadata?.title ?? og?.ogTitle ?? null;
-  const description = metadata?.description ?? og?.ogDescription ?? null;
+  const title =
+    metadata?.title ??
+    og?.ogTitle ??
+    options.originMetadataFallback?.title ??
+    null;
+  const description =
+    metadata?.description ??
+    og?.ogDescription ??
+    options.originMetadataFallback?.description ??
+    null;
 
   await upsertOrigin({
     origin,

--- a/apps/scan/src/services/discovery/fetch-discovery.ts
+++ b/apps/scan/src/services/discovery/fetch-discovery.ts
@@ -91,6 +91,7 @@ export async function fetchDiscoveryDocument(
     success: true,
     source: mapSourceToDiscoverySource(discovered.source),
     resources,
+    ...(discovered.info ? { info: discovered.info } : {}),
     ownershipProofs: discovered.ownershipProofs ?? [],
   };
 }

--- a/apps/scan/src/trpc/routers/developer.ts
+++ b/apps/scan/src/trpc/routers/developer.ts
@@ -6,6 +6,7 @@ import { getOriginFromUrl } from '@/lib/url';
 import { scrapeOriginData } from '@/services/scraper';
 import type { FailedResource, TestedResource } from '@/types/batch-test';
 import { probeX402Endpoint } from '@/lib/discovery/probe';
+import { fetchDiscoveryDocument } from '@/services/discovery';
 
 async function testSingleResource(url: string, method?: string) {
   try {
@@ -48,15 +49,22 @@ export const developerRouter = createTRPCRouter({
       const cleanUrl = urlObj.toString();
 
       const origin = getOriginFromUrl(cleanUrl);
-      const {
-        og,
-        metadata,
-        origin: scrapedOrigin,
-        favicon,
-      } = await scrapeOriginData(origin);
+      const [scraped, discovery] = await Promise.all([
+        scrapeOriginData(origin),
+        // OpenAPI info backstops origin metadata when the homepage isn't HTML.
+        // Cheap to fetch in parallel — discovery's already cached in many flows.
+        fetchDiscoveryDocument(origin).catch(() => null),
+      ]);
+      const { og, metadata, origin: scrapedOrigin, favicon } = scraped;
+      const openApiInfo = discovery?.success ? discovery.info : undefined;
 
-      const title = metadata?.title ?? og?.ogTitle ?? null;
-      const description = metadata?.description ?? og?.ogDescription ?? null;
+      const title =
+        metadata?.title ?? og?.ogTitle ?? openApiInfo?.title ?? null;
+      const description =
+        metadata?.description ??
+        og?.ogDescription ??
+        openApiInfo?.description ??
+        null;
       const ogImages = (og?.ogImage ?? []).map(image => ({
         url: image.url,
         height: image.height,

--- a/apps/scan/src/trpc/routers/public/resources.ts
+++ b/apps/scan/src/trpc/routers/public/resources.ts
@@ -241,7 +241,8 @@ export const resourcesRouter = createTRPCRouter({
 
       const result = await registerResourcesFromDiscovery(
         discoveryResult.resources,
-        discoveryResult.source
+        discoveryResult.source,
+        discoveryResult.info
       );
 
       if (result.registered === 0) {

--- a/apps/scan/src/types/discovery.ts
+++ b/apps/scan/src/types/discovery.ts
@@ -43,6 +43,12 @@ export interface X402DiscoveryResult {
   source?: DiscoverySource;
   /** Resources with URLs and optional methods */
   resources: DiscoveredResource[];
+  /**
+   * OpenAPI info.title / info.description / info.version when discovery used
+   * the origin's OpenAPI document. Falls back source for origin metadata when
+   * the origin's homepage isn't HTML (e.g. APIs that serve JSON at /).
+   */
+  info?: { title: string; description?: string; version?: string };
   /** Optional instructions for AI agents consuming this API */
   instructions?: string;
   /**


### PR DESCRIPTION
## Use OpenAPI `info` as a fallback for origin title/description

### Problem

Origins whose homepage doesn't return HTML (e.g. `scout.hugen.tokyo`, which serves `{"status":"ok","service":"scout-mcp"}` at `/`) end up with `null` title and description on their server page. The HTML scraper has nothing to extract — no `<title>`, no meta tags, no OG tags — even though the same origin has a perfectly good `info.title` and `info.description` in its `/openapi.json`.

### Root cause

`@agentcash/discovery` already extracts `info.title` / `info.description` from OpenAPI (and from `.well-known/x402`) and exposes them on `discoverOriginSchema`'s result as a top-level `info` field. x402scan's `fetchDiscoveryDocument` was dropping that field, and `registerResource` only ever consulted `scrapeOriginData`. So the data was sitting one layer away — we just weren't reading it.

### Fix

Thread `discovered.info` through as a last-resort fallback after the HTML scraper:

- `services/discovery/fetch-discovery.ts` — forward `discovered.info` on the result
- `types/discovery.ts` — add `info?: { title; description?; version? }` to `X402DiscoveryResult`
- `lib/discovery/register-origin.ts` — `registerResourcesFromDiscovery` accepts `originInfo` and passes it to each `registerResource` call
- `lib/resources.ts` — `registerResource` accepts `originMetadataFallback` and uses it in the title/description resolution chain
- `trpc/routers/public/resources.ts` & `app/api/x402/_handlers/registry-register-origin.ts` — forward `discoveryResult.info`
- `trpc/routers/developer.ts` — `developer.preview` also falls back to OpenAPI info so the ProbeResult card on `/resources/register` shows title/description before registration

The HTML scraper still runs first and wins when it has data (it also produces favicon and OG images, which `info` doesn't have). OpenAPI info is only used when the scraper comes up empty.

### Effect on existing rows

Origins previously registered with `null` title/description (like scout.hugen.tokyo) will be updated on the next registration — `upsertOrigin`'s update clause sets the new string values when they're truthy.

### Test plan

- [x] Re-register `scout.hugen.tokyo` from `/resources/register`; confirm the server page shows the Scout title and description
- [x] Confirm origins with proper HTML metadata (most existing servers) still show their scraped values, not OpenAPI info
- [x] Confirm the ProbeResult card on `/resources/register` shows a title/description when entering a JSON-only origin