### PR TITLE
Fix sync endpoint chain ID normalization

### DIFF
--- a/apps/scan/src/app/api/resources/sync/route.ts
+++ b/apps/scan/src/app/api/resources/sync/route.ts
@@ -6,6 +6,7 @@ import { upsertResource } from '@/services/db/resources/resource';
 
 import { checkCronSecret } from '@/lib/cron';
 import { getOriginFromUrl } from '@/lib/url';
+import { normalizeChainId } from '@/lib/x402';
 
 import type { AcceptsNetwork } from '@x402scan/scan-db/types';
 import type z from 'zod';
@@ -143,7 +144,7 @@ export const GET = async (request: NextRequest) => {
             ...facilitatorResource,
             accepts: facilitatorResource.accepts.map(accept => ({
               ...accept,
-              network: accept.network.replace('-', '_') as AcceptsNetwork,
+              network: normalizeChainId(accept.network) as AcceptsNetwork,
             })) as z.input<typeof upsertResourceSchema>['accepts'],
           });
           return { resource: facilitatorResource.resource, success: true };

--- a/apps/scan/src/lib/resources.ts
+++ b/apps/scan/src/lib/resources.ts
@@ -124,7 +124,7 @@ export const registerResource = async (
 
   const allMappedAccepts = x402Options.map(opt => ({
     scheme: opt.scheme ?? 'exact',
-    network: normalizeChainId(opt.network).replace('-', '_') as AcceptsNetwork,
+    network: normalizeChainId(opt.network) as AcceptsNetwork,
     maxAmountRequired:
       ('amount' in opt ? opt.amount : opt.maxAmountRequired) ?? '0',
     payTo: opt.payTo ?? '',

--- a/apps/scan/src/lib/x402/index.ts
+++ b/apps/scan/src/lib/x402/index.ts
@@ -303,20 +303,21 @@ export async function extractX402Data(response: Response): Promise<unknown> {
 }
 
 export function normalizeChainId(chainId: string): string {
+  let result = chainId;
   if (chainId.startsWith('eip155:')) {
     const id = Number(chainId.split(':')[1]);
-    const network = ChainIdToNetwork[id];
-    return network ?? chainId;
-  }
-  if (chainId.startsWith('solana:')) {
+    result = ChainIdToNetwork[id] ?? chainId;
+  } else if (chainId.startsWith('solana:')) {
     const suffix = chainId.split(':')[1];
-    if (suffix === 'mainnet') return 'solana';
-    if (suffix === 'devnet') return 'solana_devnet';
-    if (suffix === 'testnet') return 'solana_testnet';
-    if (suffix === '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp') return 'solana';
-    if (suffix === 'EtWTRABZaYq6iMfeYKouRu166VU2xqa1') return 'solana_devnet';
-    if (suffix === '4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z') return 'solana_testnet';
-    return `solana_${suffix}`;
+    if (suffix === 'mainnet') result = 'solana';
+    else if (suffix === 'devnet') result = 'solana_devnet';
+    else if (suffix === 'testnet') result = 'solana_testnet';
+    else if (suffix === '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp') result = 'solana';
+    else if (suffix === 'EtWTRABZaYq6iMfeYKouRu166VU2xqa1')
+      result = 'solana_devnet';
+    else if (suffix === '4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z')
+      result = 'solana_testnet';
+    else result = `solana_${suffix}`;
   }
-  return chainId;
+  return result.replaceAll('-', '_');
 }


### PR DESCRIPTION
## Summary
- The sync endpoint used a naive `.replace('-', '_')` for network normalization, which silently failed for CAIP-2 chain IDs like `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` (no hyphens to replace)
- Moved the hyphen-to-underscore conversion into `normalizeChainId()` itself (using `replaceAll`) so all return paths are covered and callers don't need to chain an extra `.replace()`
- Removed the now-redundant `.replace('-', '_')` from both call sites (`sync/route.ts` and `lib/resources.ts`)

## Test plan
- [ ] Verify Solana mainnet resources sync correctly (network resolves to `solana`, not `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`)
- [ ] Verify EVM testnet resources sync correctly (e.g. `base-sepolia` → `base_sepolia`)
- [ ] Verify manual registration path still works (lib/resources.ts)