### PR TITLE
SEO

### DIFF
--- a/apps/scan/src/app/(app)/(home)/(discover)/_components/heading.tsx
+++ b/apps/scan/src/app/(app)/(home)/(discover)/_components/heading.tsx
@@ -28,7 +28,8 @@ export const DiscoverHeading = () => {
           </Link>
         </div>
         <p className="text-muted-foreground text-sm">
-          The x402 analytics dashboard and block explorer
+          The x402 block explorer, analytics dashboard and marketplace for paid
+          APIs and agentic commerce
         </p>
       </div>
       <div className="flex flex-col md:flex-row items-center gap-2">

--- a/apps/scan/src/app/(app)/(home)/(discover)/layout.tsx
+++ b/apps/scan/src/app/(app)/(home)/(discover)/layout.tsx
@@ -1,5 +1,13 @@
 import { DiscoverSearchProvider } from './_components/discover-search-context';
 
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: '/',
+  },
+};
+
 export default function DiscoverLayout({
   children,
 }: {

--- a/apps/scan/src/app/(app)/(home)/_components/json-ld.tsx
+++ b/apps/scan/src/app/(app)/(home)/_components/json-ld.tsx
@@ -1,0 +1,14 @@
+interface JsonLdProps {
+  data: Record<string, unknown> | Record<string, unknown>[];
+}
+
+export function JsonLd({ data }: JsonLdProps) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(data).replace(/</g, '\\u003c'),
+      }}
+    />
+  );
+}

--- a/apps/scan/src/app/(app)/(home)/agentic-commerce/_components/content.tsx
+++ b/apps/scan/src/app/(app)/(home)/agentic-commerce/_components/content.tsx
@@ -1,0 +1,177 @@
+import Link from 'next/link';
+
+import { Body, Heading, Section } from '@/app/_components/layout/page-utils';
+import { JsonLd } from '../../_components/json-ld';
+import { Button } from '@/components/ui/button';
+import { env } from '@/env';
+
+const description =
+  'Learn how AI agents discover, pay for, and use APIs through x402 payments, discovery specs, and x402scan listings.';
+
+const appUrl = env.NEXT_PUBLIC_APP_URL.replace(/\/$/, '');
+
+const faqs = [
+  {
+    question: 'What is agentic commerce?',
+    answer:
+      'Agentic commerce is the market where AI agents discover, pay for, and use digital services directly on behalf of users or businesses.',
+  },
+  {
+    question: 'How do agents pay for APIs?',
+    answer:
+      'Agents can use open payment standards such as x402 to receive a 402 Payment Required challenge, pay per request, and retry the API call automatically.',
+  },
+  {
+    question: 'What role does x402scan play?',
+    answer:
+      'x402scan is the marketplace, explorer, and analytics layer where x402 services can be listed, discovered, and measured.',
+  },
+  {
+    question: 'What role does AgentCash play?',
+    answer:
+      'AgentCash is an MCP that helps agents discover premium APIs, pay with stablecoin micropayments, and execute requests.',
+  },
+];
+
+const jsonLd = [
+  {
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    name: 'Agentic Commerce',
+    url: `${appUrl}/agentic-commerce`,
+    description,
+    isPartOf: {
+      '@type': 'WebSite',
+      name: 'x402scan',
+      url: appUrl,
+    },
+  },
+  {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: 'Home',
+        item: `${appUrl}/`,
+      },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: 'Agentic Commerce',
+        item: `${appUrl}/agentic-commerce`,
+      },
+    ],
+  },
+  {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: faqs.map(faq => ({
+      '@type': 'Question',
+      name: faq.question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: faq.answer,
+      },
+    })),
+  },
+];
+
+export function AgenticCommerceContent() {
+  return (
+    <>
+      <JsonLd data={jsonLd} />
+      <Heading
+        title="Agentic Commerce"
+        description="AI agents discover, pay for, and use digital services directly."
+        actions={
+          <div className="flex flex-col sm:flex-row gap-2">
+            <Button asChild size="sm">
+              <Link href="/resources/register">Register API</Link>
+            </Button>
+            <Button asChild size="sm" variant="outline">
+              <Link href="/resources">Browse services</Link>
+            </Button>
+          </div>
+        }
+      />
+      <Body className="gap-8">
+        <Section title="What is agentic commerce?">
+          <div className="max-w-3xl space-y-3 text-sm leading-6 text-muted-foreground">
+            <p>
+              Agentic commerce happens when AI agents discover, pay for, and use
+              digital services directly. In this model, the commercial unit is
+              often an API request rather than a pageview, subscription, or
+              human checkout session.
+            </p>
+            <p>
+              This matters because more internet activity is moving through
+              agent interfaces. When agents do the work, providers need ways to
+              charge directly for data, content, tools, and services that can be
+              called programmatically.
+            </p>
+          </div>
+        </Section>
+
+        <Section
+          title="How providers sell to agents"
+          description="The provider path is simple: make the API payable, make it discoverable, and let agents call it."
+        >
+          <ol className="max-w-3xl space-y-3 text-sm leading-6 text-muted-foreground">
+            <li>
+              <span className="font-medium text-foreground">1. Add pay-per-call:</span>{' '}
+              enable per-request pricing so agents can pay without
+              subscriptions or invoices.
+            </li>
+            <li>
+              <span className="font-medium text-foreground">2. Publish discovery:</span>{' '}
+              describe what the API does, what it costs, and how an agent should
+              call it.
+            </li>
+            <li>
+              <span className="font-medium text-foreground">3. Reach agents:</span>{' '}
+              let agents inspect schemas and pricing, pay, and execute the
+              request.
+            </li>
+          </ol>
+        </Section>
+
+        <Section
+          title="The x402scan role"
+          description="x402scan is the public marketplace and analytics layer for x402 services."
+        >
+          <div className="max-w-3xl space-y-3 text-sm leading-6 text-muted-foreground">
+            <p>
+              x402 is the payment standard, AgentCash is the MCP for
+              discovering and paying for premium APIs, and x402scan is where
+              those services become visible.
+            </p>
+            <p>
+              The goal is not a new checkout page. The goal is a market where
+              software can understand the service, pay the listed price, and get
+              the result.
+            </p>
+          </div>
+        </Section>
+
+        <Section
+          title="Enter the agent market"
+          description="Register your API on x402scan and publish discovery metadata so agents can understand and call it."
+        >
+          <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm">
+            <Link className="font-medium underline-offset-4 hover:underline" href="/discovery">
+              Sell to agents
+            </Link>
+            <Link className="font-medium underline-offset-4 hover:underline" href="/resources/register">
+              Register API
+            </Link>
+            <Link className="font-medium underline-offset-4 hover:underline" href="/x402">
+              Explore x402
+            </Link>
+          </div>
+        </Section>
+      </Body>
+    </>
+  );
+}

--- a/apps/scan/src/app/(app)/(home)/agentic-commerce/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/agentic-commerce/page.tsx
@@ -1,0 +1,18 @@
+import { AgenticCommerceContent } from './_components/content';
+
+import type { Metadata } from 'next';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Agentic Commerce APIs and Payments',
+  description:
+    'Learn how AI agents discover, pay for, and use APIs through x402 payments, discovery specs, and x402scan listings.',
+  alternates: {
+    canonical: '/agentic-commerce',
+  },
+};
+
+export default function AgenticCommercePage() {
+  return <AgenticCommerceContent />;
+}

--- a/apps/scan/src/app/(app)/(home)/x402/_components/content.tsx
+++ b/apps/scan/src/app/(app)/(home)/x402/_components/content.tsx
@@ -1,0 +1,194 @@
+import Link from 'next/link';
+
+import { Body, Heading, Section } from '@/app/_components/layout/page-utils';
+import { JsonLd } from '../../_components/json-ld';
+import { Button } from '@/components/ui/button';
+import { env } from '@/env';
+
+const description =
+  'Explore x402 payments, transactions, servers, facilitators, and paid APIs across the x402 ecosystem.';
+
+const appUrl = env.NEXT_PUBLIC_APP_URL.replace(/\/$/, '');
+
+const faqs = [
+  {
+    question: 'What is x402?',
+    answer:
+      'x402 is an open, neutral, HTTP-native payments standard that lets clients and servers complete payments through the existing 402 Payment Required flow.',
+  },
+  {
+    question: 'How does x402 work?',
+    answer:
+      'A client requests a paid resource, the server responds with 402 Payment Required, the client pays, retries the request, and receives API access.',
+  },
+  {
+    question: 'What is x402scan?',
+    answer:
+      'x402scan is an explorer, marketplace, and analytics dashboard for x402 servers, resources, facilitators, transactions, buyers, and sellers.',
+  },
+  {
+    question: 'Do x402 APIs need subscriptions or API keys?',
+    answer:
+      'x402 APIs can support pay-per-request access without manual account setup, prepaid subscriptions, or long-lived API keys.',
+  },
+];
+
+const jsonLd = [
+  {
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    name: 'x402 Explorer',
+    url: `${appUrl}/x402`,
+    description,
+    isPartOf: {
+      '@type': 'WebSite',
+      name: 'x402scan',
+      url: appUrl,
+    },
+  },
+  {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: 'Home',
+        item: `${appUrl}/`,
+      },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: 'x402',
+        item: `${appUrl}/x402`,
+      },
+    ],
+  },
+  {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: faqs.map(faq => ({
+      '@type': 'Question',
+      name: faq.question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: faq.answer,
+      },
+    })),
+  },
+  {
+    '@context': 'https://schema.org',
+    '@type': 'SoftwareApplication',
+    name: 'x402scan',
+    applicationCategory: 'DeveloperApplication',
+    operatingSystem: 'Web',
+    url: appUrl,
+    description:
+      'Explorer, marketplace, and analytics dashboard for x402 payments and paid APIs.',
+  },
+];
+
+export function X402Content() {
+  return (
+    <>
+      <JsonLd data={jsonLd} />
+      <Heading
+        title="x402"
+        description="An HTTP-native payment standard for paid APIs and agentic commerce."
+        actions={
+          <div className="flex flex-col sm:flex-row gap-2">
+            <Button asChild size="sm">
+              <Link href="/resources">Explore marketplace</Link>
+            </Button>
+            <Button asChild size="sm" variant="outline">
+              <Link href="/transactions">View transactions</Link>
+            </Button>
+          </div>
+        }
+      />
+      <Body className="gap-8">
+        <Section title="What is x402?">
+          <div className="max-w-3xl space-y-3 text-sm leading-6 text-muted-foreground">
+            <p>
+              x402 is an open, neutral standard for internet-native payments
+              between clients and servers. Instead of forcing a user or agent
+              through account creation, checkout, and prepaid credits, a server
+              can answer a paid request with <code>402 Payment Required</code>.
+            </p>
+            <p>
+              The client reads the payment requirements, pays, retries the
+              request, and receives access to the API or resource. That flow
+              makes paid APIs usable by software, not just by humans filling out
+              web forms.
+            </p>
+          </div>
+        </Section>
+
+        <Section title="How x402 works">
+          <ol className="max-w-3xl space-y-3 text-sm leading-6 text-muted-foreground">
+            <li>
+              <span className="font-medium text-foreground">1. Request:</span>{' '}
+              a client or AI agent sends a normal HTTP request to a paid
+              resource.
+            </li>
+            <li>
+              <span className="font-medium text-foreground">2. Pay:</span> the
+              server responds with <code>402 Payment Required</code> and the
+              client submits payment.
+            </li>
+            <li>
+              <span className="font-medium text-foreground">3. Retry:</span>{' '}
+              the client retries with payment proof and receives the API result.
+            </li>
+          </ol>
+        </Section>
+
+        <Section
+          title="Why x402 matters"
+          description="x402 replaces manual API onboarding with request-time access."
+        >
+          <p className="max-w-3xl text-sm leading-6 text-muted-foreground">
+            Paid APIs usually require accounts, checkout, prepaid credits, and
+            API keys before software can do anything useful. x402 lets services
+            price individual requests, so agents and developers can pay only
+            when they need access.
+          </p>
+        </Section>
+
+        <Section
+          title="Explore x402 on x402scan"
+          description="x402scan indexes the services, payments, and infrastructure behind the x402 ecosystem."
+        >
+          <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm">
+            <Link className="font-medium underline-offset-4 hover:underline" href="/resources">
+              Marketplace
+            </Link>
+            <Link className="font-medium underline-offset-4 hover:underline" href="/transactions">
+              Transactions
+            </Link>
+            <Link className="font-medium underline-offset-4 hover:underline" href="/facilitators">
+              Facilitators
+            </Link>
+            <Link className="font-medium underline-offset-4 hover:underline" href="/networks">
+              Networks
+            </Link>
+          </div>
+        </Section>
+
+        <Section
+          title="Build with x402"
+          description="Register an x402-compatible API so agents and developers can discover what it does, what it costs, and how to call it."
+        >
+          <div className="flex flex-col sm:flex-row gap-2">
+            <Button asChild>
+              <Link href="/resources/register">Add your API</Link>
+            </Button>
+            <Button asChild variant="outline">
+              <Link href="/discovery">Become discoverable</Link>
+            </Button>
+          </div>
+        </Section>
+      </Body>
+    </>
+  );
+}

--- a/apps/scan/src/app/(app)/(home)/x402/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/x402/page.tsx
@@ -1,0 +1,18 @@
+import { X402Content } from './_components/content';
+
+import type { Metadata } from 'next';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'x402 Explorer, Transactions, Servers, and Marketplace',
+  description:
+    'Explore x402 payments, transactions, servers, facilitators, and paid APIs across the x402 ecosystem.',
+  alternates: {
+    canonical: '/x402',
+  },
+};
+
+export default function X402Page() {
+  return <X402Content />;
+}

--- a/apps/scan/src/app/(app)/@breadcrumbs/default.tsx
+++ b/apps/scan/src/app/(app)/@breadcrumbs/default.tsx
@@ -1,3 +1,3 @@
-export const DefaultBreadcrumbs = () => {
+export default function DefaultBreadcrumbs() {
   return null;
-};
+}

--- a/apps/scan/src/app/(app)/facilitator/[id]/(overview)/page.tsx
+++ b/apps/scan/src/app/(app)/facilitator/[id]/(overview)/page.tsx
@@ -46,5 +46,8 @@ export const generateMetadata = async ({
   return {
     title: facilitator.name,
     description: `x402 activity for the ${facilitator.name} facilitator`,
+    alternates: {
+      canonical: `/facilitator/${id}`,
+    },
   };
 };

--- a/apps/scan/src/app/(app)/server/[id]/layout.tsx
+++ b/apps/scan/src/app/(app)/server/[id]/layout.tsx
@@ -46,6 +46,9 @@ export async function generateMetadata({
   return {
     title,
     description,
+    alternates: {
+      canonical: `/server/${id}`,
+    },
     openGraph: {
       title,
       description,

--- a/apps/scan/src/app/layout.tsx
+++ b/apps/scan/src/app/layout.tsx
@@ -35,13 +35,15 @@ const geistMono = Geist_Mono({
   subsets: ['latin'],
 });
 
+const siteDescription =
+  'Explore the x402 ecosystem. View transactions, sellers, origins and resources. Explore the future of agentic commerce.';
+
 export const metadata: Metadata = {
   title: {
     default: 'x402scan | x402 Ecosystem Explorer',
     template: '%s | x402scan',
   },
-  description:
-    'Explore the x402 ecosystem. View transactions, sellers, origins and resources. Explore the future of agentic commerce.',
+  description: siteDescription,
   keywords: [
     'x402',
     'blockchain',
@@ -90,11 +92,43 @@ export const viewport: Viewport = {
 
 export default async function RootLayout({ children }: LayoutProps<'/'>) {
   await connection();
+  const appUrl = env.NEXT_PUBLIC_APP_URL.replace(/\/$/, '');
+  const jsonLd = [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'WebSite',
+      name: 'x402scan',
+      url: appUrl,
+      description: siteDescription,
+      potentialAction: {
+        '@type': 'SearchAction',
+        target: `${appUrl}/?q={search_term_string}`,
+        'query-input': 'required name=search_term_string',
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Organization',
+      name: 'x402scan',
+      url: appUrl,
+      sameAs: [
+        'https://github.com/Merit-Systems/x402scan',
+        'https://x.com/x402scan',
+      ],
+    },
+  ];
+
   return (
     <html lang="en" suppressHydrationWarning>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(jsonLd).replace(/</g, '\\u003c'),
+          }}
+        />
         <Toaster />
         <SpeedInsights />
         <Analytics />

--- a/apps/scan/src/app/robots.ts
+++ b/apps/scan/src/app/robots.ts
@@ -1,11 +1,13 @@
 import type { MetadataRoute } from 'next';
 
+import { env } from '@/env';
+
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
       userAgent: '*',
       allow: '/',
     },
-    sitemap: 'https://x402scan.com/sitemap.xml',
+    sitemap: `${env.NEXT_PUBLIC_APP_URL}/sitemap.xml`,
   };
 }

--- a/apps/scan/src/app/sitemap.ts
+++ b/apps/scan/src/app/sitemap.ts
@@ -1,54 +1,93 @@
 import type { MetadataRoute } from 'next';
 
-export default function sitemap(): MetadataRoute.Sitemap {
-  return [
-    {
-      url: 'https://x402scan.com',
-      lastModified: new Date(),
-      changeFrequency: 'hourly',
-      priority: 1,
+import { scanDb } from '@x402scan/scan-db';
+
+import { env } from '@/env';
+import { facilitators } from '@/lib/facilitators';
+
+const baseUrl = env.NEXT_PUBLIC_APP_URL.replace(/\/$/, '');
+const staticLastModified = new Date('2026-05-20T00:00:00.000Z');
+
+const url = (path: string) => `${baseUrl}${path}`;
+
+const staticRouteEntries = [
+  { url: url('/'), changeFrequency: 'hourly', priority: 1 },
+  { url: url('/x402'), changeFrequency: 'daily', priority: 0.95 },
+  {
+    url: url('/agentic-commerce'),
+    changeFrequency: 'daily',
+    priority: 0.9,
+  },
+  { url: url('/transactions'), changeFrequency: 'hourly', priority: 0.8 },
+  { url: url('/resources'), changeFrequency: 'daily', priority: 0.8 },
+  { url: url('/resources/register'), changeFrequency: 'weekly', priority: 0.7 },
+  { url: url('/discovery'), changeFrequency: 'weekly', priority: 0.75 },
+  {
+    url: url('/discovery/quickstart'),
+    changeFrequency: 'weekly',
+    priority: 0.65,
+  },
+  { url: url('/discovery/spec'), changeFrequency: 'weekly', priority: 0.7 },
+  {
+    url: url('/discovery/architecture'),
+    changeFrequency: 'weekly',
+    priority: 0.6,
+  },
+  { url: url('/all'), changeFrequency: 'daily', priority: 0.65 },
+  { url: url('/networks'), changeFrequency: 'daily', priority: 0.6 },
+  { url: url('/ecosystem'), changeFrequency: 'daily', priority: 0.6 },
+  { url: url('/facilitators'), changeFrequency: 'daily', priority: 0.6 },
+  { url: url('/mcp'), changeFrequency: 'weekly', priority: 0.55 },
+  { url: url('/mcp/guide'), changeFrequency: 'weekly', priority: 0.5 },
+  { url: url('/composer'), changeFrequency: 'daily', priority: 0.45 },
+  { url: url('/developer'), changeFrequency: 'daily', priority: 0.4 },
+] satisfies Omit<MetadataRoute.Sitemap[number], 'lastModified'>[];
+
+const staticRoutes: MetadataRoute.Sitemap = staticRouteEntries.map(route => ({
+  lastModified: staticLastModified,
+  ...route,
+}));
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const origins = await scanDb.resourceOrigin.findMany({
+    where: {
+      resources: {
+        some: {
+          deprecatedAt: null,
+          response: {
+            isNot: null,
+          },
+          accepts: {
+            some: {},
+          },
+        },
+      },
     },
-    {
-      url: 'https://x402scan.com/transactions',
-      lastModified: new Date(),
-      changeFrequency: 'hourly',
-      priority: 0.8,
+    select: {
+      id: true,
+      updatedAt: true,
     },
-    {
-      url: 'https://x402scan.com/resources',
-      lastModified: new Date(),
+    orderBy: {
+      updatedAt: 'desc',
+    },
+    take: 1000,
+  });
+
+  const serverRoutes: MetadataRoute.Sitemap = origins.map(origin => ({
+    url: url(`/server/${origin.id}`),
+    lastModified: origin.updatedAt,
+    changeFrequency: 'daily',
+    priority: 0.55,
+  }));
+
+  const facilitatorRoutes: MetadataRoute.Sitemap = facilitators.map(
+    facilitator => ({
+      url: url(`/facilitator/${facilitator.id}`),
+      lastModified: staticLastModified,
       changeFrequency: 'daily',
-      priority: 0.7,
-    },
-    {
-      url: 'https://x402scan.com/networks',
-      lastModified: new Date(),
-      changeFrequency: 'daily',
-      priority: 0.6,
-    },
-    {
-      url: 'https://x402scan.com/ecosystem',
-      lastModified: new Date(),
-      changeFrequency: 'daily',
-      priority: 0.6,
-    },
-    {
-      url: 'https://x402scan.com/facilitators',
-      lastModified: new Date(),
-      changeFrequency: 'daily',
-      priority: 0.6,
-    },
-    {
-      url: 'https://x402scan.com/composer',
-      lastModified: new Date(),
-      changeFrequency: 'daily',
-      priority: 0.6,
-    },
-    {
-      url: 'https://x402scan.com/developer',
-      lastModified: new Date(),
-      changeFrequency: 'daily',
-      priority: 0.4,
-    },
-  ];
+      priority: 0.5,
+    })
+  );
+
+  return [...staticRoutes, ...serverRoutes, ...facilitatorRoutes];
 }


### PR DESCRIPTION
- Added dedicated /x402 and /agentic-commerce pages so Google has focused, indexable targets for the highest-priority x402scan search terms.
- Added page metadata, canonical URLs, Open Graph data, and Twitter card data so shared and indexed results use accurate titles and descriptions.
- Added JSON-LD for the new pages, breadcrumbs, FAQs, and x402scan as a software application so crawlers can better understand the site structure.
- Added sitemap.xml entries with priorities for core SEO pages and high-value explorer pages so search engines can discover the important URLs reliably.
- Added robots.txt with the production sitemap reference so crawlers know what can be indexed and where the sitemap lives.
- Kept /x402 and /agentic-commerce out of visible frontend navigation so the SEO pages do not clutter the product experience.
- Simplified the /x402 and /agentic-commerce page designs so they read like clean reference pages instead of noisy dashboard surfaces.
- Fixed route metadata and breadcrumb defaults that could break or weaken rendering for the new SEO routes.
- Updated key server and facilitator detail metadata so long-tail indexed pages get more descriptive search snippets.