### PR TITLE
Add resource pricing to origin pages

### DIFF
--- a/apps/scan/src/app/(app)/_components/resources/origin-resources.tsx
+++ b/apps/scan/src/app/(app)/_components/resources/origin-resources.tsx
@@ -11,6 +11,7 @@ import {
 import { ResourceCard, LoadingResourceCard } from './resource-card';
 
 import { getBazaarMethod } from './utils';
+import { serializeAccepts } from '@/lib/token';
 
 import type { RouterOutputs } from '@/trpc/client';
 
@@ -64,6 +65,7 @@ export const OriginResources: React.FC<Props> = ({
               response={resource.data}
               hideOrigin={hideOrigin}
               isFlat={isFlat}
+              accepts={serializeAccepts(resource.accepts)}
             />
           );
         })}

--- a/apps/scan/src/app/(app)/_components/resources/resource-card.tsx
+++ b/apps/scan/src/app/(app)/_components/resources/resource-card.tsx
@@ -13,13 +13,21 @@ import {
 
 import { Header } from './header/index';
 
-import { cn } from '@/lib/utils';
+import { cn, formatCurrency } from '@/lib/utils';
 import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard';
 import { toast } from 'sonner';
 
+import { Chains, Chain as ChainIcon } from '@/app/(app)/_components/chains';
+
 import type { Methods } from '@/types/x402';
+import type { Chain } from '@/types/chain';
 import type { ParsedX402Response } from '@/lib/x402';
 import type { Resources, Tag } from '@x402scan/scan-db';
+
+interface SerializedAccept {
+  maxAmountRequired: number;
+  network: string;
+}
 
 interface Props {
   resource: Resources;
@@ -31,6 +39,7 @@ interface Props {
   isFlat?: boolean;
   warnings?: string[];
   ownershipVerified?: boolean;
+  accepts?: SerializedAccept[];
 }
 
 export const ResourceCard: React.FC<Props> = ({
@@ -43,6 +52,7 @@ export const ResourceCard: React.FC<Props> = ({
   isFlat = false,
   warnings = [],
   ownershipVerified = false,
+  accepts,
 }) => {
   const prompt = `Use agentcash.dev to test out this resource's endpoint: ${bazaarMethod} ${resource.resource}`;
   const { isCopied, copyToClipboard } = useCopyToClipboard(() => {
@@ -64,6 +74,9 @@ export const ResourceCard: React.FC<Props> = ({
             hideOrigin={hideOrigin}
           />
           <div className="flex items-center gap-2">
+            {accepts && accepts.length > 0 && (
+              <ResourcePricing accepts={accepts} />
+            )}
             {ownershipVerified && (
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -112,6 +125,45 @@ export const ResourceCard: React.FC<Props> = ({
           </div>
         </CardHeader>
       </Card>
+    </div>
+  );
+};
+
+const ResourcePricing: React.FC<{ accepts: SerializedAccept[] }> = ({
+  accepts,
+}) => {
+  const allSameAmount = accepts.every(
+    accept => accept.maxAmountRequired === accepts[0]!.maxAmountRequired
+  );
+
+  if (allSameAmount) {
+    return (
+      <div className="flex items-center gap-1 shrink-0">
+        <span className="text-xs font-semibold text-primary font-mono">
+          {formatCurrency(accepts[0]!.maxAmountRequired)}
+        </span>
+        <Chains
+          chains={accepts.map(accept => accept.network as Chain).sort()}
+          iconClassName="size-3"
+          className="gap-0.5"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2 shrink-0">
+      {accepts.map(accept => (
+        <div
+          key={accept.network}
+          className="flex items-center gap-0.5 shrink-0"
+        >
+          <span className="text-xs font-semibold text-primary font-mono">
+            {formatCurrency(accept.maxAmountRequired)}
+          </span>
+          <ChainIcon chain={accept.network as Chain} iconClassName="size-3" />
+        </div>
+      ))}
     </div>
   );
 };

--- a/apps/scan/src/app/(app)/_components/resources/resource-card.tsx
+++ b/apps/scan/src/app/(app)/_components/resources/resource-card.tsx
@@ -17,10 +17,7 @@ import { cn, formatCurrency } from '@/lib/utils';
 import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard';
 import { toast } from 'sonner';
 
-import { Chains, Chain as ChainIcon } from '@/app/(app)/_components/chains';
-
 import type { Methods } from '@/types/x402';
-import type { Chain } from '@/types/chain';
 import type { ParsedX402Response } from '@/lib/x402';
 import type { Resources, Tag } from '@x402scan/scan-db';
 
@@ -132,39 +129,11 @@ export const ResourceCard: React.FC<Props> = ({
 const ResourcePricing: React.FC<{ accepts: SerializedAccept[] }> = ({
   accepts,
 }) => {
-  const allSameAmount = accepts.every(
-    accept => accept.maxAmountRequired === accepts[0]!.maxAmountRequired
-  );
-
-  if (allSameAmount) {
-    return (
-      <div className="flex items-center gap-1 shrink-0">
-        <span className="text-xs font-semibold text-primary font-mono">
-          {formatCurrency(accepts[0]!.maxAmountRequired)}
-        </span>
-        <Chains
-          chains={accepts.map(accept => accept.network as Chain).sort()}
-          iconClassName="size-3"
-          className="gap-0.5"
-        />
-      </div>
-    );
-  }
-
+  const minAmount = Math.min(...accepts.map(a => a.maxAmountRequired));
   return (
-    <div className="flex items-center gap-2 shrink-0">
-      {accepts.map(accept => (
-        <div
-          key={accept.network}
-          className="flex items-center gap-0.5 shrink-0"
-        >
-          <span className="text-xs font-semibold text-primary font-mono">
-            {formatCurrency(accept.maxAmountRequired)}
-          </span>
-          <ChainIcon chain={accept.network as Chain} iconClassName="size-3" />
-        </div>
-      ))}
-    </div>
+    <span className="text-xs font-semibold text-primary font-mono shrink-0">
+      {formatCurrency(minAmount)}
+    </span>
   );
 };
 


### PR DESCRIPTION
## Summary
- Display per-resource pricing with chain icons on origin detail pages (`/server/[id]`)
- Pricing appears on the right side of each resource card, just left of the copy button
- Uses existing `serializeAccepts` utility to convert BigInt amounts and `formatCurrency` for display
- Follows the same pattern as the composer resource list's `ToolAccepts` component
