### PR TITLE
Disable Add API button when no endpoints pass x402 validation

### DIFF
--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -386,7 +386,9 @@ export const RegisterResourceForm = () => {
             <Button
               variant="turbo"
               disabled={
-                isLoading || isBatchTestLoading || testedResources.length === 0
+                isLoading ||
+                isBatchTestLoading ||
+                (failedResources.length > 0 && testedResources.length === 0)
               }
               onClick={handleRegisterDiscovered}
               className="flex-1"
@@ -728,7 +730,9 @@ export const RegisterResourceForm = () => {
                 </>
               )}
               <DiscoveryFixHint
-                needsSetup={testedResources.length === 0}
+                needsSetup={
+                  failedResources.length > 0 && testedResources.length === 0
+                }
                 failedResources={failedResources.map(r => ({
                   url: r.url,
                   error: getPrimaryProbeError(r),

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -385,7 +385,9 @@ export const RegisterResourceForm = () => {
           <div className="flex gap-2">
             <Button
               variant="turbo"
-              disabled={isLoading || isBatchTestLoading}
+              disabled={
+                isLoading || isBatchTestLoading || testedResources.length === 0
+              }
               onClick={handleRegisterDiscovered}
               className="flex-1"
             >
@@ -400,7 +402,7 @@ export const RegisterResourceForm = () => {
                   Verifying endpoints...
                 </>
               ) : (
-                `Add API (${actualDiscoveredResources.length} resources)`
+                `Add API (${testedResources.length} resources)`
               )}
             </Button>
             {canUseManualMode && (

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -728,6 +728,7 @@ export const RegisterResourceForm = () => {
                 </>
               )}
               <DiscoveryFixHint
+                needsSetup={testedResources.length === 0}
                 failedResources={failedResources.map(r => ({
                   url: r.url,
                   error: getPrimaryProbeError(r),

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
@@ -95,12 +95,16 @@ export function DiscoveryFixHint({
     <p className={cn('text-xs text-muted-foreground', className)}>
       <DiscoveryActions
         label={label}
-        failedResources={needsSetup ? undefined : failedResources}
-        warnings={needsSetup ? undefined : warnings}
+        {...(needsSetup
+          ? {}
+          : {
+              failedResources,
+              warnings,
+              missingSchema,
+              missingSchemaResources,
+            })}
         v1Migration={v1Migration}
         noDiscovery={noDiscovery}
-        missingSchema={needsSetup ? undefined : missingSchema}
-        missingSchemaResources={needsSetup ? undefined : missingSchemaResources}
       />{' '}
       or{' '}
       <Link

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
@@ -67,6 +67,7 @@ export function DiscoveryFixHint({
   warnings,
   v1Migration,
   noDiscovery,
+  needsSetup,
   missingSchema,
   missingSchemaResources,
 }: {
@@ -75,27 +76,31 @@ export function DiscoveryFixHint({
   warnings?: { url: string; error: string; status?: number }[];
   v1Migration?: boolean;
   noDiscovery?: boolean;
+  /** All endpoints failed — treat as needing x402 setup from scratch. */
+  needsSetup?: boolean;
   missingSchema?: boolean;
   missingSchemaResources?: string[];
 }) {
   const label = noDiscovery
     ? 'Have your agent create an OpenAPI spec for your resource'
-    : v1Migration
-      ? 'Migrate to x402 v2 spec in one prompt'
-      : missingSchema
-        ? 'Add input schemas with a prompt'
-        : 'Have your agent fix the errors with a prompt';
+    : needsSetup
+      ? 'Set up x402 with a prompt'
+      : v1Migration
+        ? 'Migrate to x402 v2 spec in one prompt'
+        : missingSchema
+          ? 'Add input schemas with a prompt'
+          : 'Have your agent fix the errors with a prompt';
 
   return (
     <p className={cn('text-xs text-muted-foreground', className)}>
       <DiscoveryActions
         label={label}
-        failedResources={failedResources}
-        warnings={warnings}
+        failedResources={needsSetup ? undefined : failedResources}
+        warnings={needsSetup ? undefined : warnings}
         v1Migration={v1Migration}
         noDiscovery={noDiscovery}
-        missingSchema={missingSchema}
-        missingSchemaResources={missingSchemaResources}
+        missingSchema={needsSetup ? undefined : missingSchema}
+        missingSchemaResources={needsSetup ? undefined : missingSchemaResources}
       />{' '}
       or{' '}
       <Link


### PR DESCRIPTION
## Summary
- Disable the "Add API" button when zero endpoints pass x402 validation (previously it was always clickable after batch test completed)
- Show only the count of valid/registerable endpoints in the button label instead of total discovered endpoints
