### PR TITLE
Include HTTP status codes in error prompts

### DIFF
--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -726,7 +726,11 @@ export const RegisterResourceForm = () => {
                 </>
               )}
               <DiscoveryFixHint
-                failedResources={failedResources}
+                failedResources={failedResources.map(r => ({
+                  url: r.url,
+                  error: getPrimaryProbeError(r),
+                  status: r.statusCode,
+                }))}
                 missingSchemaResources={missingSchemaUrls}
               />
             </CollapsibleContent>

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-actions.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-actions.tsx
@@ -12,10 +12,13 @@ const GENERIC_PROMPT =
   "Read https://agentcash.dev/merchants.md and follow the guide to make my API discoverable and payable by agents. Do everything automatically. Only ask me if you need input you can't determine yourself.";
 
 function buildErrorPrompt(
-  resources: { url: string; error: string }[],
+  resources: { url: string; error: string; status?: number }[],
   missingSchemaUrls?: string[]
 ): string {
-  const lines = resources.map(r => `- ${r.url}: ${r.error}`);
+  const lines = resources.map(r => {
+    const status = r.status ? ` (HTTP ${r.status})` : '';
+    return `- ${r.url}: ${r.error}${status}`;
+  });
 
   let schemaSection = '';
   if (missingSchemaUrls && missingSchemaUrls.length > 0) {
@@ -45,9 +48,12 @@ Fix each issue. Only ask me if you need input you can't determine yourself.`;
 }
 
 function buildWarningPrompt(
-  resources: { url: string; error: string }[]
+  resources: { url: string; error: string; status?: number }[]
 ): string {
-  const lines = resources.map(r => `- ${r.url}: ${r.error}`);
+  const lines = resources.map(r => {
+    const status = r.status ? ` (HTTP ${r.status})` : '';
+    return `- ${r.url}: ${r.error}${status}`;
+  });
   return `These endpoints were found in my API spec but triggered warnings during registration on x402scan.com:
 
 ${lines.join('\n')}
@@ -106,8 +112,8 @@ export function DiscoveryActions({
 }: {
   iconOnly?: boolean;
   label?: string;
-  failedResources?: { url: string; error: string }[];
-  warnings?: { url: string; error: string }[];
+  failedResources?: { url: string; error: string; status?: number }[];
+  warnings?: { url: string; error: string; status?: number }[];
   v1Migration?: boolean;
   noDiscovery?: boolean;
   missingSchema?: boolean;

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
@@ -71,8 +71,8 @@ export function DiscoveryFixHint({
   missingSchemaResources,
 }: {
   className?: string;
-  failedResources?: { url: string; error: string }[];
-  warnings?: { url: string; error: string }[];
+  failedResources?: { url: string; error: string; status?: number }[];
+  warnings?: { url: string; error: string; status?: number }[];
   v1Migration?: boolean;
   noDiscovery?: boolean;
   missingSchema?: boolean;
@@ -912,7 +912,13 @@ function FailedResourceCard({
               <DiscoveryFixHint v1Migration />
             ) : (
               <DiscoveryFixHint
-                failedResources={[{ url: resourceUrl, error: errorMessage }]}
+                failedResources={[
+                  {
+                    url: resourceUrl,
+                    error: errorMessage,
+                    status: failedDetails?.statusCode,
+                  },
+                ]}
               />
             )}
 


### PR DESCRIPTION
## Summary

- Thread HTTP status codes (e.g. 500, 404, 200) into the copy-pasteable agent prompts for failed and warned endpoints
- Status codes were already captured during probing and shown in the UI, but excluded from the prompt text — coding agents couldn't see them
- Prompt lines now read: `- https://example.com/api/foo: Endpoint did not return a 402 payment challenge (HTTP 500)`
