### PR TITLE
fix: registration count mismatch + surface post-registration warnings

### DIFF
--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -158,13 +158,12 @@ export const RegisterResourceForm = () => {
   const hasDiscoveryResources =
     discoveryFound && actualDiscoveredResources.length > 0;
 
-  // After batch test completes, count only passing resources.
-  // Before batch test, fall back to total discovered count.
+  // Always show the discovered count. The server re-discovers independently
+  // and will process all resources, so showing only the batch-test-passing
+  // subset is misleading (the success message would show a higher number).
   const batchTestComplete =
     testedResources.length > 0 || failedResources.length > 0;
-  const registrableResourceCount = batchTestComplete
-    ? testedResources.length
-    : actualDiscoveredResources.length;
+  const registrableResourceCount = actualDiscoveredResources.length;
 
   const canUseManualMode = isValidUrl && !isOriginOnly;
   const currentUrlAlreadyInManualList = manualUrls.includes(normalizedUrl);
@@ -411,7 +410,9 @@ export const RegisterResourceForm = () => {
                   <Loader2 className="size-4 animate-spin mr-2" />
                   {`Verifying ${actualDiscoveredResources.length} endpoints...`}
                 </>
-              ) : batchTestComplete && registrableResourceCount === 0 ? (
+              ) : batchTestComplete &&
+                failedResources.length > 0 &&
+                testedResources.length === 0 ? (
                 `0 valid resources`
               ) : (
                 `Add API (${registrableResourceCount} resources)`

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
@@ -160,6 +160,10 @@ export interface DiscoveryPanelProps {
     failedDetails?: { url: string; error: string; status?: number }[];
     siwxDetails?: { url: string }[];
     skippedDetails?: { url: string; error: string; status?: number }[];
+    warningDetails?: {
+      url: string;
+      warnings: { code: string; severity: string; message: string }[];
+    }[];
   } | null;
   /** Called when "Register All" is clicked (required in register mode) */
   onRegisterAll?: () => void;
@@ -370,6 +374,67 @@ export function DiscoveryPanel({
               </p>
             </div>
           </div>
+        )}
+
+        {/* Warnings — registered but with issues */}
+        {bulkResult.warningDetails && bulkResult.warningDetails.length > 0 && (
+          <details className="border rounded-md group">
+            <summary className="p-3 cursor-pointer hover:bg-muted/50 font-medium text-sm flex items-center gap-2">
+              <ChevronDown className="size-4 transition-transform group-open:rotate-180" />
+              <AlertCircle className="size-4 text-yellow-600 shrink-0" />
+              {bulkResult.warningDetails.length} resource
+              {bulkResult.warningDetails.length === 1 ? '' : 's'} registered
+              with warnings
+            </summary>
+            <div className="p-4 pt-2 border-t space-y-2">
+              <div className="space-y-2 max-h-[400px] overflow-y-auto">
+                {bulkResult.warningDetails.map((entry, idx) => (
+                  <div
+                    key={idx}
+                    className="p-3 bg-muted/50 rounded border text-xs space-y-1"
+                  >
+                    <div className="flex items-start gap-2">
+                      <span className="text-muted-foreground shrink-0">
+                        URL:
+                      </span>
+                      <span className="font-mono break-all">
+                        {(() => {
+                          try {
+                            return new URL(entry.url).pathname;
+                          } catch {
+                            return entry.url;
+                          }
+                        })()}
+                      </span>
+                    </div>
+                    {entry.warnings.map((w, wi) => (
+                      <div key={wi} className="flex items-start gap-2">
+                        <span className="text-muted-foreground shrink-0">
+                          {w.severity === 'error'
+                            ? '!'
+                            : w.severity === 'warn'
+                              ? '!'
+                              : 'i'}
+                        </span>
+                        <span className="text-yellow-600 wrap-break-word">
+                          {w.message}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                ))}
+              </div>
+              <DiscoveryFixHint
+                className="font-medium pt-2"
+                warnings={bulkResult.warningDetails.flatMap(entry =>
+                  entry.warnings.map(w => ({
+                    url: entry.url,
+                    error: w.message,
+                  }))
+                )}
+              />
+            </div>
+          </details>
         )}
 
         {/* Not registered — consolidated skipped + failed */}

--- a/apps/scan/src/app/(app)/_components/discovery/use-discovery.ts
+++ b/apps/scan/src/app/(app)/_components/discovery/use-discovery.ts
@@ -107,6 +107,10 @@ export interface UseDiscoveryReturn {
     failedDetails?: { url: string; error: string; status?: number }[];
     siwxDetails?: { url: string }[];
     skippedDetails?: { url: string; error: string; status?: number }[];
+    warningDetails?: {
+      url: string;
+      warnings: { code: string; severity: string; message: string }[];
+    }[];
     originId?: string;
   } | null;
   bulkError: string | null;
@@ -351,6 +355,7 @@ export function useDiscovery({
           failedDetails: bulkData.failedDetails,
           siwxDetails: bulkData.siwxDetails,
           skippedDetails: bulkData.skippedDetails,
+          warningDetails: bulkData.warningDetails,
           originId: bulkData.originId,
         }
       : null,

--- a/apps/scan/src/hooks/use-register-from-origin.ts
+++ b/apps/scan/src/hooks/use-register-from-origin.ts
@@ -13,6 +13,10 @@ interface RegisterFromOriginSuccessData {
   failedDetails?: { url: string; error: string; status?: number }[];
   siwxDetails?: { url: string }[];
   skippedDetails?: { url: string; error: string; status?: number }[];
+  warningDetails?: {
+    url: string;
+    warnings: { code: string; severity: string; message: string }[];
+  }[];
   originId?: string;
 }
 
@@ -70,6 +74,7 @@ export function useRegisterFromOrigin(
         failedDetails: data.failedDetails,
         siwxDetails: data.siwxDetails,
         skippedDetails: data.skippedDetails,
+        warningDetails: data.warningDetails,
         originId: data.originId,
       });
     },

--- a/apps/scan/src/lib/discovery/register-origin.ts
+++ b/apps/scan/src/lib/discovery/register-origin.ts
@@ -63,6 +63,10 @@ export interface RegisterOriginResult {
   failedDetails: { url: string; error: string; status?: number }[];
   siwxDetails: { url: string }[];
   skippedDetails: { url: string; error: string; status?: number }[];
+  warningDetails: {
+    url: string;
+    warnings: { code: string; severity: string; message: string }[];
+  }[];
   originId: string | undefined;
 }
 
@@ -155,6 +159,10 @@ export async function registerResourcesFromDiscovery(
   const siwxResults: { url: string }[] = [];
   const failedResults: { url: string; error: string; status?: number }[] = [];
   const skippedResults: { url: string; error: string; status?: number }[] = [];
+  const warningResults: {
+    url: string;
+    warnings: { code: string; severity: string; message: string }[];
+  }[] = [];
   let originId: string | undefined;
 
   for (let i = 0; i < results.length; i++) {
@@ -178,6 +186,22 @@ export async function registerResourcesFromDiscovery(
           });
           if (!originId && 'resource' in value && value.resource?.origin?.id) {
             originId = value.resource.origin.id;
+          }
+          if (
+            'warnings' in value &&
+            Array.isArray(value.warnings) &&
+            value.warnings.length > 0
+          ) {
+            warningResults.push({
+              url: resourceUrl,
+              warnings: value.warnings.map(
+                (w: { code: string; severity: string; message: string }) => ({
+                  code: w.code,
+                  severity: w.severity,
+                  message: w.message,
+                })
+              ),
+            });
           }
         }
       } else if (
@@ -250,6 +274,7 @@ export async function registerResourcesFromDiscovery(
     failedDetails: failedResults,
     siwxDetails: siwxResults,
     skippedDetails: skippedResults,
+    warningDetails: warningResults,
     originId,
   };
 }


### PR DESCRIPTION
## Summary
- **Count mismatch fix**: The "Add API (N resources)" button was showing only batch-test-passing endpoints, but the server re-discovers independently and registers all found resources. This caused a confusing mismatch (e.g. button says 26 but success banner says 30). Now the button always shows the full discovered count.
- **Surface probe warnings**: Probe warnings (missing output schema, ownership issues, etc.) were collected during registration but silently dropped before reaching the client. Threaded `warningDetails` through the full stack and added a yellow collapsible section in the post-registration success view with a copy-prompt to help merchants fix the issues.
