### PR TITLE
Unify registration validation across REST API and UI

### DIFF
--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -499,11 +499,6 @@ export const RegisterResourceForm = () => {
                     isBatchTestLoading={isBatchTestLoading}
                     authModeMap={authModeMap}
                     invalidResourcesMap={invalidResourcesMap}
-                    warningUrls={testedResources
-                      .filter(r =>
-                        r.warnings.some(w => w.code === 'MISSING_INPUT_SCHEMA')
-                      )
-                      .map(r => r.url)}
                   />
                 )}
 
@@ -735,56 +730,6 @@ export const RegisterResourceForm = () => {
         );
       })()}
 
-      {/* Warnings — registered but with issues */}
-      {(() => {
-        const missingSchemaResources = testedResources.filter(r =>
-          r.warnings.some(w => w.code === 'MISSING_INPUT_SCHEMA')
-        );
-
-        if (
-          activeBulkResult ||
-          isBatchTestLoading ||
-          missingSchemaResources.length === 0
-        )
-          return null;
-
-        return (
-          <Collapsible>
-            <CollapsibleTrigger asChild>
-              <button className="text-xs text-yellow-600 dark:text-yellow-500 flex items-center gap-1 hover:text-yellow-700 transition-colors">
-                <ChevronDown className="size-3" />
-                {missingSchemaResources.length} endpoint
-                {missingSchemaResources.length === 1 ? '' : 's'} with warnings
-              </button>
-            </CollapsibleTrigger>
-            <CollapsibleContent className="pt-2 space-y-3">
-              <p className="text-xs text-muted-foreground">
-                <strong>
-                  {missingSchemaResources.length} endpoint
-                  {missingSchemaResources.length === 1 ? '' : 's'} missing input
-                  schema.
-                </strong>{' '}
-                These will still be registered, but agents won&apos;t know what
-                request to send. Add request/response schemas to your OpenAPI
-                spec to fix this.
-              </p>
-              <ul className="space-y-0.5 text-xs text-muted-foreground">
-                {missingSchemaResources.map((r, idx) => (
-                  <li
-                    key={`${r.url}-${idx}`}
-                    className="font-mono truncate flex items-center gap-1.5"
-                  >
-                    <TriangleAlert className="size-3 text-yellow-500 shrink-0" />
-                    {toPathLabel(r.url)}
-                  </li>
-                ))}
-              </ul>
-              <DiscoveryFixHint missingSchema />
-            </CollapsibleContent>
-          </Collapsible>
-        );
-      })()}
-
       {/* Bulk result */}
       {activeBulkResult && activeSummaryOrigin ? (
         <DiscoveryPanel
@@ -875,7 +820,6 @@ function ProbeResult({
   isBatchTestLoading = false,
   authModeMap = {},
   invalidResourcesMap = {},
-  warningUrls = [],
 }: {
   preview: {
     favicon: string | null;
@@ -889,7 +833,6 @@ function ProbeResult({
   isBatchTestLoading?: boolean;
   authModeMap?: Record<string, string>;
   invalidResourcesMap?: Record<string, { invalid: boolean; reason?: string }>;
-  warningUrls?: string[];
 }) {
   const testedUrls = useMemo(
     () => new Set(testedResources.map(r => r.url)),
@@ -899,7 +842,6 @@ function ProbeResult({
     () => new Set(failedResources.map(r => r.url)),
     [failedResources]
   );
-  const warningUrlSet = useMemo(() => new Set(warningUrls), [warningUrls]);
   const siwxUrls = useMemo(
     () =>
       new Set(
@@ -921,11 +863,10 @@ function ProbeResult({
   const sortedResources = useMemo(() => {
     const priority = (url: string) => {
       if (invalidUrls.has(url) || failedUrls.has(url)) return 0;
-      if (warningUrlSet.has(url)) return 1;
       return 2;
     };
     return [...resources].sort((a, b) => priority(a) - priority(b));
-  }, [resources, invalidUrls, failedUrls, warningUrlSet]);
+  }, [resources, invalidUrls, failedUrls]);
 
   const [expanded, setExpanded] = useState(false);
   const previewResources = expanded
@@ -1000,8 +941,6 @@ function ProbeResult({
                   <X className="size-3 text-red-500 shrink-0" />
                 ) : siwxUrls.has(resource) ? (
                   <Check className="size-3 text-primary shrink-0" />
-                ) : warningUrlSet.has(resource) ? (
-                  <TriangleAlert className="size-3 text-yellow-500 shrink-0" />
                 ) : testedUrls.has(resource) ? (
                   <Check className="size-3 text-green-600 shrink-0" />
                 ) : failedUrls.has(resource) ? (

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -158,6 +158,14 @@ export const RegisterResourceForm = () => {
   const hasDiscoveryResources =
     discoveryFound && actualDiscoveredResources.length > 0;
 
+  // After batch test completes, count only passing resources.
+  // Before batch test, fall back to total discovered count.
+  const batchTestComplete =
+    testedResources.length > 0 || failedResources.length > 0;
+  const registrableResourceCount = batchTestComplete
+    ? testedResources.length
+    : actualDiscoveredResources.length;
+
   const canUseManualMode = isValidUrl && !isOriginOnly;
   const currentUrlAlreadyInManualList = manualUrls.includes(normalizedUrl);
   const canAddCurrentUrl =
@@ -404,7 +412,7 @@ export const RegisterResourceForm = () => {
                   Verifying endpoints...
                 </>
               ) : (
-                `Add API (${actualDiscoveredResources.length} resources)`
+                `Add API (${registrableResourceCount} resources)`
               )}
             </Button>
             {canUseManualMode && (

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -411,6 +411,8 @@ export const RegisterResourceForm = () => {
                   <Loader2 className="size-4 animate-spin mr-2" />
                   Verifying endpoints...
                 </>
+              ) : batchTestComplete && registrableResourceCount === 0 ? (
+                `0 valid resources`
               ) : (
                 `Add API (${registrableResourceCount} resources)`
               )}

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -404,7 +404,7 @@ export const RegisterResourceForm = () => {
                   Verifying endpoints...
                 </>
               ) : (
-                `Add API (${testedResources.length} resources)`
+                `Add API (${actualDiscoveredResources.length} resources)`
               )}
             </Button>
             {canUseManualMode && (
@@ -426,7 +426,13 @@ export const RegisterResourceForm = () => {
         ) : (
           <Button
             variant="turbo"
-            disabled={manualTargets.length === 0 || isLoading || !isValidUrl}
+            disabled={
+              manualTargets.length === 0 ||
+              isLoading ||
+              isBatchTestLoading ||
+              !isValidUrl ||
+              (!!currentManualFailed && !currentManualTested)
+            }
             onClick={() => {
               void handleRegisterManual();
             }}
@@ -519,11 +525,6 @@ export const RegisterResourceForm = () => {
                       <div className="flex items-center gap-2 text-green-700">
                         <Check className="size-3" />
                         Valid 402 response.
-                      </div>
-                    ) : currentManualFailed ? (
-                      <div className="flex items-center gap-2 text-red-700">
-                        <X className="size-3" />
-                        {getPrimaryProbeError(currentManualFailed)}
                       </div>
                     ) : null}
                   </div>
@@ -668,9 +669,12 @@ export const RegisterResourceForm = () => {
         const issueCount =
           failedResources.length + missingSchemaResources.length;
         const missingSchemaUrls = missingSchemaResources.map(r => r.url);
+        const isV1Issue =
+          failedResources.length > 0 &&
+          failedResources.every(r => r.error?.includes('v1 response detected'));
 
         return (
-          <Collapsible>
+          <Collapsible defaultOpen>
             <CollapsibleTrigger asChild>
               <button className="text-xs text-red-600 dark:text-red-500 flex items-center gap-1 hover:text-red-700 transition-colors">
                 <ChevronDown className="size-3" />
@@ -687,10 +691,9 @@ export const RegisterResourceForm = () => {
                       {failedResources.length === 1 ? '' : 's'} won&apos;t be
                       registered.
                     </strong>{' '}
-                    They need to return a 402 payment challenge — ensure the
-                    x402 paywall runs before request validation, or mark the
-                    required parameters in your OpenAPI spec so we can probe
-                    automatically.
+                    {isV1Issue
+                      ? 'This endpoint returns an x402 v1 response. x402scan only supports v2 — update your paywall to return the v2 format.'
+                      : 'They need to return a 402 payment challenge — ensure the x402 paywall runs before request validation, or mark the required parameters in your OpenAPI spec so we can probe automatically.'}
                   </p>
                   <div className="space-y-2 max-h-[360px] overflow-y-auto">
                     {failedResources.map((failed, idx) => (
@@ -733,6 +736,7 @@ export const RegisterResourceForm = () => {
                 needsSetup={
                   failedResources.length > 0 && testedResources.length === 0
                 }
+                v1Migration={isV1Issue}
                 failedResources={failedResources.map(r => ({
                   url: r.url,
                   error: getPrimaryProbeError(r),
@@ -763,7 +767,7 @@ export const RegisterResourceForm = () => {
       {activeBulkResult?.originId ? (
         <Link href={`/server/${activeBulkResult.originId}`}>
           <Button variant="outline" className="w-full">
-            View API
+            View your API page &rarr;
           </Button>
         </Link>
       ) : null}

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -678,9 +678,6 @@ export const RegisterResourceForm = () => {
         const isV1Issue =
           failedResources.length > 0 &&
           failedResources.every(r => r.error?.includes('v1 response detected'));
-        const missingSchemaResources = testedResources.filter(r =>
-          r.warnings.some(w => w.code === 'MISSING_INPUT_SCHEMA')
-        );
 
         return (
           <Collapsible defaultOpen>
@@ -723,7 +720,6 @@ export const RegisterResourceForm = () => {
                   error: getPrimaryProbeError(r),
                   status: r.statusCode,
                 }))}
-                missingSchemaResources={missingSchemaResources.map(r => r.url)}
               />
             </CollapsibleContent>
           </Collapsible>

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -921,10 +921,11 @@ function ProbeResult({
   const sortedResources = useMemo(() => {
     const priority = (url: string) => {
       if (invalidUrls.has(url) || failedUrls.has(url)) return 0;
+      if (warningUrlSet.has(url)) return 1;
       return 2;
     };
     return [...resources].sort((a, b) => priority(a) - priority(b));
-  }, [resources, invalidUrls, failedUrls]);
+  }, [resources, invalidUrls, failedUrls, warningUrlSet]);
 
   const [expanded, setExpanded] = useState(false);
   const previewResources = expanded

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -499,6 +499,11 @@ export const RegisterResourceForm = () => {
                     isBatchTestLoading={isBatchTestLoading}
                     authModeMap={authModeMap}
                     invalidResourcesMap={invalidResourcesMap}
+                    warningUrls={testedResources
+                      .filter(r =>
+                        r.warnings.some(w => w.code === 'MISSING_INPUT_SCHEMA')
+                      )
+                      .map(r => r.url)}
                   />
                 )}
 
@@ -666,82 +671,53 @@ export const RegisterResourceForm = () => {
         </Collapsible>
       )}
 
-      {/* Errors, warnings, and schema issues — consolidated */}
+      {/* Errors — endpoints that won't be registered */}
       {(() => {
-        const missingSchemaResources = testedResources.filter(r =>
-          r.warnings.some(w => w.code === 'MISSING_INPUT_SCHEMA')
-        );
-        const hasIssues =
-          failedResources.length > 0 || missingSchemaResources.length > 0;
+        if (
+          activeBulkResult ||
+          isBatchTestLoading ||
+          failedResources.length === 0
+        )
+          return null;
 
-        if (activeBulkResult || isBatchTestLoading || !hasIssues) return null;
-
-        const issueCount =
-          failedResources.length + missingSchemaResources.length;
-        const missingSchemaUrls = missingSchemaResources.map(r => r.url);
         const isV1Issue =
           failedResources.length > 0 &&
           failedResources.every(r => r.error?.includes('v1 response detected'));
+        const missingSchemaResources = testedResources.filter(r =>
+          r.warnings.some(w => w.code === 'MISSING_INPUT_SCHEMA')
+        );
 
         return (
           <Collapsible defaultOpen>
             <CollapsibleTrigger asChild>
               <button className="text-xs text-red-600 dark:text-red-500 flex items-center gap-1 hover:text-red-700 transition-colors">
                 <ChevronDown className="size-3" />
-                {issueCount} endpoint
-                {issueCount === 1 ? '' : 's'} with issues
+                {failedResources.length} endpoint
+                {failedResources.length === 1 ? '' : 's'} with errors
               </button>
             </CollapsibleTrigger>
             <CollapsibleContent className="pt-2 space-y-3">
-              {failedResources.length > 0 && (
-                <>
-                  <p className="text-xs text-muted-foreground">
-                    <strong>
-                      {failedResources.length} endpoint
-                      {failedResources.length === 1 ? '' : 's'} won&apos;t be
-                      registered.
-                    </strong>{' '}
-                    {isV1Issue
-                      ? 'This endpoint returns an x402 v1 response. x402scan only supports v2 — update your paywall to return the v2 format.'
-                      : 'They need to return a 402 payment challenge — ensure the x402 paywall runs before request validation, or mark the required parameters in your OpenAPI spec so we can probe automatically.'}
-                  </p>
-                  <div className="space-y-2 max-h-[360px] overflow-y-auto">
-                    {failedResources.map((failed, idx) => (
-                      <FailedResourceRow
-                        key={`${failed.url}-${idx}`}
-                        url={failed.url}
-                        error={getPrimaryProbeError(failed)}
-                        statusCode={failed.statusCode}
-                        issues={failed.issues}
-                      />
-                    ))}
-                  </div>
-                </>
-              )}
-              {missingSchemaResources.length > 0 && (
-                <>
-                  <p className="text-xs text-muted-foreground">
-                    <strong>
-                      {missingSchemaResources.length} endpoint
-                      {missingSchemaResources.length === 1 ? '' : 's'} missing
-                      input schema.
-                    </strong>{' '}
-                    Agents can find and pay but won&apos;t know what request to
-                    send.
-                  </p>
-                  <ul className="space-y-0.5 text-xs text-muted-foreground">
-                    {missingSchemaResources.map((r, idx) => (
-                      <li
-                        key={`${r.url}-${idx}`}
-                        className="font-mono truncate flex items-center gap-1.5"
-                      >
-                        <TriangleAlert className="size-3 text-yellow-500 shrink-0" />
-                        {toPathLabel(r.url)}
-                      </li>
-                    ))}
-                  </ul>
-                </>
-              )}
+              <p className="text-xs text-muted-foreground">
+                <strong>
+                  {failedResources.length} endpoint
+                  {failedResources.length === 1 ? '' : 's'} won&apos;t be
+                  registered.
+                </strong>{' '}
+                {isV1Issue
+                  ? 'This endpoint returns an x402 v1 response. x402scan only supports v2 — update your paywall to return the v2 format.'
+                  : 'They need to return a 402 payment challenge — ensure the x402 paywall runs before request validation, or mark the required parameters in your OpenAPI spec so we can probe automatically.'}
+              </p>
+              <div className="space-y-2 max-h-[360px] overflow-y-auto">
+                {failedResources.map((failed, idx) => (
+                  <FailedResourceRow
+                    key={`${failed.url}-${idx}`}
+                    url={failed.url}
+                    error={getPrimaryProbeError(failed)}
+                    statusCode={failed.statusCode}
+                    issues={failed.issues}
+                  />
+                ))}
+              </div>
               <DiscoveryFixHint
                 needsSetup={
                   failedResources.length > 0 && testedResources.length === 0
@@ -752,8 +728,57 @@ export const RegisterResourceForm = () => {
                   error: getPrimaryProbeError(r),
                   status: r.statusCode,
                 }))}
-                missingSchemaResources={missingSchemaUrls}
+                missingSchemaResources={missingSchemaResources.map(r => r.url)}
               />
+            </CollapsibleContent>
+          </Collapsible>
+        );
+      })()}
+
+      {/* Warnings — registered but with issues */}
+      {(() => {
+        const missingSchemaResources = testedResources.filter(r =>
+          r.warnings.some(w => w.code === 'MISSING_INPUT_SCHEMA')
+        );
+
+        if (
+          activeBulkResult ||
+          isBatchTestLoading ||
+          missingSchemaResources.length === 0
+        )
+          return null;
+
+        return (
+          <Collapsible>
+            <CollapsibleTrigger asChild>
+              <button className="text-xs text-yellow-600 dark:text-yellow-500 flex items-center gap-1 hover:text-yellow-700 transition-colors">
+                <ChevronDown className="size-3" />
+                {missingSchemaResources.length} endpoint
+                {missingSchemaResources.length === 1 ? '' : 's'} with warnings
+              </button>
+            </CollapsibleTrigger>
+            <CollapsibleContent className="pt-2 space-y-3">
+              <p className="text-xs text-muted-foreground">
+                <strong>
+                  {missingSchemaResources.length} endpoint
+                  {missingSchemaResources.length === 1 ? '' : 's'} missing input
+                  schema.
+                </strong>{' '}
+                Agents can find and pay but won&apos;t know what request to
+                send.
+              </p>
+              <ul className="space-y-0.5 text-xs text-muted-foreground">
+                {missingSchemaResources.map((r, idx) => (
+                  <li
+                    key={`${r.url}-${idx}`}
+                    className="font-mono truncate flex items-center gap-1.5"
+                  >
+                    <TriangleAlert className="size-3 text-yellow-500 shrink-0" />
+                    {toPathLabel(r.url)}
+                  </li>
+                ))}
+              </ul>
+              <DiscoveryFixHint missingSchema />
             </CollapsibleContent>
           </Collapsible>
         );
@@ -849,6 +874,7 @@ function ProbeResult({
   isBatchTestLoading = false,
   authModeMap = {},
   invalidResourcesMap = {},
+  warningUrls = [],
 }: {
   preview: {
     favicon: string | null;
@@ -862,6 +888,7 @@ function ProbeResult({
   isBatchTestLoading?: boolean;
   authModeMap?: Record<string, string>;
   invalidResourcesMap?: Record<string, { invalid: boolean; reason?: string }>;
+  warningUrls?: string[];
 }) {
   const testedUrls = useMemo(
     () => new Set(testedResources.map(r => r.url)),
@@ -871,6 +898,7 @@ function ProbeResult({
     () => new Set(failedResources.map(r => r.url)),
     [failedResources]
   );
+  const warningUrlSet = useMemo(() => new Set(warningUrls), [warningUrls]);
   const siwxUrls = useMemo(
     () =>
       new Set(
@@ -889,16 +917,13 @@ function ProbeResult({
       ),
     [invalidResourcesMap]
   );
-  // Sort failed/invalid to the top only after the batch test finishes.
-  // During loading, keep the original order to avoid items jumping around.
   const sortedResources = useMemo(() => {
-    if (isBatchTestLoading) return resources;
     const priority = (url: string) => {
       if (invalidUrls.has(url) || failedUrls.has(url)) return 0;
       return 2;
     };
     return [...resources].sort((a, b) => priority(a) - priority(b));
-  }, [resources, invalidUrls, failedUrls, isBatchTestLoading]);
+  }, [resources, invalidUrls, failedUrls]);
 
   const [expanded, setExpanded] = useState(false);
   const previewResources = expanded
@@ -952,43 +977,50 @@ function ProbeResult({
           root to display an icon.
         </p>
       )}
-      <button
-        type="button"
-        onClick={() => setExpanded(!expanded)}
-        className="w-full text-left"
-      >
-        <ul className="space-y-0.5 text-xs text-muted-foreground">
-          {previewResources.map(resource => (
-            <li
-              key={resource}
-              className="font-mono truncate flex items-center gap-1.5"
-            >
-              {invalidUrls.has(resource) ? (
-                <X className="size-3 text-red-500 shrink-0" />
-              ) : siwxUrls.has(resource) ? (
-                <Check className="size-3 text-primary shrink-0" />
-              ) : testedUrls.has(resource) ? (
-                <Check className="size-3 text-green-600 shrink-0" />
-              ) : failedUrls.has(resource) ? (
-                <X className="size-3 text-red-500 shrink-0" />
-              ) : isBatchTestLoading ? (
-                <Loader2 className="size-3 animate-spin text-muted-foreground/50 shrink-0" />
-              ) : null}
-              {toPathLabel(resource)}
-            </li>
-          ))}
-          {!expanded && hiddenCount > 0 && (
-            <li className="text-muted-foreground/60 hover:text-muted-foreground transition-colors">
-              + {hiddenCount} more
-            </li>
-          )}
-          {expanded && sortedResources.length > 8 && (
-            <li className="text-muted-foreground/60 hover:text-muted-foreground transition-colors">
-              show less
-            </li>
-          )}
-        </ul>
-      </button>
+      {isBatchTestLoading ? (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground py-1">
+          <Loader2 className="size-3 animate-spin" />
+          Verifying {resources.length} endpoints...
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setExpanded(!expanded)}
+          className="w-full text-left"
+        >
+          <ul className="space-y-0.5 text-xs text-muted-foreground">
+            {previewResources.map(resource => (
+              <li
+                key={resource}
+                className="font-mono truncate flex items-center gap-1.5"
+              >
+                {invalidUrls.has(resource) ? (
+                  <X className="size-3 text-red-500 shrink-0" />
+                ) : siwxUrls.has(resource) ? (
+                  <Check className="size-3 text-primary shrink-0" />
+                ) : warningUrlSet.has(resource) ? (
+                  <TriangleAlert className="size-3 text-yellow-500 shrink-0" />
+                ) : testedUrls.has(resource) ? (
+                  <Check className="size-3 text-green-600 shrink-0" />
+                ) : failedUrls.has(resource) ? (
+                  <X className="size-3 text-red-500 shrink-0" />
+                ) : null}
+                {toPathLabel(resource)}
+              </li>
+            ))}
+            {!expanded && hiddenCount > 0 && (
+              <li className="text-muted-foreground/60 hover:text-muted-foreground transition-colors">
+                + {hiddenCount} more
+              </li>
+            )}
+            {expanded && sortedResources.length > 8 && (
+              <li className="text-muted-foreground/60 hover:text-muted-foreground transition-colors">
+                show less
+              </li>
+            )}
+          </ul>
+        </button>
+      )}
     </div>
   );
 }

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -409,7 +409,7 @@ export const RegisterResourceForm = () => {
               ) : isBatchTestLoading ? (
                 <>
                   <Loader2 className="size-4 animate-spin mr-2" />
-                  Verifying endpoints...
+                  {`Verifying ${actualDiscoveredResources.length} endpoints...`}
                 </>
               ) : batchTestComplete && registrableResourceCount === 0 ? (
                 `0 valid resources`
@@ -889,13 +889,16 @@ function ProbeResult({
       ),
     [invalidResourcesMap]
   );
+  // Sort failed/invalid to the top only after the batch test finishes.
+  // During loading, keep the original order to avoid items jumping around.
   const sortedResources = useMemo(() => {
+    if (isBatchTestLoading) return resources;
     const priority = (url: string) => {
       if (invalidUrls.has(url) || failedUrls.has(url)) return 0;
       return 2;
     };
     return [...resources].sort((a, b) => priority(a) - priority(b));
-  }, [resources, invalidUrls, failedUrls]);
+  }, [resources, invalidUrls, failedUrls, isBatchTestLoading]);
 
   const [expanded, setExpanded] = useState(false);
   const previewResources = expanded
@@ -949,48 +952,43 @@ function ProbeResult({
           root to display an icon.
         </p>
       )}
-      {isBatchTestLoading ? (
-        <div className="flex items-center gap-2 text-xs text-muted-foreground py-1">
-          <Loader2 className="size-3 animate-spin" />
-          Verifying {resources.length} endpoints...
-        </div>
-      ) : (
-        <button
-          type="button"
-          onClick={() => setExpanded(!expanded)}
-          className="w-full text-left"
-        >
-          <ul className="space-y-0.5 text-xs text-muted-foreground">
-            {previewResources.map(resource => (
-              <li
-                key={resource}
-                className="font-mono truncate flex items-center gap-1.5"
-              >
-                {invalidUrls.has(resource) ? (
-                  <X className="size-3 text-red-500 shrink-0" />
-                ) : siwxUrls.has(resource) ? (
-                  <Check className="size-3 text-primary shrink-0" />
-                ) : testedUrls.has(resource) ? (
-                  <Check className="size-3 text-green-600 shrink-0" />
-                ) : failedUrls.has(resource) ? (
-                  <X className="size-3 text-red-500 shrink-0" />
-                ) : null}
-                {toPathLabel(resource)}
-              </li>
-            ))}
-            {!expanded && hiddenCount > 0 && (
-              <li className="text-muted-foreground/60 hover:text-muted-foreground transition-colors">
-                + {hiddenCount} more
-              </li>
-            )}
-            {expanded && sortedResources.length > 8 && (
-              <li className="text-muted-foreground/60 hover:text-muted-foreground transition-colors">
-                show less
-              </li>
-            )}
-          </ul>
-        </button>
-      )}
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className="w-full text-left"
+      >
+        <ul className="space-y-0.5 text-xs text-muted-foreground">
+          {previewResources.map(resource => (
+            <li
+              key={resource}
+              className="font-mono truncate flex items-center gap-1.5"
+            >
+              {invalidUrls.has(resource) ? (
+                <X className="size-3 text-red-500 shrink-0" />
+              ) : siwxUrls.has(resource) ? (
+                <Check className="size-3 text-primary shrink-0" />
+              ) : testedUrls.has(resource) ? (
+                <Check className="size-3 text-green-600 shrink-0" />
+              ) : failedUrls.has(resource) ? (
+                <X className="size-3 text-red-500 shrink-0" />
+              ) : isBatchTestLoading ? (
+                <Loader2 className="size-3 animate-spin text-muted-foreground/50 shrink-0" />
+              ) : null}
+              {toPathLabel(resource)}
+            </li>
+          ))}
+          {!expanded && hiddenCount > 0 && (
+            <li className="text-muted-foreground/60 hover:text-muted-foreground transition-colors">
+              + {hiddenCount} more
+            </li>
+          )}
+          {expanded && sortedResources.length > 8 && (
+            <li className="text-muted-foreground/60 hover:text-muted-foreground transition-colors">
+              show less
+            </li>
+          )}
+        </ul>
+      </button>
     </div>
   );
 }

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -711,6 +711,7 @@ export const RegisterResourceForm = () => {
                 ))}
               </div>
               <DiscoveryFixHint
+                className="font-medium"
                 needsSetup={
                   failedResources.length > 0 && testedResources.length === 0
                 }

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -764,8 +764,9 @@ export const RegisterResourceForm = () => {
                   {missingSchemaResources.length === 1 ? '' : 's'} missing input
                   schema.
                 </strong>{' '}
-                Agents can find and pay but won&apos;t know what request to
-                send.
+                These will still be registered, but agents won&apos;t know what
+                request to send. Add request/response schemas to your OpenAPI
+                spec to fix this.
               </p>
               <ul className="space-y-0.5 text-xs text-muted-foreground">
                 {missingSchemaResources.map((r, idx) => (

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
@@ -380,36 +380,40 @@ export function DiscoveryPanel({
               {notRegisteredCount} Resource
               {notRegisteredCount === 1 ? '' : 's'} Not Registered
             </summary>
-            <div className="p-4 pt-2 border-t space-y-2 max-h-[400px] overflow-y-auto">
-              {allNotRegistered.map((failed, idx) => (
-                <div
-                  key={idx}
-                  className="p-3 bg-muted/50 rounded border text-xs space-y-1"
-                >
-                  <div className="flex items-start gap-2">
-                    <span className="text-muted-foreground shrink-0">URL:</span>
-                    <span className="font-mono break-all">
-                      {(() => {
-                        try {
-                          return new URL(failed.url).pathname;
-                        } catch {
-                          return failed.url;
-                        }
-                      })()}
-                    </span>
+            <div className="p-4 pt-2 border-t space-y-2">
+              <div className="space-y-2 max-h-[400px] overflow-y-auto">
+                {allNotRegistered.map((failed, idx) => (
+                  <div
+                    key={idx}
+                    className="p-3 bg-muted/50 rounded border text-xs space-y-1"
+                  >
+                    <div className="flex items-start gap-2">
+                      <span className="text-muted-foreground shrink-0">
+                        URL:
+                      </span>
+                      <span className="font-mono break-all">
+                        {(() => {
+                          try {
+                            return new URL(failed.url).pathname;
+                          } catch {
+                            return failed.url;
+                          }
+                        })()}
+                      </span>
+                    </div>
+                    <div className="flex items-start gap-2">
+                      <span className="text-muted-foreground shrink-0">
+                        Error:
+                      </span>
+                      <span className="text-red-600 wrap-break-word">
+                        {failed.error}
+                      </span>
+                    </div>
                   </div>
-                  <div className="flex items-start gap-2">
-                    <span className="text-muted-foreground shrink-0">
-                      Error:
-                    </span>
-                    <span className="text-red-600 wrap-break-word">
-                      {failed.error}
-                    </span>
-                  </div>
-                </div>
-              ))}
+                ))}
+              </div>
               <DiscoveryFixHint
-                className="mt-2 block"
+                className="font-medium pt-2"
                 failedResources={allNotRegistered}
               />
             </div>

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
@@ -284,7 +284,15 @@ export function DiscoveryPanel({
                       <span className="text-muted-foreground shrink-0">
                         URL:
                       </span>
-                      <span className="font-mono break-all">{failed.url}</span>
+                      <span className="font-mono break-all">
+                        {(() => {
+                          try {
+                            return new URL(failed.url).pathname;
+                          } catch {
+                            return failed.url;
+                          }
+                        })()}
+                      </span>
                     </div>
                     <div className="flex items-start gap-2">
                       <span className="text-muted-foreground shrink-0">
@@ -380,7 +388,15 @@ export function DiscoveryPanel({
                 >
                   <div className="flex items-start gap-2">
                     <span className="text-muted-foreground shrink-0">URL:</span>
-                    <span className="font-mono break-all">{failed.url}</span>
+                    <span className="font-mono break-all">
+                      {(() => {
+                        try {
+                          return new URL(failed.url).pathname;
+                        } catch {
+                          return failed.url;
+                        }
+                      })()}
+                    </span>
                   </div>
                   <div className="flex items-start gap-2">
                     <span className="text-muted-foreground shrink-0">

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
@@ -92,7 +92,7 @@ export function DiscoveryFixHint({
           : 'Have your agent fix the errors with a prompt';
 
   return (
-    <p className={cn('text-xs text-muted-foreground', className)}>
+    <p className={cn('text-sm text-foreground', className)}>
       <DiscoveryActions
         label={label}
         {...(needsSetup

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
@@ -238,7 +238,6 @@ export function DiscoveryPanel({
 
   // Show bulk registration result (only in register mode)
   if (!isTestMode && bulkResult?.success) {
-    const skippedCount = bulkResult.skipped ?? 0;
     const skippedDetails = bulkResult.skippedDetails ?? [];
     const siwxCount = bulkResult.siwx ?? 0;
 
@@ -322,6 +321,12 @@ export function DiscoveryPanel({
     }
 
     // Show success state if some/all resources were registered
+    const allNotRegistered = [
+      ...skippedDetails,
+      ...(bulkResult.failedDetails ?? []),
+    ];
+    const notRegisteredCount = allNotRegistered.length;
+
     return (
       <div className="space-y-3">
         <div className="flex items-center gap-3 p-4 border rounded-md bg-green-600/10 border-green-600/30">
@@ -330,40 +335,15 @@ export function DiscoveryPanel({
             <p className="text-sm font-medium">
               Successfully registered {bulkResult.registered + siwxCount} of{' '}
               {bulkResult.total} resources
-              {skippedCount > 0 && (
-                <span className="text-amber-700">
-                  {' '}
-                  ({skippedCount} skipped)
-                </span>
-              )}
-              {bulkResult.failed > 0 && (
+              {notRegisteredCount > 0 && (
                 <span className="text-red-600">
                   {' '}
-                  ({bulkResult.failed} failed)
+                  ({notRegisteredCount} not registered)
                 </span>
               )}
             </p>
           </div>
         </div>
-
-        {/* Skipped resources notice */}
-        {skippedCount > 0 && (
-          <div className="flex items-start gap-3 p-4 border rounded-md bg-red-600/10 border-red-600/30">
-            <X className="size-5 text-red-600 shrink-0 mt-0.5" />
-            <div className="space-y-2">
-              <h3 className="font-medium text-red-700">
-                {skippedCount} resource
-                {skippedCount === 1 ? '' : 's'} not registered
-              </h3>
-              <p className="text-sm text-muted-foreground">
-                These endpoints didn&apos;t return a 402 payment challenge.
-                Ensure the x402 paywall runs before request validation, then
-                re-register.
-              </p>
-              <DiscoveryFixHint failedResources={skippedDetails} />
-            </div>
-          </div>
-        )}
 
         {/* Deprecation notice */}
         {bulkResult.deprecated !== undefined && bulkResult.deprecated > 0 && (
@@ -384,44 +364,41 @@ export function DiscoveryPanel({
           </div>
         )}
 
-        {/* Failed resources details */}
-        {bulkResult.failed > 0 &&
-          bulkResult.failedDetails &&
-          bulkResult.failedDetails.length > 0 && (
-            <details className="border rounded-md group">
-              <summary className="p-3 cursor-pointer hover:bg-muted/50 font-medium text-sm flex items-center gap-2">
-                <ChevronDown className="size-4 transition-transform group-open:rotate-180" />
-                Failed Resources ({bulkResult.failedDetails.length})
-              </summary>
-              <div className="p-4 pt-2 border-t space-y-2 max-h-[400px] overflow-y-auto">
-                {bulkResult.failedDetails.map((failed, idx) => (
-                  <div
-                    key={idx}
-                    className="p-3 bg-muted/50 rounded border text-xs space-y-1"
-                  >
-                    <div className="flex items-start gap-2">
-                      <span className="text-muted-foreground shrink-0">
-                        URL:
-                      </span>
-                      <span className="font-mono break-all">{failed.url}</span>
-                    </div>
-                    <div className="flex items-start gap-2">
-                      <span className="text-muted-foreground shrink-0">
-                        Error:
-                      </span>
-                      <span className="text-red-600 wrap-break-word">
-                        {failed.error}
-                      </span>
-                    </div>
+        {/* Not registered — consolidated skipped + failed */}
+        {notRegisteredCount > 0 && (
+          <details className="border rounded-md group" open>
+            <summary className="p-3 cursor-pointer hover:bg-muted/50 font-medium text-sm flex items-center gap-2">
+              <ChevronDown className="size-4 transition-transform group-open:rotate-180" />
+              {notRegisteredCount} Resource
+              {notRegisteredCount === 1 ? '' : 's'} Not Registered
+            </summary>
+            <div className="p-4 pt-2 border-t space-y-2 max-h-[400px] overflow-y-auto">
+              {allNotRegistered.map((failed, idx) => (
+                <div
+                  key={idx}
+                  className="p-3 bg-muted/50 rounded border text-xs space-y-1"
+                >
+                  <div className="flex items-start gap-2">
+                    <span className="text-muted-foreground shrink-0">URL:</span>
+                    <span className="font-mono break-all">{failed.url}</span>
                   </div>
-                ))}
-                <DiscoveryFixHint
-                  className="mt-2 block"
-                  failedResources={bulkResult.failedDetails}
-                />
-              </div>
-            </details>
-          )}
+                  <div className="flex items-start gap-2">
+                    <span className="text-muted-foreground shrink-0">
+                      Error:
+                    </span>
+                    <span className="text-red-600 wrap-break-word">
+                      {failed.error}
+                    </span>
+                  </div>
+                </div>
+              ))}
+              <DiscoveryFixHint
+                className="mt-2 block"
+                failedResources={allNotRegistered}
+              />
+            </div>
+          </details>
+        )}
       </div>
     );
   }

--- a/apps/scan/src/app/(app)/_components/discovery/use-batch-test.ts
+++ b/apps/scan/src/app/(app)/_components/discovery/use-batch-test.ts
@@ -17,7 +17,7 @@ interface BatchTestResult {
   ) => Promise<void>;
 }
 
-const BATCH_SIZE = 20;
+const BATCH_SIZE = 5;
 
 /**
  * Split array into chunks of specified size
@@ -32,7 +32,8 @@ function chunkArray<T>(array: T[], size: number): T[][] {
 
 /**
  * Wrapper hook for api.developer.batchTest that handles pagination.
- * Automatically splits resources into chunks of 20 and makes parallel requests.
+ * Splits resources into small chunks and streams results progressively —
+ * each chunk updates the UI as soon as it resolves.
  * Uses a mutation (POST) to avoid URL length limits with large inputs.
  */
 export function useBatchTest(
@@ -58,33 +59,39 @@ export function useBatchTest(
   useEffect(() => {
     if (!enabled || chunks.length === 0) return;
 
-    // Start requests immediately, but defer all setState calls into the async chain
-    // to satisfy react-hooks/set-state-in-effect
-    const request = Promise.all(
-      chunks.map(chunk => mutateAsyncRef.current({ resources: chunk }))
-    );
-
+    // Clear previous results and start loading
     void Promise.resolve()
-      .then(() => setIsLoading(true))
-      .then(() => request)
-      .then(results => {
-        const allResources: TestedResource[] = [];
-        const allFailed: FailedResource[] = [];
-        for (const result of results) {
-          allResources.push(...result.resources);
-          allFailed.push(...result.failed);
-        }
-        setResources(allResources);
-        setFailed(allFailed);
+      .then(() => {
+        setIsLoading(true);
+        setResources([]);
+        setFailed([]);
       })
-      .catch(err => {
-        const error = err instanceof Error ? err.message : 'Request failed';
-        setFailed(
-          chunks
-            .flat()
-            .map(r => ({ success: false as const, url: r.url, error }))
-        );
-      })
+      .then(() =>
+        // Fire all chunks in parallel; update state as each resolves so the
+        // merchant sees results stream in progressively.
+        Promise.all(
+          chunks.map(chunk =>
+            mutateAsyncRef.current({ resources: chunk }).then(
+              result => {
+                setResources(prev => [...prev, ...result.resources]);
+                setFailed(prev => [...prev, ...result.failed]);
+              },
+              err => {
+                const error =
+                  err instanceof Error ? err.message : 'Request failed';
+                setFailed(prev => [
+                  ...prev,
+                  ...chunk.map(r => ({
+                    success: false as const,
+                    url: r.url,
+                    error,
+                  })),
+                ]);
+              }
+            )
+          )
+        )
+      )
       .finally(() => {
         setIsLoading(false);
       });

--- a/apps/scan/src/app/(app)/_components/discovery/use-batch-test.ts
+++ b/apps/scan/src/app/(app)/_components/discovery/use-batch-test.ts
@@ -59,14 +59,19 @@ export function useBatchTest(
   useEffect(() => {
     if (!enabled || chunks.length === 0) return;
 
+    let cancelled = false;
+
     const request = Promise.all(
       chunks.map(chunk => mutateAsyncRef.current({ resources: chunk }))
     );
 
     void Promise.resolve()
-      .then(() => setIsLoading(true))
+      .then(() => {
+        if (!cancelled) setIsLoading(true);
+      })
       .then(() => request)
       .then(results => {
+        if (cancelled) return;
         const allResources: TestedResource[] = [];
         const allFailed: FailedResource[] = [];
         for (const result of results) {
@@ -77,6 +82,7 @@ export function useBatchTest(
         setFailed(allFailed);
       })
       .catch(err => {
+        if (cancelled) return;
         const error = err instanceof Error ? err.message : 'Request failed';
         setFailed(
           chunks
@@ -85,8 +91,12 @@ export function useBatchTest(
         );
       })
       .finally(() => {
-        setIsLoading(false);
+        if (!cancelled) setIsLoading(false);
       });
+
+    return () => {
+      cancelled = true;
+    };
   }, [enabled, chunks, runCount]);
 
   const active = enabled && chunks.length > 0;

--- a/apps/scan/src/app/(app)/_components/discovery/use-batch-test.ts
+++ b/apps/scan/src/app/(app)/_components/discovery/use-batch-test.ts
@@ -17,7 +17,7 @@ interface BatchTestResult {
   ) => Promise<void>;
 }
 
-const BATCH_SIZE = 5;
+const BATCH_SIZE = 20;
 
 /**
  * Split array into chunks of specified size
@@ -32,8 +32,8 @@ function chunkArray<T>(array: T[], size: number): T[][] {
 
 /**
  * Wrapper hook for api.developer.batchTest that handles pagination.
- * Splits resources into small chunks and streams results progressively —
- * each chunk updates the UI as soon as it resolves.
+ * Processes chunks sequentially so results stream into the UI progressively
+ * without overwhelming the server with concurrent requests.
  * Uses a mutation (POST) to avoid URL length limits with large inputs.
  */
 export function useBatchTest(
@@ -59,39 +59,31 @@ export function useBatchTest(
   useEffect(() => {
     if (!enabled || chunks.length === 0) return;
 
-    // Clear previous results and start loading
+    const request = Promise.all(
+      chunks.map(chunk => mutateAsyncRef.current({ resources: chunk }))
+    );
+
     void Promise.resolve()
-      .then(() => {
-        setIsLoading(true);
-        setResources([]);
-        setFailed([]);
+      .then(() => setIsLoading(true))
+      .then(() => request)
+      .then(results => {
+        const allResources: TestedResource[] = [];
+        const allFailed: FailedResource[] = [];
+        for (const result of results) {
+          allResources.push(...result.resources);
+          allFailed.push(...result.failed);
+        }
+        setResources(allResources);
+        setFailed(allFailed);
       })
-      .then(() =>
-        // Fire all chunks in parallel; update state as each resolves so the
-        // merchant sees results stream in progressively.
-        Promise.all(
-          chunks.map(chunk =>
-            mutateAsyncRef.current({ resources: chunk }).then(
-              result => {
-                setResources(prev => [...prev, ...result.resources]);
-                setFailed(prev => [...prev, ...result.failed]);
-              },
-              err => {
-                const error =
-                  err instanceof Error ? err.message : 'Request failed';
-                setFailed(prev => [
-                  ...prev,
-                  ...chunk.map(r => ({
-                    success: false as const,
-                    url: r.url,
-                    error,
-                  })),
-                ]);
-              }
-            )
-          )
-        )
-      )
+      .catch(err => {
+        const error = err instanceof Error ? err.message : 'Request failed';
+        setFailed(
+          chunks
+            .flat()
+            .map(r => ({ success: false as const, url: r.url, error }))
+        );
+      })
       .finally(() => {
         setIsLoading(false);
       });

--- a/apps/scan/src/app/api/x402/_handlers/registry-register.ts
+++ b/apps/scan/src/app/api/x402/_handlers/registry-register.ts
@@ -1,58 +1,22 @@
 import type { registryRegisterBodySchema } from '@/app/api/x402/_lib/schemas';
 import { jsonResponse } from '@/app/api/x402/_lib/utils';
-import { registerResource } from '@/lib/resources';
-
-import { probeX402Endpoint } from '@/lib/discovery/probe';
+import { registerEndpoint } from '@/lib/discovery/register-endpoint';
 import type { z } from 'zod';
 
 export async function handleRegistryRegister(
   body: z.infer<typeof registryRegisterBodySchema>
 ) {
-  const { url } = body;
-
-  const probeResult = await probeX402Endpoint(
-    url.replaceAll('{', '').replaceAll('}', '')
-  );
-
-  if (!probeResult.success) {
-    return jsonResponse(
-      {
-        success: false,
-        error: { type: 'no_402', message: probeResult.error },
-      },
-      422
-    );
-  }
-
-  const result = await registerResource(url, probeResult.advisory);
+  const result = await registerEndpoint(body.url);
 
   if (!result.success) {
-    return jsonResponse(
-      {
-        success: false,
-        error: {
-          type: 'parse_error',
-          parseErrors:
-            result.error.type === 'parseResponse'
-              ? result.error.parseErrors
-              : [JSON.stringify(result.error)],
-        },
-        data: result.data,
-      },
-      422
-    );
+    return jsonResponse(result, 422);
   }
 
+  // BigInt serialization — REST-specific (TRPC uses superjson)
   return jsonResponse(
     JSON.parse(
-      JSON.stringify(
-        {
-          success: true,
-          resource: result.resource,
-          accepts: result.accepts,
-          registrationDetails: result.registrationDetails,
-        },
-        (_k, v: unknown) => (typeof v === 'bigint' ? Number(v) : v)
+      JSON.stringify(result, (_k, v: unknown) =>
+        typeof v === 'bigint' ? Number(v) : v
       )
     )
   );

--- a/apps/scan/src/lib/discovery/discover-siblings.ts
+++ b/apps/scan/src/lib/discovery/discover-siblings.ts
@@ -1,0 +1,43 @@
+import { getOriginFromUrl, normalizeUrl } from '@/lib/url';
+import { fetchDiscoveryDocument } from '@/services/discovery';
+import type { DiscoveryInfo } from '@/types/discovery';
+
+/**
+ * After registering a single resource, check the origin for a discovery
+ * document and return info about sibling resources. Non-blocking — swallows
+ * errors so callers never fail because of a missing discovery doc.
+ */
+export async function discoverSiblingResources(
+  registeredUrl: string
+): Promise<DiscoveryInfo> {
+  const origin = getOriginFromUrl(registeredUrl);
+
+  try {
+    const discoveryResult = await fetchDiscoveryDocument(origin);
+    if (discoveryResult.success && Array.isArray(discoveryResult.resources)) {
+      const normalizedInputUrl = normalizeUrl(String(registeredUrl));
+      const otherResources = discoveryResult.resources.filter(r => {
+        if (
+          !r ||
+          typeof r !== 'object' ||
+          !('url' in r) ||
+          typeof r.url !== 'string'
+        ) {
+          return false;
+        }
+        return normalizeUrl(String(r.url)) !== normalizedInputUrl;
+      });
+      return {
+        found: true,
+        source: discoveryResult.source,
+        otherResourceCount: otherResources.length,
+        origin,
+        resources: otherResources.map(r => r.url),
+      };
+    }
+  } catch {
+    // Discovery check failed, continue without discovery info
+  }
+
+  return { found: false, otherResourceCount: 0, origin };
+}

--- a/apps/scan/src/lib/discovery/register-endpoint.ts
+++ b/apps/scan/src/lib/discovery/register-endpoint.ts
@@ -1,0 +1,65 @@
+import { probeX402Endpoint } from './probe';
+import { registerResource } from '@/lib/resources';
+import { discoverSiblingResources } from './discover-siblings';
+
+/**
+ * Single orchestrator for registering a single x402 resource.
+ *
+ * Owns the full flow: probe → validate → register → discover siblings.
+ * Both the REST API handler and the TRPC mutation delegate to this function
+ * so that registration behavior is identical across all surfaces.
+ */
+export async function registerEndpoint(
+  url: string,
+  options?: {
+    notifyNewServer?: boolean;
+    originMetadataFallback?: { title?: string; description?: string };
+  }
+) {
+  const cleanUrl = url.replaceAll('{', '').replaceAll('}', '');
+
+  // 1. Probe the endpoint for a 402 response
+  const probeResult = await probeX402Endpoint(cleanUrl);
+
+  if (!probeResult.success) {
+    return {
+      success: false as const,
+      error: {
+        type: 'no402' as const,
+        message: probeResult.error,
+      },
+    };
+  }
+
+  // 2. Register the resource (includes HTTPS, v1, SIWX validation)
+  const result = await registerResource(url, probeResult.advisory, {
+    warnings: probeResult.warnings,
+    ...options,
+  });
+
+  if (!result.success) {
+    const parseErrors: string[] =
+      result.error.type === 'parseResponse' ||
+      result.error.type === 'validation'
+        ? result.error.parseErrors
+        : 'upsertErrors' in result.error
+          ? result.error.upsertErrors
+          : [JSON.stringify(result.error)];
+
+    return {
+      success: false as const,
+      error: { type: 'parseErrors' as const, parseErrors },
+      data: result.data,
+      warnings: result.warnings,
+    };
+  }
+
+  // 3. Check for sibling resources at the same origin
+  const discovery = await discoverSiblingResources(url);
+
+  return {
+    ...result,
+    methodUsed: probeResult.advisory.method,
+    discovery,
+  };
+}

--- a/apps/scan/src/lib/discovery/register-origin.ts
+++ b/apps/scan/src/lib/discovery/register-origin.ts
@@ -121,19 +121,7 @@ export async function registerResourcesFromDiscovery(
 
     const { advisory } = probeResult;
 
-    // Check for v1 — only v2 resources can be registered
-    const x402Options = (advisory.paymentOptions ?? []).filter(
-      o => o.protocol === 'x402'
-    );
-    const hasOnlyV1 =
-      x402Options.length > 0 && x402Options.every(o => o.version === 1);
-    if (hasOnlyV1) {
-      return {
-        success: false as const,
-        url: resourceUrl,
-        error: 'x402 v1 response detected — migrate to v2 spec',
-      };
-    }
+    // v1 rejection is handled inside registerResource() — no duplicate check needed here.
 
     if (advisory.authMode === 'siwx') {
       return {
@@ -146,6 +134,7 @@ export async function registerResourcesFromDiscovery(
     const result = await registerResource(resourceUrl, advisory, {
       notifyNewServer: false,
       originMetadataFallback: originInfo,
+      warnings: probeResult.warnings,
     });
 
     if (result.success) return result;

--- a/apps/scan/src/lib/resources.ts
+++ b/apps/scan/src/lib/resources.ts
@@ -5,7 +5,10 @@ import {
   upsertOrigin,
 } from '@/services/db/resources/origin';
 
-import type { EndpointMethodAdvisory } from '@agentcash/discovery';
+import type {
+  EndpointMethodAdvisory,
+  AuditWarning,
+} from '@agentcash/discovery';
 import { isX402PaymentOption } from '@/lib/discovery/utils';
 
 import { getOriginFromUrl } from '@/lib/url';
@@ -39,12 +42,64 @@ export const registerResource = async (
      * `info` block from discovery.
      */
     originMetadataFallback?: { title?: string; description?: string };
+    /** Warnings from probeX402Endpoint — merged into the result. */
+    warnings?: AuditWarning[];
   } = {}
 ) => {
+  const warnings: AuditWarning[] = [...(options.warnings ?? [])];
+
+  // --- Pre-registration validation (all rules in one place) ---
+
+  // HTTPS enforcement (allow localhost / 127.0.0.1 for dev)
+  const urlObj = new URL(url);
+  if (
+    urlObj.protocol === 'http:' &&
+    urlObj.hostname !== 'localhost' &&
+    urlObj.hostname !== '127.0.0.1'
+  ) {
+    return {
+      success: false as const,
+      data: advisory.paymentRequiredBody,
+      error: {
+        type: 'validation' as const,
+        parseErrors: [
+          'HTTPS is required for x402 resource registration. Received http:// URL.',
+        ],
+      },
+      warnings,
+    };
+  }
+
+  // v1 rejection — only v2 resources can be registered
   const x402Options = (advisory.paymentOptions ?? []).filter(
     isX402PaymentOption
   );
-  const urlObj = new URL(url);
+  const hasOnlyV1 =
+    x402Options.length > 0 && x402Options.every(o => o.version === 1);
+  if (hasOnlyV1) {
+    return {
+      success: false as const,
+      data: advisory.paymentRequiredBody,
+      error: {
+        type: 'validation' as const,
+        parseErrors: [
+          'x402 v1 response detected — migrate to v2 spec. See https://x402scan.com/discovery/spec',
+        ],
+      },
+      warnings,
+    };
+  }
+
+  // SIWX warning — identity-gated endpoints are valid but not payment-protected
+  if (advisory.authMode === 'siwx') {
+    warnings.push({
+      code: 'SIWX_ENDPOINT',
+      severity: 'warn',
+      message:
+        'This endpoint uses SIWX authentication (identity-gated, not payment-protected)',
+    });
+  }
+
   urlObj.search = '';
   const cleanUrl = urlObj.toString();
   const origin = getOriginFromUrl(cleanUrl);
@@ -58,6 +113,7 @@ export const registerResource = async (
         type: 'parseResponse' as const,
         parseErrors: ['No payment options found'],
       },
+      warnings,
     };
   }
 
@@ -69,6 +125,7 @@ export const registerResource = async (
         type: 'parseResponse' as const,
         parseErrors: ['Missing input schema'],
       },
+      warnings,
     };
   }
 
@@ -159,6 +216,7 @@ export const registerResource = async (
           `No supported networks advertised. Got: [${advertisedNetworks.join(', ')}]. Supported: [${(SUPPORTED_CHAINS as readonly string[]).join(', ')}]. Testnets are not indexed.`,
         ],
       },
+      warnings,
     };
   }
 
@@ -173,6 +231,7 @@ export const registerResource = async (
         type: 'parseResponse' as const,
         parseErrors: parsedPaymentRequiredBody.errors,
       },
+      warnings,
     };
   }
 
@@ -194,6 +253,7 @@ export const registerResource = async (
         type: 'database' as const,
         upsertErrors: ['Resource failed to upsert'],
       },
+      warnings,
     };
   }
 
@@ -271,6 +331,7 @@ export const registerResource = async (
       maxAmountRequired: formatTokenAmount(accept.maxAmountRequired),
     })),
     response: advisory.paymentRequiredBody,
+    warnings,
     registrationDetails: {
       providedAccepts: mappedAccepts,
       supportedAccepts: resource.accepts,

--- a/apps/scan/src/lib/resources.ts
+++ b/apps/scan/src/lib/resources.ts
@@ -31,6 +31,86 @@ import type { AcceptsNetwork } from '@x402scan/scan-db';
 import { convertOpenApiSchemaToV1 } from '@/lib/openapi-to-v1';
 import { notifyNewServer } from '@/lib/discord-notifications';
 
+/**
+ * Pure validation — no DB writes, no side effects. Used by both
+ * registerResource() and the batch-test endpoint so the pre-registration
+ * count matches the actual registration outcome.
+ */
+export function validateResource(
+  url: string,
+  advisory: EndpointMethodAdvisory
+): { valid: true; warnings: AuditWarning[] } | { valid: false; error: string } {
+  const warnings: AuditWarning[] = [];
+
+  // HTTPS enforcement (allow localhost / 127.0.0.1 for dev)
+  const urlObj = new URL(url);
+  if (
+    urlObj.protocol === 'http:' &&
+    urlObj.hostname !== 'localhost' &&
+    urlObj.hostname !== '127.0.0.1'
+  ) {
+    return {
+      valid: false,
+      error: 'HTTPS is required for x402 resource registration',
+    };
+  }
+
+  // v1 rejection — only v2 resources can be registered
+  const x402Options = (advisory.paymentOptions ?? []).filter(
+    isX402PaymentOption
+  );
+  const hasOnlyV1 =
+    x402Options.length > 0 && x402Options.every(o => o.version === 1);
+  if (hasOnlyV1) {
+    return {
+      valid: false,
+      error: 'x402 v1 response detected — migrate to v2 spec',
+    };
+  }
+
+  // No x402 payment options
+  if (x402Options.length === 0) {
+    return { valid: false, error: 'No x402 payment options found' };
+  }
+
+  // Missing input schema
+  if (!advisory.inputSchema) {
+    return {
+      valid: false,
+      error:
+        'Missing input schema — add request/response schemas to your OpenAPI spec',
+    };
+  }
+
+  // Unsupported networks
+  const hasSupported = x402Options.some(opt =>
+    (SUPPORTED_CHAINS as readonly string[]).includes(
+      normalizeChainId(opt.network)
+    )
+  );
+  if (!hasSupported) {
+    const advertisedNetworks = Array.from(
+      new Set(x402Options.map(o => normalizeChainId(o.network)))
+    );
+    return {
+      valid: false,
+      error: `No supported networks. Got: [${advertisedNetworks.join(', ')}]. Supported: [${(SUPPORTED_CHAINS as readonly string[]).join(', ')}]`,
+    };
+  }
+
+  // SIWX warning — identity-gated endpoints are valid but not payment-protected
+  if (advisory.authMode === 'siwx') {
+    warnings.push({
+      code: 'SIWX_ENDPOINT',
+      severity: 'warn',
+      message:
+        'This endpoint uses SIWX authentication (identity-gated, not payment-protected)',
+    });
+  }
+
+  return { valid: true, warnings };
+}
+
 export const registerResource = async (
   url: string,
   advisory: EndpointMethodAdvisory,
@@ -46,88 +126,33 @@ export const registerResource = async (
     warnings?: AuditWarning[];
   } = {}
 ) => {
-  const warnings: AuditWarning[] = [...(options.warnings ?? [])];
+  const validation = validateResource(url, advisory);
 
-  // --- Pre-registration validation (all rules in one place) ---
-
-  // HTTPS enforcement (allow localhost / 127.0.0.1 for dev)
-  const urlObj = new URL(url);
-  if (
-    urlObj.protocol === 'http:' &&
-    urlObj.hostname !== 'localhost' &&
-    urlObj.hostname !== '127.0.0.1'
-  ) {
+  if (!validation.valid) {
     return {
       success: false as const,
       data: advisory.paymentRequiredBody,
       error: {
         type: 'validation' as const,
-        parseErrors: [
-          'HTTPS is required for x402 resource registration. Received http:// URL.',
-        ],
+        parseErrors: [validation.error],
       },
-      warnings,
+      warnings: [...(options.warnings ?? [])],
     };
   }
 
-  // v1 rejection — only v2 resources can be registered
   const x402Options = (advisory.paymentOptions ?? []).filter(
     isX402PaymentOption
   );
-  const hasOnlyV1 =
-    x402Options.length > 0 && x402Options.every(o => o.version === 1);
-  if (hasOnlyV1) {
-    return {
-      success: false as const,
-      data: advisory.paymentRequiredBody,
-      error: {
-        type: 'validation' as const,
-        parseErrors: [
-          'x402 v1 response detected — migrate to v2 spec. See https://x402scan.com/discovery/spec',
-        ],
-      },
-      warnings,
-    };
-  }
+  const warnings: AuditWarning[] = [
+    ...(options.warnings ?? []),
+    ...validation.warnings,
+  ];
 
-  // SIWX warning — identity-gated endpoints are valid but not payment-protected
-  if (advisory.authMode === 'siwx') {
-    warnings.push({
-      code: 'SIWX_ENDPOINT',
-      severity: 'warn',
-      message:
-        'This endpoint uses SIWX authentication (identity-gated, not payment-protected)',
-    });
-  }
-
+  const urlObj = new URL(url);
   urlObj.search = '';
   const cleanUrl = urlObj.toString();
   const origin = getOriginFromUrl(cleanUrl);
   const shouldNotifyNewServer = options.notifyNewServer ?? true;
-
-  if (x402Options.length === 0) {
-    return {
-      success: false as const,
-      data: advisory.paymentRequiredBody,
-      error: {
-        type: 'parseResponse' as const,
-        parseErrors: ['No payment options found'],
-      },
-      warnings,
-    };
-  }
-
-  if (!advisory.inputSchema) {
-    return {
-      success: false as const,
-      data: advisory.paymentRequiredBody,
-      error: {
-        type: 'parseResponse' as const,
-        parseErrors: ['Missing input schema'],
-      },
-      warnings,
-    };
-  }
 
   const existingOriginResourceCount = shouldNotifyNewServer
     ? await getOriginResourceCount(origin)
@@ -157,10 +182,6 @@ export const registerResource = async (
   }
 
   // Fallback: convert raw OpenAPI-format inputSchema to v1 format.
-  // The discovery package returns schemas from the OpenAPI spec as
-  // { requestBody?: JsonSchema, parameters?: OpenApiParam[] } or a
-  // bare JSON Schema when only a requestBody exists. Convert those
-  // into the v1 { method, bodyFields, queryParams, headerFields } shape.
   if (!outputSchemaForDb && advisory.inputSchema) {
     const converted = convertOpenApiSchemaToV1(
       advisory.inputSchema,
@@ -203,6 +224,8 @@ export const registerResource = async (
     (SUPPORTED_CHAINS as readonly string[]).includes(accept.network)
   );
 
+  // This should never fire since validateResource already checked, but
+  // guard defensively in case the chain list diverges at runtime.
   if (mappedAccepts.length === 0) {
     const advertisedNetworks = Array.from(
       new Set(allMappedAccepts.map(a => a.network))

--- a/apps/scan/src/trpc/routers/developer.ts
+++ b/apps/scan/src/trpc/routers/developer.ts
@@ -6,8 +6,14 @@ import { getOriginFromUrl } from '@/lib/url';
 import { scrapeOriginData } from '@/services/scraper';
 import type { FailedResource, TestedResource } from '@/types/batch-test';
 import { probeX402Endpoint } from '@/lib/discovery/probe';
+import { validateResource } from '@/lib/resources';
 import { fetchDiscoveryDocument } from '@/services/discovery';
 
+/**
+ * Test a single resource by probing it and running the same validation
+ * that registerResource() uses (via shared validateResource()). This
+ * ensures the batch-test count matches the actual registration outcome.
+ */
 async function testSingleResource(
   url: string,
   method?: string,
@@ -54,28 +60,14 @@ async function testSingleResource(
 
     const { advisory } = result;
 
-    // Check for v1 — all x402 payment options must be v2
-    const x402Options = (advisory.paymentOptions ?? []).filter(
-      o => o.protocol === 'x402'
-    );
-    const hasOnlyV1 =
-      x402Options.length > 0 && x402Options.every(o => o.version === 1);
-    if (hasOnlyV1) {
+    // Run the same validation as registerResource()
+    const validation = validateResource(url, advisory);
+    if (!validation.valid) {
       return {
         success: false as const,
         url,
-        error: 'x402 v1 response detected — migrate to v2 spec',
+        error: validation.error,
       };
-    }
-
-    const warnings = [...result.warnings];
-    if (!advisory.inputSchema) {
-      warnings.push({
-        code: 'MISSING_INPUT_SCHEMA',
-        severity: 'warn' as const,
-        message:
-          "Missing input schema — agents can find and pay for this endpoint but won't know what request to send",
-      });
     }
 
     return {
@@ -84,7 +76,7 @@ async function testSingleResource(
       method: advisory.method as TestedResource['method'],
       description: advisory.summary ?? null,
       parsed: advisory,
-      warnings,
+      warnings: [...result.warnings, ...validation.warnings],
     };
   } catch (err) {
     return {

--- a/apps/scan/src/trpc/routers/public/resources.ts
+++ b/apps/scan/src/trpc/routers/public/resources.ts
@@ -20,9 +20,7 @@ import { scanDb } from '@x402scan/scan-db';
 
 import { mixedAddressSchema } from '@/lib/schemas';
 
-import { registerResource } from '@/lib/resources';
-
-import { probeX402Endpoint } from '@/lib/discovery/probe';
+import { registerEndpoint } from '@/lib/discovery/register-endpoint';
 import { registerResourcesFromDiscovery } from '@/lib/discovery/register-origin';
 import { TRPCError } from '@trpc/server';
 import {
@@ -33,7 +31,6 @@ import {
 
 import { convertTokenAmount } from '@/lib/token';
 import { usdc } from '@/lib/tokens/usdc';
-import { getOriginFromUrl, normalizeUrl } from '@/lib/url';
 import { fetchDiscoveryDocument } from '@/services/discovery';
 import {
   getResourceVerificationStatus,
@@ -42,7 +39,6 @@ import {
 
 import type { Prisma } from '@x402scan/scan-db';
 import type { SupportedChain } from '@/types/chain';
-import type { DiscoveryInfo } from '@/types/discovery';
 import { verifyAnyOwnershipProof } from '@/lib/ownership-proof';
 
 export const resourcesRouter = createTRPCRouter({
@@ -142,78 +138,7 @@ export const resourcesRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ input }) => {
-      const probeResult = await probeX402Endpoint(
-        input.url.toString().replaceAll('{', '').replaceAll('}', '')
-      );
-
-      if (!probeResult.success) {
-        return { success: false as const, error: { type: 'no402' as const } };
-      }
-
-      const result = await registerResource(
-        input.url.toString(),
-        probeResult.advisory
-      );
-
-      if (result.success === false) {
-        return {
-          success: false as const,
-          data: result.data,
-          error: {
-            type: 'parseErrors' as const,
-            parseErrors:
-              result.error.type === 'parseResponse'
-                ? result.error.parseErrors
-                : [JSON.stringify(result.error)],
-          },
-        };
-      }
-
-      // Check for additional resources via discovery
-      const origin = getOriginFromUrl(input.url);
-      let discovery: DiscoveryInfo = {
-        found: false,
-        otherResourceCount: 0,
-        origin,
-      };
-
-      try {
-        const discoveryResult = await fetchDiscoveryDocument(origin);
-        if (
-          discoveryResult.success &&
-          Array.isArray(discoveryResult.resources)
-        ) {
-          const inputUrlStr = String(input.url);
-          const normalizedInputUrl = normalizeUrl(inputUrlStr);
-          const otherResources = discoveryResult.resources.filter(r => {
-            if (
-              !r ||
-              typeof r !== 'object' ||
-              !('url' in r) ||
-              typeof r.url !== 'string'
-            ) {
-              return false;
-            }
-            const resourceUrl = String(r.url);
-            return normalizeUrl(resourceUrl) !== normalizedInputUrl;
-          });
-          discovery = {
-            found: true,
-            source: discoveryResult.source,
-            otherResourceCount: otherResources.length,
-            origin,
-            resources: otherResources.map(r => r.url),
-          };
-        }
-      } catch {
-        // Discovery check failed, continue without discovery info
-      }
-
-      return {
-        ...result,
-        methodUsed: probeResult.advisory.method,
-        discovery,
-      };
+      return await registerEndpoint(input.url.toString());
     }),
 
   /**


### PR DESCRIPTION
## Summary
- Extract `validateResource()` as single source of truth for pre-registration checks — used by both `registerResource()` (actual registration) and `testSingleResource()` (batch test), ensuring the "Add API (N resources)" count matches actual registration outcome
- Consolidate single-resource registration into `registerEndpoint()` orchestrator — REST API and TRPC mutation share identical probe → validate → register → discover flow
- Add server-side validation: HTTPS enforcement, x402 v1 rejection, missing input schema rejection, unsupported network rejection, SIWX warnings
- Fix UI: accurate button count, errors-only dropdown (no mixed warnings), consolidated post-registration failures, fix hint bolded outside scrollable area, truncated URLs in error list

## Architecture

### Validation & Registration Flow

```
UI form / AgentCash MCP / any future surface
         │
    ┌────┴────┐
    │ TRPC    │  REST API
    │ handler │  handler
    └────┬────┘
         │
   registerEndpoint()     ← one function owns the full single-resource flow
    ├── probeX402Endpoint()
    ├── registerResource()
    │    ├── validateResource()  ← ALL validation rules live here (pure, no side effects)
    │    │    ├── HTTPS enforcement
    │    │    ├── v1 rejection
    │    │    ├── no payment options
    │    │    ├── missing input schema
    │    │    ├── unsupported networks
    │    │    └── SIWX warning
    │    └── DB upsert + metadata scrape (only if validation passes)
    └── discoverSiblingResources()
```

The batch test (`testSingleResource` in `developer.ts`) calls the same `validateResource()`, so the pre-registration count always matches.

### Where to make changes

| Change | File | Function |
|---|---|---|
| **Add/change a validation rule** | `apps/scan/src/lib/resources.ts` | `validateResource()` — single chokepoint, both batch test and registration call it |
| **Add a post-registration step** | `apps/scan/src/lib/discovery/register-endpoint.ts` | `registerEndpoint()` for single-resource; `register-origin.ts` → `registerResourcesFromDiscovery()` for origin-level |
| **Change probe behavior** | `apps/scan/src/lib/discovery/probe.ts` | `probeX402Endpoint()` — all paths use this |
| **Change UI registration UX** | `apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx` | UI delegates to TRPC → `registerEndpoint()`, never does validation itself |

### Key design decisions

- **`validateResource()` is pure** — no DB, no network calls, no side effects. Takes URL + advisory, returns valid/invalid. This makes it safe to call from the batch test without registering anything.
- **`registerResource()` re-derives `x402Options`** after calling `validateResource()` rather than receiving them from the return value. This avoids lint issues with complex union types from `@agentcash/discovery` crossing the function boundary.
- **Missing input schema is a hard reject** (not a warning). This matches what `registerResource()` has always done — the batch test was previously inconsistent (treating it as a warning), causing the button count to overcount.

## Test plan
- [x] `surf.cascade.fyi` — v2 (OAuth) endpoints correctly rejected, v1 (x402) endpoints pass
- [x] `blockrun.ai` — 96 endpoints, button count matches registration outcome
- [x] `mpp.hyreagent.fun` — missing schema endpoints correctly rejected pre-registration
- [x] TypeScript, lint, format all pass
- [x] CI checks pass