### PR TITLE
Registration overhaul: SIWX Free endpoints, display filtering, schema detection, robustness

### DIFF
--- a/apps/scan/src/app/(app)/(home)/integration-spec/_content/markdown.ts
+++ b/apps/scan/src/app/(app)/(home)/integration-spec/_content/markdown.ts
@@ -105,6 +105,33 @@ SIWX routes are identity-gated, requiring a wallet proof but no payment. Agents 
 
 The scheme **must** be named \`siwx\`. Discovery resolves it by name. Routes with both \`x-payment-info\` and \`siwx\` security are classified as paid, not SIWX.
 
+## Free (Unprotected) Endpoints
+
+If your OpenAPI spec includes endpoints that are neither x402-paid nor SIWX (e.g. health checks, public read endpoints, webhooks), mark them with an empty \`security\` array:
+
+\`\`\`json
+{
+  "/v1/health": {
+    "get": {
+      "operationId": "health_check",
+      "security": [],
+      "summary": "Health check"
+    }
+  }
+}
+\`\`\`
+
+\`"security": []\` is the standard OpenAPI way to declare "no authentication required." Without it, the scanner can't distinguish free endpoints from paid ones that are misconfigured, and will probe them unnecessarily — producing errors and slowing registration.
+
+**Summary of endpoint classification:**
+
+| Type | OpenAPI Declaration | Scanner Behavior |
+|---|---|---|
+| Paid (x402) | \`x-payment-info\` + \`responses.402\` | Probed and registered |
+| Identity-gated (SIWX) | \`security: [{ "siwx": [] }]\` | Registered as Free (no probe) |
+| Free / public | \`security: []\` | Skipped entirely |
+| Unclassified (no declaration) | Nothing | Probed (may fail if not x402) |
+
 ## Common Failure Reasons
 
 | Error | Likely Cause | Fix |
@@ -112,4 +139,5 @@ The scheme **must** be named \`siwx\`. Discovery resolves it by name. Routes wit
 | Not Found | OpenAPI not found at \`{origin}/openapi.json\` | Add an OpenAPI document at \`{origin}/openapi.json\` |
 | Input/Output Schema Missing | Operation has no input or output schema | Add an input and output schema to the operation |
 | No Payment Modes Detected | No payment modes detected in the response | Add a valid payment mode to the response (x402) |
+| No valid x402 response / No 402 challenge | Endpoint is free but not marked as such | Add \`"security": []\` to the operation in your OpenAPI spec |
 `;

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -159,11 +159,13 @@ export const RegisterResourceForm = () => {
     discoveryFound && actualDiscoveredResources.length > 0;
 
   // Always show the discovered count. The server re-discovers independently
-  // and will process all resources, so showing only the batch-test-passing
-  // subset is misleading (the success message would show a higher number).
+  // After batch test completes, count only passing resources.
+  // Before batch test, fall back to total discovered count.
   const batchTestComplete =
     testedResources.length > 0 || failedResources.length > 0;
-  const registrableResourceCount = actualDiscoveredResources.length;
+  const registrableResourceCount = batchTestComplete
+    ? testedResources.length
+    : actualDiscoveredResources.length;
 
   const canUseManualMode = isValidUrl && !isOriginOnly;
   const currentUrlAlreadyInManualList = manualUrls.includes(normalizedUrl);

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -507,7 +507,7 @@ export const RegisterResourceForm = () => {
                 </strong>{' '}
                 {isV1Issue
                   ? 'This endpoint returns an x402 v1 response. x402scan only supports v2 — update your paywall to return the v2 format.'
-                  : 'They need to return a 402 payment challenge — ensure the x402 paywall runs before request validation, or mark the required parameters in your OpenAPI spec so we can probe automatically.'}
+                  : 'They need to return a 402 payment challenge — ensure the x402 paywall runs before request validation, or mark the required parameters in your OpenAPI spec so we can probe automatically. If these endpoints are free (not x402-paid), add "security": [] to their OpenAPI definition to exclude them from probing.'}
               </p>
               <div className="space-y-2 max-h-[360px] overflow-y-auto">
                 {failedResources.map((failed, idx) => (

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -829,7 +829,7 @@ function ProbeResult({
   } | null;
   urlOrigin: string | null;
   resources: string[];
-  testedResources?: { url: string }[];
+  testedResources?: { url: string; warnings?: { code: string }[] }[];
   failedResources?: { url: string }[];
   isBatchTestLoading?: boolean;
   authModeMap?: Record<string, string>;
@@ -837,6 +837,15 @@ function ProbeResult({
 }) {
   const testedUrls = useMemo(
     () => new Set(testedResources.map(r => r.url)),
+    [testedResources]
+  );
+  const warningUrls = useMemo(
+    () =>
+      new Set(
+        testedResources
+          .filter(r => r.warnings && r.warnings.length > 0)
+          .map(r => r.url)
+      ),
     [testedResources]
   );
   const failedUrls = useMemo(
@@ -871,14 +880,16 @@ function ProbeResult({
       ),
     [invalidResourcesMap]
   );
+  // Sort: failed → warnings → verified/siwx → skipped (non-paid)
   const sortedResources = useMemo(() => {
     const priority = (url: string) => {
-      if (nonPaidUrls.has(url)) return 2;
       if (invalidUrls.has(url) || failedUrls.has(url)) return 0;
-      return 1; // passed or siwx
+      if (warningUrls.has(url)) return 1;
+      if (testedUrls.has(url) || siwxUrls.has(url)) return 2;
+      return 3; // non-paid — skipped
     };
     return [...resources].sort((a, b) => priority(a) - priority(b));
-  }, [resources, invalidUrls, failedUrls, nonPaidUrls]);
+  }, [resources, invalidUrls, failedUrls, warningUrls, testedUrls, siwxUrls]);
 
   const [expanded, setExpanded] = useState(false);
   const previewResources = expanded
@@ -955,6 +966,8 @@ function ProbeResult({
                   <X className="size-3 text-red-500 shrink-0" />
                 ) : siwxUrls.has(resource) ? (
                   <Check className="size-3 text-primary shrink-0" />
+                ) : warningUrls.has(resource) ? (
+                  <TriangleAlert className="size-3 text-yellow-500 shrink-0" />
                 ) : testedUrls.has(resource) ? (
                   <Check className="size-3 text-green-600 shrink-0" />
                 ) : failedUrls.has(resource) ? (

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -6,6 +6,7 @@ import {
   Check,
   ChevronDown,
   Loader2,
+  Minus,
   Plus,
   CircleHelp,
   Trash2,
@@ -851,6 +852,16 @@ function ProbeResult({
       ),
     [authModeMap]
   );
+  const paidModes = useMemo(() => new Set(['paid', 'apiKey+paid']), []);
+  const nonPaidUrls = useMemo(
+    () =>
+      new Set(
+        resources.filter(
+          url => !siwxUrls.has(url) && !paidModes.has(authModeMap[url] ?? '')
+        )
+      ),
+    [resources, authModeMap, siwxUrls, paidModes]
+  );
   const invalidUrls = useMemo(
     () =>
       new Set(
@@ -862,12 +873,12 @@ function ProbeResult({
   );
   const sortedResources = useMemo(() => {
     const priority = (url: string) => {
+      if (nonPaidUrls.has(url)) return 2;
       if (invalidUrls.has(url) || failedUrls.has(url)) return 0;
-      if (testedUrls.has(url) || siwxUrls.has(url)) return 1;
-      return 2; // non-probed (not paid) — sort to bottom
+      return 1; // passed or siwx
     };
     return [...resources].sort((a, b) => priority(a) - priority(b));
-  }, [resources, invalidUrls, failedUrls, testedUrls, siwxUrls]);
+  }, [resources, invalidUrls, failedUrls, nonPaidUrls]);
 
   const [expanded, setExpanded] = useState(false);
   const previewResources = expanded
@@ -938,7 +949,9 @@ function ProbeResult({
                 key={resource}
                 className="font-mono truncate flex items-center gap-1.5"
               >
-                {invalidUrls.has(resource) ? (
+                {nonPaidUrls.has(resource) ? (
+                  <Minus className="size-3 text-muted-foreground/40 shrink-0" />
+                ) : invalidUrls.has(resource) ? (
                   <X className="size-3 text-red-500 shrink-0" />
                 ) : siwxUrls.has(resource) ? (
                   <Check className="size-3 text-primary shrink-0" />
@@ -946,11 +959,16 @@ function ProbeResult({
                   <Check className="size-3 text-green-600 shrink-0" />
                 ) : failedUrls.has(resource) ? (
                   <X className="size-3 text-red-500 shrink-0" />
-                ) : !isBatchTestLoading &&
-                  (testedUrls.size > 0 || failedUrls.size > 0) ? (
-                  <X className="size-3 text-red-500 shrink-0" />
                 ) : null}
-                {toPathLabel(resource)}
+                <span
+                  className={
+                    nonPaidUrls.has(resource)
+                      ? 'line-through text-muted-foreground/40'
+                      : undefined
+                  }
+                >
+                  {toPathLabel(resource)}
+                </span>
               </li>
             ))}
             {!expanded && hiddenCount > 0 && (

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -863,10 +863,11 @@ function ProbeResult({
   const sortedResources = useMemo(() => {
     const priority = (url: string) => {
       if (invalidUrls.has(url) || failedUrls.has(url)) return 0;
-      return 2;
+      if (testedUrls.has(url) || siwxUrls.has(url)) return 1;
+      return 2; // non-probed (not paid) — sort to bottom
     };
     return [...resources].sort((a, b) => priority(a) - priority(b));
-  }, [resources, invalidUrls, failedUrls]);
+  }, [resources, invalidUrls, failedUrls, testedUrls, siwxUrls]);
 
   const [expanded, setExpanded] = useState(false);
   const previewResources = expanded
@@ -944,6 +945,9 @@ function ProbeResult({
                 ) : testedUrls.has(resource) ? (
                   <Check className="size-3 text-green-600 shrink-0" />
                 ) : failedUrls.has(resource) ? (
+                  <X className="size-3 text-red-500 shrink-0" />
+                ) : !isBatchTestLoading &&
+                  (testedUrls.size > 0 || failedUrls.size > 0) ? (
                   <X className="size-3 text-red-500 shrink-0" />
                 ) : null}
                 {toPathLabel(resource)}

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -7,9 +7,7 @@ import {
   ChevronDown,
   Loader2,
   Minus,
-  Plus,
   CircleHelp,
-  Trash2,
   TriangleAlert,
   X,
 } from 'lucide-react';
@@ -20,8 +18,6 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from '@/components/ui/collapsible';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import {
   Tooltip,
   TooltipContent,
@@ -109,9 +105,6 @@ function getPrimaryProbeError(
 export const RegisterResourceForm = () => {
   const [url, setUrl] = useState('');
   const [httpWarning, setHttpWarning] = useState(false);
-  const [headers, setHeaders] = useState<{ name: string; value: string }[]>([]);
-  const [manualUrls, setManualUrls] = useState<string[]>([]);
-  const [manualListError, setManualListError] = useState<string | null>(null);
   const [manualProgress, setManualProgress] = useState<{
     current: number;
     total: number;
@@ -152,11 +145,6 @@ export const RegisterResourceForm = () => {
 
   const normalizedUrl = useMemo(() => normalizeUrl(url.trim()), [url]);
 
-  const queueOrigin = useMemo(
-    () => (manualUrls.length > 0 ? safeGetOrigin(manualUrls[0] ?? '') : null),
-    [manualUrls]
-  );
-
   const hasDiscoveryResources =
     discoveryFound && actualDiscoveredResources.length > 0;
 
@@ -173,18 +161,8 @@ export const RegisterResourceForm = () => {
     : actualDiscoveredResources.length;
 
   const canUseManualMode = isValidUrl && !isOriginOnly;
-  const currentUrlAlreadyInManualList = manualUrls.includes(normalizedUrl);
-  const canAddCurrentUrl =
-    canUseManualMode &&
-    !currentUrlAlreadyInManualList &&
-    (!queueOrigin || queueOrigin === urlOrigin);
 
-  const manualTargets =
-    manualUrls.length > 0
-      ? manualUrls
-      : canUseManualMode
-        ? [normalizedUrl]
-        : [];
+  const manualTargets = canUseManualMode ? [normalizedUrl] : [];
 
   const testedResourceByUrl = useMemo(() => {
     const map = new Map<string, (typeof testedResources)[number]>();
@@ -209,27 +187,10 @@ export const RegisterResourceForm = () => {
 
   const activeBulkResult = manualResult ?? bulkData ?? null;
   const activeSummaryOrigin = manualResult?.origin ?? urlOrigin;
-  const requestHeaders = useMemo(() => {
-    const entries = headers
-      .map(header => ({
-        name: header.name.trim(),
-        value: header.value,
-      }))
-      .filter(header => header.name.length > 0);
-
-    if (entries.length === 0) {
-      return undefined;
-    }
-
-    return Object.fromEntries(
-      entries.map(header => [header.name, header.value])
-    );
-  }, [headers]);
 
   const resetStateForNewRun = () => {
     setManualResult(null);
     setManualProgress(null);
-    setManualListError(null);
     resetBulk();
   };
 
@@ -237,40 +198,12 @@ export const RegisterResourceForm = () => {
     setUrl(nextUrl);
     setManualResult(null);
     setManualProgress(null);
-    setManualListError(null);
     resetBulk();
-  };
-
-  const handleAddCurrentUrl = () => {
-    if (!canUseManualMode) {
-      return;
-    }
-
-    if (queueOrigin && queueOrigin !== urlOrigin) {
-      setManualListError('All manual URLs must share the same origin.');
-      return;
-    }
-
-    if (!currentUrlAlreadyInManualList) {
-      setManualUrls(current => [...current, normalizedUrl]);
-    }
-
-    setManualListError(null);
-    setManualResult(null);
-    setManualProgress(null);
-  };
-
-  const handleRemoveManualUrl = (targetUrl: string) => {
-    setManualUrls(current => current.filter(item => item !== targetUrl));
-    setManualResult(null);
-    setManualProgress(null);
-    setManualListError(null);
   };
 
   const handleRegisterDiscovered = () => {
     setManualResult(null);
     setManualProgress(null);
-    setManualListError(null);
     handleRegisterAll();
   };
 
@@ -301,7 +234,6 @@ export const RegisterResourceForm = () => {
       try {
         const result = await registerMutation.mutateAsync({
           url: targetUrl,
-          headers: requestHeaders,
         });
 
         if (result.success) {
@@ -353,12 +285,6 @@ export const RegisterResourceForm = () => {
     await runManualRegistration([normalizedUrl]);
   };
 
-  // Show advanced only after discovery fails or user has manual URLs
-  const showAdvanced =
-    (isValidUrl && !isDiscoveryLoading && !hasDiscoveryResources) ||
-    manualUrls.length > 0 ||
-    headers.length > 0;
-
   const isLoading = isRegisteringAll || isRegisteringManual;
 
   return (
@@ -388,9 +314,6 @@ export const RegisterResourceForm = () => {
               <TriangleAlert className="size-3 shrink-0" />
               x402 requires HTTPS. We&apos;ve upgraded your URL automatically.
             </p>
-          )}
-          {manualListError && (
-            <p className="text-xs text-red-600">{manualListError}</p>
           )}
         </div>
 
@@ -552,129 +475,6 @@ export const RegisterResourceForm = () => {
             </div>
           );
         })()}
-
-      {/* Advanced — only when relevant */}
-      {showAdvanced && (
-        <Collapsible>
-          <CollapsibleTrigger asChild>
-            <button className="text-xs text-muted-foreground/60 hover:text-muted-foreground transition-colors flex items-center gap-1">
-              Advanced
-              <ChevronDown className="size-3" />
-            </button>
-          </CollapsibleTrigger>
-          <CollapsibleContent className="pt-3 space-y-4">
-            {/* Headers */}
-            <div className="space-y-2">
-              <div className="flex items-center justify-between">
-                <Label className="text-xs text-muted-foreground">
-                  Custom Headers
-                </Label>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="xs"
-                  onClick={() =>
-                    setHeaders(current => [...current, { name: '', value: '' }])
-                  }
-                  className="size-fit px-1 text-xs"
-                >
-                  <Plus className="size-3 mr-1" />
-                  Add
-                </Button>
-              </div>
-              {headers.map((header, index) => (
-                <div key={index} className="flex gap-1 items-center">
-                  <Input
-                    type="text"
-                    placeholder="Name"
-                    value={header.name}
-                    onChange={event =>
-                      setHeaders(current =>
-                        current.map((item, itemIndex) =>
-                          itemIndex === index
-                            ? { ...item, name: event.target.value }
-                            : item
-                        )
-                      )
-                    }
-                  />
-                  <Input
-                    type="text"
-                    placeholder="Value"
-                    value={header.value}
-                    onChange={event =>
-                      setHeaders(current =>
-                        current.map((item, itemIndex) =>
-                          itemIndex === index
-                            ? { ...item, value: event.target.value }
-                            : item
-                        )
-                      )
-                    }
-                  />
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    onClick={() =>
-                      setHeaders(current =>
-                        current.filter((_, itemIndex) => itemIndex !== index)
-                      )
-                    }
-                    className="shrink-0"
-                  >
-                    <Trash2 className="size-4" />
-                  </Button>
-                </div>
-              ))}
-            </div>
-
-            {/* Manual URLs */}
-            {!hasDiscoveryResources && (
-              <div className="space-y-2">
-                <div className="flex items-center justify-between">
-                  <Label className="text-xs text-muted-foreground">
-                    Manual URLs
-                  </Label>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="xs"
-                    onClick={handleAddCurrentUrl}
-                    disabled={!canAddCurrentUrl || isRegisteringManual}
-                    className="size-fit px-1 text-xs"
-                  >
-                    <Plus className="size-3 mr-1" />
-                    Add Current URL
-                  </Button>
-                </div>
-                {manualUrls.length > 0 && (
-                  <ul className="space-y-1">
-                    {manualUrls.map(item => (
-                      <li
-                        key={item}
-                        className="flex items-center gap-2 text-xs"
-                      >
-                        <code className="font-mono break-all flex-1 text-muted-foreground">
-                          {item}
-                        </code>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon"
-                          onClick={() => handleRemoveManualUrl(item)}
-                        >
-                          <Trash2 className="size-4" />
-                        </Button>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </div>
-            )}
-          </CollapsibleContent>
-        </Collapsible>
-      )}
 
       {/* Errors — endpoints that won't be registered */}
       {(() => {

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -522,10 +522,6 @@ export const RegisterResourceForm = () => {
               </div>
               <DiscoveryFixHint
                 className="font-medium"
-                needsSetup={
-                  failedResources.length > 0 && testedResources.length === 0
-                }
-                v1Migration={isV1Issue}
                 failedResources={failedResources.map(r => ({
                   url: r.url,
                   error: getPrimaryProbeError(r),

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -861,16 +861,17 @@ function ProbeResult({
       ),
     [authModeMap]
   );
-  const paidModes = useMemo(() => new Set(['paid', 'apiKey+paid']), []);
-  const nonPaidUrls = useMemo(
-    () =>
-      new Set(
-        resources.filter(
-          url => !siwxUrls.has(url) && !paidModes.has(authModeMap[url] ?? '')
-        )
-      ),
-    [resources, authModeMap, siwxUrls, paidModes]
-  );
+  const nonPaidUrls = useMemo(() => {
+    const paid = new Set(['paid', 'apiKey+paid']);
+    return new Set(
+      resources.filter(url => {
+        const mode = authModeMap[url];
+        // Only mark as non-paid if discovery explicitly classified it
+        // as non-paid. If authMode is missing, don't pre-judge.
+        return mode !== undefined && mode !== 'siwx' && !paid.has(mode);
+      })
+    );
+  }, [resources, authModeMap]);
   const invalidUrls = useMemo(
     () =>
       new Set(
@@ -880,16 +881,17 @@ function ProbeResult({
       ),
     [invalidResourcesMap]
   );
-  // Sort: failed → warnings → verified/siwx → skipped (non-paid)
+  // Sort: errors → warnings → SIWX (blue) → verified (green) → skipped
   const sortedResources = useMemo(() => {
     const priority = (url: string) => {
       if (invalidUrls.has(url) || failedUrls.has(url)) return 0;
       if (warningUrls.has(url)) return 1;
-      if (testedUrls.has(url) || siwxUrls.has(url)) return 2;
-      return 3; // non-paid — skipped
+      if (siwxUrls.has(url)) return 2;
+      if (testedUrls.has(url)) return 3;
+      return 4; // non-paid — skipped
     };
     return [...resources].sort((a, b) => priority(a) - priority(b));
-  }, [resources, invalidUrls, failedUrls, warningUrls, testedUrls, siwxUrls]);
+  }, [resources, invalidUrls, failedUrls, warningUrls, siwxUrls, testedUrls]);
 
   const [expanded, setExpanded] = useState(false);
   const previewResources = expanded

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -533,6 +533,63 @@ export const RegisterResourceForm = () => {
         );
       })()}
 
+      {/* Warnings — endpoints that will register but have issues */}
+      {(() => {
+        if (activeBulkResult || isBatchTestLoading) return null;
+        const resourcesWithWarnings = testedResources.filter(
+          r => r.warnings && r.warnings.length > 0
+        );
+        if (resourcesWithWarnings.length === 0) return null;
+
+        return (
+          <Collapsible>
+            <CollapsibleTrigger asChild>
+              <button className="text-xs text-yellow-600 dark:text-yellow-500 flex items-center gap-1 hover:text-yellow-700 transition-colors">
+                <ChevronDown className="size-3" />
+                {resourcesWithWarnings.length} endpoint
+                {resourcesWithWarnings.length === 1 ? '' : 's'} with warnings
+                (Not blocking)
+              </button>
+            </CollapsibleTrigger>
+            <CollapsibleContent className="pt-2 space-y-3">
+              <p className="text-xs text-muted-foreground">
+                These endpoints will still be registered, but have issues that
+                may affect agent compatibility.
+              </p>
+              <div className="space-y-2 max-h-[360px] overflow-y-auto">
+                {resourcesWithWarnings.map((r, idx) => (
+                  <div
+                    key={`${r.url}-${idx}`}
+                    className="p-2 bg-muted/50 rounded border text-xs space-y-1"
+                  >
+                    <div className="font-mono text-muted-foreground truncate">
+                      {toPathLabel(r.url)}
+                    </div>
+                    {r.warnings?.map((w, wi) => (
+                      <div
+                        key={wi}
+                        className="text-yellow-600 dark:text-yellow-500"
+                      >
+                        {w.message}
+                      </div>
+                    ))}
+                  </div>
+                ))}
+              </div>
+              <DiscoveryFixHint
+                className="font-medium"
+                warnings={resourcesWithWarnings.flatMap(r =>
+                  (r.warnings ?? []).map(w => ({
+                    url: r.url,
+                    error: w.message,
+                  }))
+                )}
+              />
+            </CollapsibleContent>
+          </Collapsible>
+        );
+      })()}
+
       {/* Bulk result */}
       {activeBulkResult && activeSummaryOrigin ? (
         <DiscoveryPanel

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -138,6 +138,7 @@ export const RegisterResourceForm = () => {
     resetBulk,
     preview,
     isBatchTestLoading,
+    batchTestProgress,
     testedResources,
     failedResources,
     retryResource,
@@ -159,13 +160,16 @@ export const RegisterResourceForm = () => {
   const hasDiscoveryResources =
     discoveryFound && actualDiscoveredResources.length > 0;
 
-  // Always show the discovered count. The server re-discovers independently
-  // After batch test completes, count only passing resources.
+  // After batch test completes, count passing paid resources + SIWX (free) endpoints.
+  // SIWX endpoints aren't probed, so they aren't in testedResources — add them separately.
   // Before batch test, fall back to total discovered count.
   const batchTestComplete =
     testedResources.length > 0 || failedResources.length > 0;
+  const siwxCount = actualDiscoveredResources.filter(
+    url => authModeMap[url] === 'siwx'
+  ).length;
   const registrableResourceCount = batchTestComplete
-    ? testedResources.length
+    ? testedResources.length + siwxCount
     : actualDiscoveredResources.length;
 
   const canUseManualMode = isValidUrl && !isOriginOnly;
@@ -411,7 +415,9 @@ export const RegisterResourceForm = () => {
               ) : isBatchTestLoading ? (
                 <>
                   <Loader2 className="size-4 animate-spin mr-2" />
-                  {`Verifying ${actualDiscoveredResources.length} endpoints...`}
+                  {batchTestProgress
+                    ? `Checking ${batchTestProgress.checked}/${batchTestProgress.total} endpoints...`
+                    : `Checking ${actualDiscoveredResources.length} endpoints...`}
                 </>
               ) : batchTestComplete &&
                 failedResources.length > 0 &&
@@ -881,7 +887,7 @@ function ProbeResult({
       ),
     [invalidResourcesMap]
   );
-  // Sort: errors → warnings → SIWX (blue) → verified (green) → skipped
+  // Sort: errors → warnings → free (SIWX) → verified → skipped
   const sortedResources = useMemo(() => {
     const priority = (url: string) => {
       if (invalidUrls.has(url) || failedUrls.has(url)) return 0;
@@ -967,7 +973,7 @@ function ProbeResult({
                 ) : invalidUrls.has(resource) ? (
                   <X className="size-3 text-red-500 shrink-0" />
                 ) : siwxUrls.has(resource) ? (
-                  <Check className="size-3 text-primary shrink-0" />
+                  <Check className="size-3 text-green-600 shrink-0" />
                 ) : warningUrls.has(resource) ? (
                   <TriangleAlert className="size-3 text-yellow-500 shrink-0" />
                 ) : testedUrls.has(resource) ? (

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-actions.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-actions.tsx
@@ -6,131 +6,99 @@ import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard';
 
-// Duplicated from discovery/_constants/prompts.ts to avoid cross-directory
-// import issues with Turbopack in dev. Keep in sync.
-const GENERIC_PROMPT =
-  "Read https://agentcash.dev/merchants.md and follow the guide to make my API discoverable and payable by agents. Do everything automatically. Only ask me if you need input you can't determine yourself.";
-
-function buildErrorPrompt(
-  resources: { url: string; error: string; status?: number }[],
-  missingSchemaUrls?: string[]
-): string {
-  const lines = resources.map(r => {
-    const status = r.status ? ` (HTTP ${r.status})` : '';
-    return `- ${r.url}: ${r.error}${status}`;
-  });
-
-  let schemaSection = '';
-  if (missingSchemaUrls && missingSchemaUrls.length > 0) {
-    const schemaLines = missingSchemaUrls.map(u => `- ${u}`);
-    schemaSection = `
-
-These endpoints are also missing input schemas (agents won't know what request to send):
-
-${schemaLines.join('\n')}
-
-For each, add a requestBody schema and/or parameter definitions to the OpenAPI spec.`;
-  }
-
-  return `These x402 endpoints failed registration on x402scan.com:
-
-${lines.join('\n')}${schemaSection}
-
-Read https://x402scan.com/discovery/spec for the full discovery specification.
-
-For each failing endpoint:
-1. Verify the endpoint returns a 402 status with valid x402 payment headers when called without payment
-2. Check that request validation (body schema, query params) doesn't reject the request before the x402 middleware runs
-3. In the OpenAPI spec, mark all required query parameters with "required": true — x402scan probes endpoints automatically and needs to know which parameters are required to test successfully
-4. Ensure the endpoint is listed in your OpenAPI spec with the correct method and input schema
-
-Fix each issue. Only ask me if you need input you can't determine yourself.`;
-}
-
-function buildWarningPrompt(
-  resources: { url: string; error: string; status?: number }[]
-): string {
-  const lines = resources.map(r => {
-    const status = r.status ? ` (HTTP ${r.status})` : '';
-    return `- ${r.url}: ${r.error}${status}`;
-  });
-  return `These endpoints were found in my API spec but triggered warnings during registration on x402scan.com:
-
-${lines.join('\n')}
-
-If these endpoints are meant to be paid, read https://x402scan.com/discovery/spec and ensure each one returns a 402 status with valid x402 payment headers when called without payment.
-
-If they're intentionally free, remove them from the x402 discovery document so they don't show as warnings.
-
-Only ask me if you need input you can't determine yourself.`;
-}
-
-const V1_MIGRATION_PROMPT = `My x402 endpoints are returning v1 payment responses. Migrate them to the x402 v2 spec.
-
-Key changes from v1 to v2:
-- The 402 response body must include \`"x402Version": 2\`
-- The \`accepts\` array replaces \`maxAmountRequired\` with \`amount\` (the exact price for this request)
-- Each entry in \`accepts\` must include: scheme, network, asset, amount, payTo
-- Remove \`maxTimeoutSeconds\` from accepts entries (moved to top-level \`x402Version\` sibling if needed)
-
-Read https://x402scan.com/discovery/spec for the full v2 specification.
-
-Update every endpoint that returns a v1 response. Only ask me if you need input you can't determine yourself.`;
-
-const CREATE_OPENAPI_PROMPT = `My API doesn't have a discovery document yet. Create an OpenAPI spec (openapi.json) that describes my x402-paid endpoints, then serve it so x402scan.com can discover them.
+const SETUP_PROMPT = `My API doesn't have a discovery document yet. Create an OpenAPI spec (openapi.json) that describes my endpoints, then serve it so x402scan.com can discover them.
 
 Read https://x402scan.com/discovery/spec for the full discovery specification.
 
 Steps:
-1. Identify all paid endpoints in my API
+1. Identify all endpoints in my API — both paid (x402) and free (identity-gated)
 2. Create an openapi.json with paths, methods, request/response schemas, and descriptions
 3. Serve it at /openapi.json (or /.well-known/x402 pointing to it)
-4. Ensure each paid endpoint returns a 402 with valid x402 v2 payment headers when called without payment
+4. Paid endpoints must return a 402 with valid x402 v2 payment headers when called without payment
+5. Free endpoints should declare \`"security": []\` in the OpenAPI spec
 
 Do everything automatically. Only ask me if you need input you can't determine yourself.`;
 
-const ADD_SCHEMA_PROMPT = `Some of my x402 endpoints are missing input/output schemas in the OpenAPI spec. Without these, agents can find and pay for the endpoint but don't know what request to send.
+function buildConsolidatedPrompt({
+  failedResources,
+  warnings,
+  missingSchemaResources,
+}: {
+  failedResources?: { url: string; error: string; status?: number }[];
+  warnings?: { url: string; error: string; status?: number }[];
+  missingSchemaResources?: string[];
+}): string {
+  const sections: string[] = [];
+
+  if (failedResources && failedResources.length > 0) {
+    const lines = failedResources.map(r => {
+      const status = r.status ? ` (HTTP ${r.status})` : '';
+      return `- ${r.url}: ${r.error}${status}`;
+    });
+    sections.push(`Errors (these endpoints failed and won't be registered):
+
+${lines.join('\n')}`);
+  }
+
+  if (warnings && warnings.length > 0) {
+    const lines = warnings.map(r => {
+      const status = r.status ? ` (HTTP ${r.status})` : '';
+      return `- ${r.url}: ${r.error}${status}`;
+    });
+    sections.push(`Warnings (registered but with issues):
+
+${lines.join('\n')}`);
+  }
+
+  if (missingSchemaResources && missingSchemaResources.length > 0) {
+    const lines = missingSchemaResources.map(u => `- ${u}`);
+    sections.push(`Missing input schemas (agents won't know what request to send):
+
+${lines.join('\n')}`);
+  }
+
+  const issueBlock =
+    sections.length > 0
+      ? sections.join('\n\n')
+      : 'Some endpoints have issues during registration on x402scan.com.';
+
+  return `${issueBlock}
 
 Read https://x402scan.com/discovery/spec for the full discovery specification.
 
-For each endpoint in my OpenAPI spec:
-1. Add a requestBody schema describing the expected JSON body (field names, types, descriptions, required fields)
-2. Add response schemas describing what the endpoint returns
-3. Add parameter definitions for any required query parameters
+To fix these:
+1. Paid endpoints must return a 402 status with valid x402 v2 payment headers when called without payment
+2. Request validation (body schema, query params) must not reject the request before the x402 middleware runs
+3. Mark all required query parameters with "required": true in the OpenAPI spec — x402scan probes endpoints automatically
+4. Add request/response schemas to the OpenAPI spec so agents know what to send and expect back
+5. Free (identity-gated) endpoints should declare \`"security": []\` in the OpenAPI spec
 
-Do everything automatically. Only ask me if you need input you can't determine yourself.`;
+Fix each issue. Only ask me if you need input you can't determine yourself.`;
+}
 
 export function DiscoveryActions({
   iconOnly,
   label,
   failedResources,
   warnings,
-  v1Migration,
   noDiscovery,
-  missingSchema,
   missingSchemaResources,
 }: {
   iconOnly?: boolean;
   label?: string;
   failedResources?: { url: string; error: string; status?: number }[];
   warnings?: { url: string; error: string; status?: number }[];
-  v1Migration?: boolean;
   noDiscovery?: boolean;
-  missingSchema?: boolean;
-  /** URLs missing input schemas — merged into the error prompt when both exist. */
+  /** URLs missing input schemas — merged into the consolidated prompt. */
   missingSchemaResources?: string[];
 }) {
   const prompt = noDiscovery
-    ? CREATE_OPENAPI_PROMPT
-    : v1Migration
-      ? V1_MIGRATION_PROMPT
-      : failedResources && failedResources.length > 0
-        ? buildErrorPrompt(failedResources, missingSchemaResources)
-        : missingSchema
-          ? ADD_SCHEMA_PROMPT
-          : warnings && warnings.length > 0
-            ? buildWarningPrompt(warnings)
-            : GENERIC_PROMPT;
+    ? SETUP_PROMPT
+    : buildConsolidatedPrompt({
+        failedResources,
+        warnings,
+        missingSchemaResources,
+      });
 
   const { isCopied, copyToClipboard } = useCopyToClipboard(() => {
     toast.success('Copied prompt for agents');

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-actions.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-actions.tsx
@@ -57,10 +57,13 @@ ${lines.join('\n')}`);
 ${lines.join('\n')}`);
   }
 
-  const issueBlock =
-    sections.length > 0
-      ? sections.join('\n\n')
-      : 'Some endpoints have issues during registration on x402scan.com.';
+  // Shouldn't be reachable (prompt only shown when there are issues), but
+  // fall back to the spec link rather than a misleading generic message.
+  if (sections.length === 0) {
+    return 'Read https://x402scan.com/discovery/spec for the full discovery specification. Follow the guide to ensure your endpoints are correctly configured for x402scan.';
+  }
+
+  const issueBlock = sections.join('\n\n');
 
   return `${issueBlock}
 

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
@@ -1179,6 +1179,17 @@ function RegisterModeResourceList({
 
   if (allResources.length === 0) return null;
 
+  // Sort: invalid → free (SIWX) → new → already registered
+  const sortedResources = [...allResources].sort((a, b) => {
+    const priority = (r: (typeof allResources)[number]) => {
+      if (invalidResourcesMap[r.url]?.invalid) return 0;
+      if (authModeMap[r.url] === 'siwx') return 1;
+      if (!r.isRegistered) return 2;
+      return 3; // already registered
+    };
+    return priority(a) - priority(b);
+  });
+
   return (
     <div className="border rounded-md overflow-hidden mt-3">
       <table className="w-full text-sm">
@@ -1190,87 +1201,91 @@ function RegisterModeResourceList({
           </tr>
         </thead>
         <tbody>
-          {allResources.map(({ url, source: resourceSource, isRegistered }) => {
-            const pathname = (() => {
-              try {
-                return decodeURIComponent(new URL(url).pathname);
-              } catch {
-                return url;
-              }
-            })();
+          {sortedResources.map(
+            ({ url, source: resourceSource, isRegistered }) => {
+              const pathname = (() => {
+                try {
+                  return decodeURIComponent(new URL(url).pathname);
+                } catch {
+                  return url;
+                }
+              })();
 
-            return (
-              <tr key={url} className="border-t">
-                <td className="px-3 py-2">
-                  <span className="font-mono text-sm">{pathname}</span>
-                </td>
-                <td className="px-3 py-2">
-                  <span
-                    className={cn(
-                      'text-xs px-1.5 py-0.5 rounded',
-                      resourceSource === 'entered'
-                        ? 'bg-blue-500/10 text-blue-600'
-                        : 'bg-muted text-muted-foreground'
-                    )}
-                  >
-                    {resourceSource === 'entered'
-                      ? 'Manually Entered'
-                      : resourceSource === 'openapi'
-                        ? 'OpenAPI'
-                        : resourceSource === 'probe'
-                          ? 'Runtime Probe'
-                          : resourceSource === 'interop-mpp'
-                            ? '/.well-known/mpp'
-                            : '/.well-known/x402'}
-                  </span>
-                </td>
-                <td className="px-3 py-2">
-                  <div className="flex items-center gap-2">
-                    {isRegistered ? (
-                      <span className="flex items-center gap-1 text-xs text-green-600">
-                        <Check className="size-3" />
-                        Already Registered
-                      </span>
-                    ) : (
-                      <span className="text-xs text-muted-foreground">New</span>
-                    )}
-                    {authModeMap[url] === 'siwx' && (
-                      <Tooltip>
-                        <TooltipTrigger>
-                          <span className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded bg-green-600/10 border border-green-600 text-green-600">
-                            <ShieldCheck className="size-3" />
-                            Free
-                          </span>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <p className="text-xs">
-                            Free endpoint — requires wallet authentication but
-                            no payment.
-                          </p>
-                        </TooltipContent>
-                      </Tooltip>
-                    )}
-                    {invalidResourcesMap[url]?.invalid && (
-                      <Tooltip>
-                        <TooltipTrigger>
-                          <span className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded bg-yellow-600/10 border border-yellow-600 text-yellow-600">
-                            <AlertCircle className="size-3" />
-                            INVALID
-                          </span>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <p className="text-xs">
-                            {invalidResourcesMap[url]?.reason ??
-                              'Invalid format'}
-                          </p>
-                        </TooltipContent>
-                      </Tooltip>
-                    )}
-                  </div>
-                </td>
-              </tr>
-            );
-          })}
+              return (
+                <tr key={url} className="border-t">
+                  <td className="px-3 py-2">
+                    <span className="font-mono text-sm">{pathname}</span>
+                  </td>
+                  <td className="px-3 py-2">
+                    <span
+                      className={cn(
+                        'text-xs px-1.5 py-0.5 rounded',
+                        resourceSource === 'entered'
+                          ? 'bg-blue-500/10 text-blue-600'
+                          : 'bg-muted text-muted-foreground'
+                      )}
+                    >
+                      {resourceSource === 'entered'
+                        ? 'Manually Entered'
+                        : resourceSource === 'openapi'
+                          ? 'OpenAPI'
+                          : resourceSource === 'probe'
+                            ? 'Runtime Probe'
+                            : resourceSource === 'interop-mpp'
+                              ? '/.well-known/mpp'
+                              : '/.well-known/x402'}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2">
+                    <div className="flex items-center gap-2">
+                      {isRegistered ? (
+                        <span className="flex items-center gap-1 text-xs text-green-600">
+                          <Check className="size-3" />
+                          Already Registered
+                        </span>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">
+                          New
+                        </span>
+                      )}
+                      {authModeMap[url] === 'siwx' && (
+                        <Tooltip>
+                          <TooltipTrigger>
+                            <span className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded bg-green-600/10 border border-green-600 text-green-600">
+                              <ShieldCheck className="size-3" />
+                              Free
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p className="text-xs">
+                              Free endpoint — requires wallet authentication but
+                              no payment.
+                            </p>
+                          </TooltipContent>
+                        </Tooltip>
+                      )}
+                      {invalidResourcesMap[url]?.invalid && (
+                        <Tooltip>
+                          <TooltipTrigger>
+                            <span className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded bg-yellow-600/10 border border-yellow-600 text-yellow-600">
+                              <AlertCircle className="size-3" />
+                              INVALID
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p className="text-xs">
+                              {invalidResourcesMap[url]?.reason ??
+                                'Invalid format'}
+                            </p>
+                          </TooltipContent>
+                        </Tooltip>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              );
+            }
+          )}
         </tbody>
       </table>
     </div>

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
@@ -899,7 +899,7 @@ function FailedResourceCard({
   const isV1Error =
     failedDetails?.error?.includes('v1 response detected') ?? false;
   const errorMessage = isSiwx
-    ? 'SIWX (identity-gated, no payment)'
+    ? 'Free (wallet auth, no payment)'
     : isInvalid
       ? (invalidInfo?.reason ?? 'Invalid format')
       : x402Parsed
@@ -913,7 +913,7 @@ function FailedResourceCard({
         className={cn(
           'overflow-hidden',
           isSiwx
-            ? 'border-primary'
+            ? 'border-green-600'
             : isInvalid
               ? 'border-yellow-500/30'
               : 'border-red-500/30'
@@ -931,13 +931,13 @@ function FailedResourceCard({
                   className={cn(
                     'font-mono px-1 rounded-md text-xs shrink-0',
                     isSiwx
-                      ? 'bg-primary/10 border border-primary text-primary'
+                      ? 'bg-green-600/10 border border-green-600 text-green-600'
                       : isInvalid
                         ? 'bg-yellow-600/10 border border-yellow-600 text-yellow-600'
                         : 'bg-red-600/10 border border-red-600 text-red-600'
                   )}
                 >
-                  {isSiwx ? 'SIWX' : isInvalid ? 'INVALID' : 'ERR'}
+                  {isSiwx ? 'FREE' : isInvalid ? 'INVALID' : 'ERR'}
                 </div>
                 <span className="font-mono text-sm truncate">{pathname}</span>
               </div>
@@ -1237,15 +1237,15 @@ function RegisterModeResourceList({
                     {authModeMap[url] === 'siwx' && (
                       <Tooltip>
                         <TooltipTrigger>
-                          <span className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded bg-primary/10 border border-primary text-primary">
+                          <span className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded bg-green-600/10 border border-green-600 text-green-600">
                             <ShieldCheck className="size-3" />
-                            SIWX
+                            Free
                           </span>
                         </TooltipTrigger>
                         <TooltipContent>
                           <p className="text-xs">
-                            Identity-gated route (Sign-In With X). Requires a
-                            wallet proof; no payment.
+                            Free endpoint — requires wallet authentication but
+                            no payment.
                           </p>
                         </TooltipContent>
                       </Tooltip>

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
@@ -384,7 +384,7 @@ export function DiscoveryPanel({
               <AlertCircle className="size-4 text-yellow-600 shrink-0" />
               {bulkResult.warningDetails.length} resource
               {bulkResult.warningDetails.length === 1 ? '' : 's'} registered
-              with warnings
+              with warnings (Not blocking)
             </summary>
             <div className="p-4 pt-2 border-t space-y-2">
               <div className="space-y-2 max-h-[400px] overflow-y-auto">

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
@@ -65,45 +65,26 @@ export function DiscoveryFixHint({
   className,
   failedResources,
   warnings,
-  v1Migration,
   noDiscovery,
-  needsSetup,
-  missingSchema,
   missingSchemaResources,
 }: {
   className?: string;
   failedResources?: { url: string; error: string; status?: number }[];
   warnings?: { url: string; error: string; status?: number }[];
-  v1Migration?: boolean;
   noDiscovery?: boolean;
-  /** All endpoints failed — treat as needing x402 setup from scratch. */
-  needsSetup?: boolean;
-  missingSchema?: boolean;
   missingSchemaResources?: string[];
 }) {
   const label = noDiscovery
     ? 'Have your agent create an OpenAPI spec for your resource'
-    : needsSetup
-      ? 'Set up x402 with a prompt'
-      : v1Migration
-        ? 'Migrate to x402 v2 spec in one prompt'
-        : missingSchema
-          ? 'Add input schemas with a prompt'
-          : 'Have your agent fix the errors with a prompt';
+    : 'Have your agent fix the issues with a prompt';
 
   return (
     <p className={cn('text-sm text-foreground', className)}>
       <DiscoveryActions
         label={label}
-        {...(needsSetup
-          ? {}
-          : {
-              failedResources,
-              warnings,
-              missingSchema,
-              missingSchemaResources,
-            })}
-        v1Migration={v1Migration}
+        failedResources={failedResources}
+        warnings={warnings}
+        missingSchemaResources={missingSchemaResources}
         noDiscovery={noDiscovery}
       />{' '}
       or{' '}
@@ -979,19 +960,15 @@ function FailedResourceCard({
               ]}
             />
 
-            {isV1Error ? (
-              <DiscoveryFixHint v1Migration />
-            ) : (
-              <DiscoveryFixHint
-                failedResources={[
-                  {
-                    url: resourceUrl,
-                    error: errorMessage,
-                    status: failedDetails?.statusCode,
-                  },
-                ]}
-              />
-            )}
+            <DiscoveryFixHint
+              failedResources={[
+                {
+                  url: resourceUrl,
+                  error: errorMessage,
+                  status: failedDetails?.statusCode,
+                },
+              ]}
+            />
 
             {/* Sample body input — shown for reachable endpoints that didn't return 402 */}
             {onRetry && !isSiwx && !isV1Error && (

--- a/apps/scan/src/app/(app)/_components/discovery/use-batch-test.ts
+++ b/apps/scan/src/app/(app)/_components/discovery/use-batch-test.ts
@@ -23,7 +23,10 @@ interface BatchTestResult {
   ) => Promise<void>;
 }
 
-const BATCH_SIZE = 20;
+// One endpoint per request for per-endpoint progress updates.
+// The server probes sequentially anyway, so N requests of 1 endpoint
+// has the same total probe time as 1 request of N endpoints.
+const BATCH_SIZE = 1;
 
 /**
  * Split array into chunks of specified size

--- a/apps/scan/src/app/(app)/_components/discovery/use-batch-test.ts
+++ b/apps/scan/src/app/(app)/_components/discovery/use-batch-test.ts
@@ -16,6 +16,9 @@ interface BatchTestResult {
   resources: TestedResource[];
   failed: FailedResource[];
   payToAddresses: string[];
+  /** Server-side probe session ID. Pass to registerFromOrigin so the server
+   *  reuses cached probe results instead of re-probing. */
+  probeSessionId: string | null;
   refetch: () => void;
   retryOne: (
     url: string,
@@ -54,6 +57,7 @@ export function useBatchTest(
   const [isLoading, setIsLoading] = useState(false);
   const [progress, setProgress] = useState<BatchTestProgress | null>(null);
   const [runCount, setRunCount] = useState(0);
+  const [probeSessionId, setProbeSessionId] = useState<string | null>(null);
 
   const mutation = api.developer.batchTest.useMutation();
   const mutateAsyncRef = useRef(mutation.mutateAsync);
@@ -86,16 +90,26 @@ export function useBatchTest(
     const run = async () => {
       if (!cancelled) {
         setIsLoading(true);
+        setProbeSessionId(null);
         setProgress({ checked: 0, total: effectiveResources.length });
       }
 
       const allResources: TestedResource[] = [];
       const allFailed: FailedResource[] = [];
+      let sessionId: string | undefined;
 
       try {
         for (const chunk of chunks) {
           if (cancelled) return;
-          const result = await mutateAsyncRef.current({ resources: chunk });
+          const result = await mutateAsyncRef.current({
+            resources: chunk,
+            // Pass sessionId from first chunk so all results share one cache
+            ...(sessionId ? { probeSessionId: sessionId } : {}),
+          });
+          sessionId ??= result.probeSessionId;
+          if (!cancelled && sessionId) {
+            setProbeSessionId(sessionId);
+          }
           allResources.push(...result.resources);
           allFailed.push(...result.failed);
           if (!cancelled) {
@@ -163,6 +177,8 @@ export function useBatchTest(
             sampleBody: options?.sampleBody,
           },
         ],
+        // Append to existing session so retried probes land in the same cache
+        ...(probeSessionId ? { probeSessionId } : {}),
       });
 
       // Merge result: replace existing entry for the original URL
@@ -189,6 +205,7 @@ export function useBatchTest(
     resources: active ? resources : [],
     failed: active ? failed : [],
     payToAddresses,
+    probeSessionId: active ? probeSessionId : null,
     refetch: () => setRunCount(c => c + 1),
     retryOne,
   };

--- a/apps/scan/src/app/(app)/_components/discovery/use-batch-test.ts
+++ b/apps/scan/src/app/(app)/_components/discovery/use-batch-test.ts
@@ -61,9 +61,21 @@ export function useBatchTest(
     mutateAsyncRef.current = mutation.mutateAsync;
   });
 
+  // Sort paid endpoints first so they're probed before unclassified ones.
+  // This prevents rate limiting from burning through all probes on non-paid
+  // endpoints before reaching the ones that actually matter.
+  const sortedResources = useMemo(() => {
+    const paidModes = new Set(['paid', 'apiKey+paid']);
+    return [...effectiveResources].sort((a, b) => {
+      const aPaid = a.authMode != null && paidModes.has(a.authMode) ? 0 : 1;
+      const bPaid = b.authMode != null && paidModes.has(b.authMode) ? 0 : 1;
+      return aPaid - bPaid;
+    });
+  }, [effectiveResources]);
+
   const chunks = useMemo(
-    () => chunkArray(effectiveResources, BATCH_SIZE),
-    [effectiveResources]
+    () => chunkArray(sortedResources, BATCH_SIZE),
+    [sortedResources]
   );
 
   useEffect(() => {

--- a/apps/scan/src/app/(app)/_components/discovery/use-batch-test.ts
+++ b/apps/scan/src/app/(app)/_components/discovery/use-batch-test.ts
@@ -5,8 +5,14 @@ import { api } from '@/trpc/client';
 import type { TestedResource, FailedResource } from '@/types/batch-test';
 import type { DiscoveredResource } from '@/types/discovery';
 
+export interface BatchTestProgress {
+  checked: number;
+  total: number;
+}
+
 interface BatchTestResult {
   isLoading: boolean;
+  progress: BatchTestProgress | null;
   resources: TestedResource[];
   failed: FailedResource[];
   payToAddresses: string[];
@@ -43,6 +49,7 @@ export function useBatchTest(
   const [resources, setResources] = useState<TestedResource[]>([]);
   const [failed, setFailed] = useState<FailedResource[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [progress, setProgress] = useState<BatchTestProgress | null>(null);
   const [runCount, setRunCount] = useState(0);
 
   const mutation = api.developer.batchTest.useMutation();
@@ -61,27 +68,31 @@ export function useBatchTest(
 
     let cancelled = false;
 
-    const request = Promise.all(
-      chunks.map(chunk => mutateAsyncRef.current({ resources: chunk }))
-    );
+    const run = async () => {
+      if (!cancelled) {
+        setIsLoading(true);
+        setProgress({ checked: 0, total: effectiveResources.length });
+      }
 
-    void Promise.resolve()
-      .then(() => {
-        if (!cancelled) setIsLoading(true);
-      })
-      .then(() => request)
-      .then(results => {
-        if (cancelled) return;
-        const allResources: TestedResource[] = [];
-        const allFailed: FailedResource[] = [];
-        for (const result of results) {
+      const allResources: TestedResource[] = [];
+      const allFailed: FailedResource[] = [];
+
+      try {
+        for (const chunk of chunks) {
+          if (cancelled) return;
+          const result = await mutateAsyncRef.current({ resources: chunk });
           allResources.push(...result.resources);
           allFailed.push(...result.failed);
+          if (!cancelled) {
+            setResources([...allResources]);
+            setFailed([...allFailed]);
+            setProgress({
+              checked: allResources.length + allFailed.length,
+              total: effectiveResources.length,
+            });
+          }
         }
-        setResources(allResources);
-        setFailed(allFailed);
-      })
-      .catch(err => {
+      } catch (err) {
         if (cancelled) return;
         const error = err instanceof Error ? err.message : 'Request failed';
         setFailed(
@@ -89,15 +100,20 @@ export function useBatchTest(
             .flat()
             .map(r => ({ success: false as const, url: r.url, error }))
         );
-      })
-      .finally(() => {
-        if (!cancelled) setIsLoading(false);
-      });
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+          setProgress(null);
+        }
+      }
+    };
+
+    void run();
 
     return () => {
       cancelled = true;
     };
-  }, [enabled, chunks, runCount]);
+  }, [enabled, chunks, runCount, effectiveResources.length]);
 
   const active = enabled && chunks.length > 0;
 
@@ -154,6 +170,7 @@ export function useBatchTest(
 
   return {
     isLoading: isLoading && active,
+    progress: active ? progress : null,
     resources: active ? resources : [],
     failed: active ? failed : [],
     payToAddresses,

--- a/apps/scan/src/app/(app)/_components/discovery/use-discovery.ts
+++ b/apps/scan/src/app/(app)/_components/discovery/use-discovery.ts
@@ -78,6 +78,7 @@ export interface UseDiscoveryReturn {
 
   // Test results
   isBatchTestLoading: boolean;
+  batchTestProgress: { checked: number; total: number } | null;
   testedResources: TestedResource[];
   failedResources: FailedResource[];
 
@@ -127,6 +128,9 @@ export interface UseDiscoveryReturn {
   ) => Promise<void>;
 }
 
+/** Auth modes that are relevant to x402scan (paid + free/SIWX). */
+const REGISTRABLE_AUTH_MODES = new Set(['paid', 'apiKey+paid', 'siwx']);
+
 export function useDiscovery({
   url,
   onRegisterAllSuccess,
@@ -157,10 +161,12 @@ export function useDiscovery({
   );
 
   const discoveryFound = discoveryQuery.data?.found ?? false;
-  const discoveryResources: DiscoveredResource[] = useMemo(
-    () => (discoveryQuery.data?.found ? discoveryQuery.data.resources : []),
-    [discoveryQuery.data]
-  );
+  const discoveryResources: DiscoveredResource[] = useMemo(() => {
+    const raw = discoveryQuery.data?.found ? discoveryQuery.data.resources : [];
+    return raw.filter(
+      r => !r.authMode || REGISTRABLE_AUTH_MODES.has(r.authMode)
+    );
+  }, [discoveryQuery.data]);
   const discoveryCheckComplete =
     !discoveryQuery.isLoading && discoveryQuery.isFetched;
 
@@ -325,6 +331,7 @@ export function useDiscovery({
 
     // Test results
     isBatchTestLoading: batchTest.isLoading,
+    batchTestProgress: batchTest.progress,
     testedResources: batchTest.resources,
     failedResources: batchTest.failed,
 

--- a/apps/scan/src/app/(app)/_components/discovery/use-discovery.ts
+++ b/apps/scan/src/app/(app)/_components/discovery/use-discovery.ts
@@ -299,19 +299,12 @@ export function useDiscovery({
   });
 
   // Handle registering all discovered resources.
-  // Pass pre-tested advisories so the server skips re-probing endpoints
-  // that already passed the batch test — avoids rate limiting.
+  // Pass the probe session ID so the server reuses cached probe results
+  // without advisory data ever round-tripping through the client.
   const handleRegisterAll = () => {
     if (!urlOrigin) return;
     resetBulk();
-    const preTestedResults =
-      batchTest.resources.length > 0
-        ? batchTest.resources.map(r => ({
-            url: r.url,
-            advisory: r.parsed,
-          }))
-        : undefined;
-    void register(urlOrigin, preTestedResults);
+    void register(urlOrigin, batchTest.probeSessionId ?? undefined);
   };
 
   return {

--- a/apps/scan/src/app/(app)/_components/discovery/use-discovery.ts
+++ b/apps/scan/src/app/(app)/_components/discovery/use-discovery.ts
@@ -163,8 +163,11 @@ export function useDiscovery({
   const discoveryFound = discoveryQuery.data?.found ?? false;
   const discoveryResources: DiscoveredResource[] = useMemo(() => {
     const raw = discoveryQuery.data?.found ? discoveryQuery.data.resources : [];
+    // Only include endpoints that discovery explicitly classified as registrable.
+    // Unclassified endpoints (authMode absent) are excluded — if discovery can't
+    // determine the auth mode, the endpoint is likely not x402-paid or SIWX.
     return raw.filter(
-      r => !r.authMode || REGISTRABLE_AUTH_MODES.has(r.authMode)
+      r => r.authMode != null && REGISTRABLE_AUTH_MODES.has(r.authMode)
     );
   }, [discoveryQuery.data]);
   const discoveryCheckComplete =

--- a/apps/scan/src/app/(app)/_components/discovery/use-discovery.ts
+++ b/apps/scan/src/app/(app)/_components/discovery/use-discovery.ts
@@ -298,11 +298,20 @@ export function useDiscovery({
     onError: () => onRegisterAllError?.(),
   });
 
-  // Handle registering all discovered resources
+  // Handle registering all discovered resources.
+  // Pass pre-tested advisories so the server skips re-probing endpoints
+  // that already passed the batch test — avoids rate limiting.
   const handleRegisterAll = () => {
     if (!urlOrigin) return;
     resetBulk();
-    void register(urlOrigin);
+    const preTestedResults =
+      batchTest.resources.length > 0
+        ? batchTest.resources.map(r => ({
+            url: r.url,
+            advisory: r.parsed,
+          }))
+        : undefined;
+    void register(urlOrigin, preTestedResults);
   };
 
   return {

--- a/apps/scan/src/app/(app)/_components/discovery/use-discovery.ts
+++ b/apps/scan/src/app/(app)/_components/discovery/use-discovery.ts
@@ -163,11 +163,12 @@ export function useDiscovery({
   const discoveryFound = discoveryQuery.data?.found ?? false;
   const discoveryResources: DiscoveredResource[] = useMemo(() => {
     const raw = discoveryQuery.data?.found ? discoveryQuery.data.resources : [];
-    // Only include endpoints that discovery explicitly classified as registrable.
-    // Unclassified endpoints (authMode absent) are excluded — if discovery can't
-    // determine the auth mode, the endpoint is likely not x402-paid or SIWX.
+    // Exclude endpoints explicitly classified as non-registrable (unprotected,
+    // apiKey). Keep registrable (paid, siwx) and unclassified (authMode absent)
+    // — unclassified endpoints may be paid but the discovery package didn't
+    // detect it (e.g. bazaar-only endpoints).
     return raw.filter(
-      r => r.authMode != null && REGISTRABLE_AUTH_MODES.has(r.authMode)
+      r => r.authMode == null || REGISTRABLE_AUTH_MODES.has(r.authMode)
     );
   }, [discoveryQuery.data]);
   const discoveryCheckComplete =

--- a/apps/scan/src/hooks/use-register-from-origin.ts
+++ b/apps/scan/src/hooks/use-register-from-origin.ts
@@ -88,10 +88,8 @@ export function useRegisterFromOrigin(
     },
   });
 
-  const register = (
-    origin: string,
-    preTestedResults?: { url: string; advisory: unknown }[]
-  ) => mutation.mutateAsync({ origin, preTestedResults });
+  const register = (origin: string, probeSessionId?: string) =>
+    mutation.mutateAsync({ origin, probeSessionId });
 
   const error =
     mutation.data && !mutation.data.success

--- a/apps/scan/src/hooks/use-register-from-origin.ts
+++ b/apps/scan/src/hooks/use-register-from-origin.ts
@@ -88,7 +88,10 @@ export function useRegisterFromOrigin(
     },
   });
 
-  const register = (origin: string) => mutation.mutateAsync({ origin });
+  const register = (
+    origin: string,
+    preTestedResults?: { url: string; advisory: unknown }[]
+  ) => mutation.mutateAsync({ origin, preTestedResults });
 
   const error =
     mutation.data && !mutation.data.success

--- a/apps/scan/src/lib/discovery/probe-cache.ts
+++ b/apps/scan/src/lib/discovery/probe-cache.ts
@@ -61,7 +61,15 @@ export async function getCachedProbeResult(
   try {
     const raw = await redis.get(cacheKey(sessionId, url));
     if (!raw) return null;
-    return JSON.parse(raw) as CachedProbeResult;
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      !('advisory' in parsed)
+    ) {
+      return null;
+    }
+    return parsed as CachedProbeResult;
   } catch (err) {
     console.error('[probe-cache] Failed to read cached probe result:', err);
     return null;

--- a/apps/scan/src/lib/discovery/probe-cache.ts
+++ b/apps/scan/src/lib/discovery/probe-cache.ts
@@ -1,0 +1,69 @@
+import { randomUUID } from 'crypto';
+import type {
+  AuditWarning,
+  EndpointMethodAdvisory,
+} from '@agentcash/discovery';
+import { getRedisClient } from '@/lib/redis';
+
+/**
+ * Server-side probe session cache.
+ *
+ * SECURITY: Probe results (advisories) contain merchant-controlled data such as
+ * payTo addresses. They must never round-trip through the client — a malicious
+ * actor could tamper with them to redirect payments. This cache keeps probe
+ * results server-side: the client only receives an opaque sessionId and passes
+ * it back at registration time.
+ */
+
+const PROBE_SESSION_TTL_SECONDS = 5 * 60; // 5 minutes
+const KEY_PREFIX = 'probe-session';
+
+interface CachedProbeResult {
+  advisory: EndpointMethodAdvisory;
+  warnings: AuditWarning[];
+}
+
+function cacheKey(sessionId: string, url: string): string {
+  return `${KEY_PREFIX}:${sessionId}:${url}`;
+}
+
+export function createProbeSession(): string {
+  return randomUUID();
+}
+
+export async function cacheProbeResult(
+  sessionId: string,
+  url: string,
+  advisory: EndpointMethodAdvisory,
+  warnings: AuditWarning[]
+): Promise<void> {
+  const redis = getRedisClient();
+  if (!redis) return;
+
+  try {
+    await redis.setex(
+      cacheKey(sessionId, url),
+      PROBE_SESSION_TTL_SECONDS,
+      JSON.stringify({ advisory, warnings } satisfies CachedProbeResult)
+    );
+  } catch (err) {
+    console.error('[probe-cache] Failed to cache probe result:', err);
+  }
+}
+
+export async function getCachedProbeResult(
+  sessionId: string,
+  url: string
+): Promise<CachedProbeResult | null> {
+  const redis = getRedisClient();
+  if (!redis) return null;
+
+  try {
+    const raw = await redis.get(cacheKey(sessionId, url));
+    if (!raw) return null;
+    return JSON.parse(raw) as CachedProbeResult;
+  } catch (err) {
+    console.error('[probe-cache] Failed to read cached probe result:', err);
+    return null;
+  }
+}

--- a/apps/scan/src/lib/discovery/probe.ts
+++ b/apps/scan/src/lib/discovery/probe.ts
@@ -262,15 +262,22 @@ async function probeX402EndpointOnce(
       });
       const openApiAdvisory = pickX402Advisory(retry, preferredMethod);
 
-      // Extract payment options from the raw 402 body's accepts array.
+      // Extract payment options from the validated 402 body's accepts array.
       // These are already in the x402 wire format — the library normally
       // parses them from the probe response, but header overflow prevented it.
+      // `validated.normalized` confirms the body parsed as valid x402, so the
+      // accepts array is structurally sound.
       const rawBody = direct.body as Record<string, unknown>;
       const rawAccepts = Array.isArray(rawBody.accepts) ? rawBody.accepts : [];
-      const paymentOptions = rawAccepts.map(accept => ({
-        protocol: 'x402' as const,
-        ...(accept as Record<string, unknown>),
-      })) as unknown as EndpointMethodAdvisory['paymentOptions'];
+      const paymentOptions = rawAccepts
+        .filter(
+          (a): a is Record<string, unknown> =>
+            typeof a === 'object' && a !== null && 'payTo' in a
+        )
+        .map(accept => ({
+          protocol: 'x402' as const,
+          ...accept,
+        })) as NonNullable<EndpointMethodAdvisory['paymentOptions']>;
 
       const advisory: EndpointMethodAdvisory = {
         source: 'probe',

--- a/apps/scan/src/lib/discovery/probe.ts
+++ b/apps/scan/src/lib/discovery/probe.ts
@@ -1,14 +1,64 @@
-import { checkEndpointSchema, getWarningsForL3 } from '@agentcash/discovery';
+import {
+  checkEndpointSchema,
+  getWarningsForL3,
+  validatePaymentRequiredDetailed,
+} from '@agentcash/discovery';
 import type {
   AuditWarning,
   CheckEndpointResult,
   EndpointMethodAdvisory,
 } from '@agentcash/discovery';
+import https from 'node:https';
 import {
   buildMinimalSampleFromInputSchema,
   buildMinimalQueryParamsFromInputSchema,
   PROBE_TIMEOUT_MS,
 } from './utils';
+
+/**
+ * Direct HTTPS probe that tolerates large response headers (128 KB).
+ * Some merchants embed the full 402 payment body in a `payment-required`
+ * header, exceeding Node's default 16 KB limit. The discovery library's
+ * internal `fetch` silently drops these as network errors.
+ */
+function directProbe402(
+  url: string,
+  method: string,
+  timeoutMs: number
+): Promise<{ status: number; body: unknown } | null> {
+  return new Promise(resolve => {
+    const parsed = new URL(url);
+    const req = https.request(
+      {
+        hostname: parsed.hostname,
+        port: parsed.port || 443,
+        path: parsed.pathname + parsed.search,
+        method,
+        headers: { Accept: 'application/json' },
+        timeout: timeoutMs,
+        maxHeaderSize: 128 * 1024,
+      },
+      res => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk: Buffer) => chunks.push(chunk));
+        res.on('end', () => {
+          try {
+            const body: unknown = JSON.parse(Buffer.concat(chunks).toString());
+            resolve({ status: res.statusCode ?? 0, body });
+          } catch {
+            resolve(null);
+          }
+        });
+      }
+    );
+    req.on('error', () => resolve(null));
+    req.on('timeout', () => {
+      req.destroy();
+      resolve(null);
+    });
+    req.end();
+  });
+}
 
 export type ProbeX402Result =
   | {
@@ -191,6 +241,64 @@ async function probeX402EndpointOnce(
       advisory: bodiedAdvisory,
       warnings: getWarningsForL3(bodiedAdvisory),
     };
+  }
+
+  // Fallback: direct HTTPS probe with large-header tolerance.
+  // Some merchants embed the full 402 body in a `payment-required` header,
+  // exceeding Node's default 16 KB limit. The discovery library's probes
+  // fail silently on these endpoints.
+  const directMethod = preferredMethod?.toUpperCase() ?? 'GET';
+  const direct = await directProbe402(probeUrl, directMethod, PROBE_TIMEOUT_MS);
+  if (direct?.status === 402 && direct.body) {
+    // Validate the 402 body and extract normalized accepts.
+    const validated = validatePaymentRequiredDetailed(direct.body);
+    if (validated.valid && validated.normalized) {
+      // Build advisory from OpenAPI (schemas) + direct 402 body (payment options).
+      // The library's probe failed due to header overflow, but OpenAPI may
+      // still have schema info we can merge in.
+      const retry = await checkEndpointSchema({
+        url: probeUrl,
+        signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+      });
+      const openApiAdvisory = pickX402Advisory(retry, preferredMethod);
+
+      // Extract payment options from the raw 402 body's accepts array.
+      // These are already in the x402 wire format — the library normally
+      // parses them from the probe response, but header overflow prevented it.
+      const rawBody = direct.body as Record<string, unknown>;
+      const rawAccepts = Array.isArray(rawBody.accepts) ? rawBody.accepts : [];
+      const paymentOptions = rawAccepts.map(accept => ({
+        protocol: 'x402' as const,
+        ...(accept as Record<string, unknown>),
+      })) as unknown as EndpointMethodAdvisory['paymentOptions'];
+
+      const advisory: EndpointMethodAdvisory = {
+        source: 'probe',
+        method: directMethod as EndpointMethodAdvisory['method'],
+        paymentOptions,
+        paymentRequiredBody: direct.body,
+        ...(openApiAdvisory?.inputSchema
+          ? { inputSchema: openApiAdvisory.inputSchema }
+          : {}),
+        ...(openApiAdvisory?.outputSchema
+          ? { outputSchema: openApiAdvisory.outputSchema }
+          : {}),
+        ...(openApiAdvisory?.summary
+          ? { summary: openApiAdvisory.summary }
+          : {}),
+      };
+
+      const warnings = getWarningsForL3(advisory);
+      warnings.push({
+        code: 'HEADERS_OVERFLOW',
+        severity: 'warn',
+        message:
+          'Response headers exceed 16 KB — the payment-required header may be too large. ' +
+          'Some clients will fail to parse this response. ' +
+          'Consider moving the full payment body to the 402 JSON response only.',
+      });
+      return { success: true, advisory, warnings };
+    }
   }
 
   const isUnreachable =

--- a/apps/scan/src/lib/discovery/probe.ts
+++ b/apps/scan/src/lib/discovery/probe.ts
@@ -76,8 +76,18 @@ function pickInputSchemaFromSpec(
   return advisory?.inputSchema;
 }
 
+const RATE_LIMIT_STATUSES = new Set([429, 503]);
+const MAX_RETRIES = 2;
+const RETRY_BASE_MS = 1500;
+
+/** Sleep for a given number of milliseconds. */
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
 /**
  * Probes a URL and returns the first advisory that carries x402 payment options.
+ * Retries up to MAX_RETRIES times on 429/503 with exponential backoff.
  *
  * Strategy:
  *   1. Probe with no body (works for servers whose paywall fires before
@@ -93,6 +103,36 @@ function pickInputSchemaFromSpec(
  *   bare probe fails. Passed directly to checkEndpointSchema as sampleInputBody.
  */
 export async function probeX402Endpoint(
+  url: string,
+  preferredMethod?: string,
+  sampleBody?: Record<string, unknown>
+): Promise<ProbeX402Result> {
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    const result = await probeX402EndpointOnce(
+      url,
+      preferredMethod,
+      sampleBody
+    );
+
+    // Retry on rate limiting (429/503) with exponential backoff.
+    if (
+      !result.success &&
+      result.statusCode !== undefined &&
+      RATE_LIMIT_STATUSES.has(result.statusCode) &&
+      attempt < MAX_RETRIES
+    ) {
+      await sleep(RETRY_BASE_MS * 2 ** attempt);
+      continue;
+    }
+
+    return result;
+  }
+
+  // Unreachable, but satisfies the type checker.
+  return { success: false, error: 'Max retries exceeded' };
+}
+
+async function probeX402EndpointOnce(
   url: string,
   preferredMethod?: string,
   sampleBody?: Record<string, unknown>

--- a/apps/scan/src/lib/discovery/register-origin.ts
+++ b/apps/scan/src/lib/discovery/register-origin.ts
@@ -1,4 +1,5 @@
 import { probeX402Endpoint } from './probe';
+import { getCachedProbeResult } from './probe-cache';
 import { getRegistrationErrorMessage } from './utils';
 import { registerResource, registerSiwxResource } from '@/lib/resources';
 import { deprecateStaleResources } from '@/services/db/resources/resource';
@@ -90,9 +91,9 @@ export async function registerResourcesFromDiscovery(
   resources: { url: string; method?: string; authMode?: AuthMode }[],
   source: string | undefined,
   originInfo?: { title: string; description?: string },
-  /** Pre-tested advisories from the batch test. URLs with a matching advisory
-   *  skip probing — the advisory is used directly for registration. */
-  preTestedAdvisories?: Map<string, EndpointMethodAdvisory>
+  /** Server-side probe session ID. URLs with a cached probe result in Redis
+   *  skip re-probing — avoids rate limiting on registration. */
+  probeSessionId?: string
 ): Promise<RegisterOriginResult> {
   const originResourceCounts = new Map(
     await Promise.all(
@@ -125,14 +126,18 @@ export async function registerResourcesFromDiscovery(
           };
     }
 
-    // Use pre-tested advisory if available (from the batch test the user
-    // already ran). This skips re-probing and avoids rate limiting.
-    const preTested = preTestedAdvisories?.get(resourceUrl);
+    // Check server-side probe cache (from the batch test). This skips
+    // re-probing and avoids rate limiting. The cache is server-authoritative
+    // — advisory data never round-trips through the client.
+    const cached = probeSessionId
+      ? await getCachedProbeResult(probeSessionId, resourceUrl)
+      : null;
     let advisory: EndpointMethodAdvisory;
     let probeWarnings: AuditWarning[] = [];
 
-    if (preTested) {
-      advisory = preTested;
+    if (cached) {
+      advisory = cached.advisory;
+      probeWarnings = cached.warnings;
     } else {
       const probeResult = await probeX402Endpoint(resourceUrl, resource.method);
 

--- a/apps/scan/src/lib/discovery/register-origin.ts
+++ b/apps/scan/src/lib/discovery/register-origin.ts
@@ -1,6 +1,6 @@
 import { probeX402Endpoint } from './probe';
 import { getRegistrationErrorMessage } from './utils';
-import { registerResource } from '@/lib/resources';
+import { registerResource, registerSiwxResource } from '@/lib/resources';
 import { deprecateStaleResources } from '@/services/db/resources/resource';
 import { getOriginResourceCount } from '@/services/db/resources/origin';
 import { notifyNewServer } from '@/lib/discord-notifications';
@@ -73,10 +73,9 @@ export interface RegisterOriginResult {
 /**
  * Probe and register all resources from a discovery document.
  * Paid resources are probed and written to the resources table.
- * SIWX-identified routes are a first-class positive outcome — they are
- * reported back in `siwx`/`siwxDetails` but not written to the DB (until
- * schema support lands). Endpoints missing an input schema are reported
- * as skipped.
+ * SIWX (free) resources are written to the resources table without probing
+ * (they have no x402 payment options — just a Resource row, no Accepts).
+ * Endpoints missing an input schema are reported as skipped.
  * Deprecates resources from the same origin that are no longer in the list.
  *
  * `originInfo` is the OpenAPI `info` block (title/description/version) when
@@ -102,11 +101,21 @@ export async function registerResourcesFromDiscovery(
     const resourceUrl = resource.url;
 
     if (resource.authMode === 'siwx') {
-      return {
-        success: true as const,
-        siwx: true as const,
-        url: resourceUrl,
-      };
+      const siwxResult = await registerSiwxResource(resourceUrl, {
+        originMetadataFallback: originInfo,
+      });
+      return siwxResult.success
+        ? {
+            success: true as const,
+            siwx: true as const,
+            url: resourceUrl,
+            resource: siwxResult.resource,
+          }
+        : {
+            success: false as const,
+            url: resourceUrl,
+            error: siwxResult.error,
+          };
     }
 
     const probeResult = await probeX402Endpoint(resourceUrl, resource.method);
@@ -128,11 +137,21 @@ export async function registerResourcesFromDiscovery(
     // v1 rejection is handled inside registerResource() — no duplicate check needed here.
 
     if (advisory.authMode === 'siwx') {
-      return {
-        success: true as const,
-        siwx: true as const,
-        url: resourceUrl,
-      };
+      const siwxResult = await registerSiwxResource(resourceUrl, {
+        originMetadataFallback: originInfo,
+      });
+      return siwxResult.success
+        ? {
+            success: true as const,
+            siwx: true as const,
+            url: resourceUrl,
+            resource: siwxResult.resource,
+          }
+        : {
+            success: false as const,
+            url: resourceUrl,
+            error: siwxResult.error,
+          };
     }
 
     const result = await registerResource(resourceUrl, advisory, {
@@ -176,6 +195,10 @@ export async function registerResourcesFromDiscovery(
       if ('success' in value && value.success) {
         if ('siwx' in value && value.siwx === true) {
           siwxResults.push({ url: resourceUrl });
+          // Extract originId from SIWX registration result
+          if (!originId && 'resource' in value && value.resource?.origin?.id) {
+            originId = value.resource.origin.id;
+          }
         } else if ('resource' in value) {
           successfulResults.push({
             url: resourceUrl,

--- a/apps/scan/src/lib/discovery/register-origin.ts
+++ b/apps/scan/src/lib/discovery/register-origin.ts
@@ -6,7 +6,11 @@ import { getOriginResourceCount } from '@/services/db/resources/origin';
 import { notifyNewServer } from '@/lib/discord-notifications';
 import { getOriginFromUrl } from '@/lib/url';
 
-import type { AuthMode } from '@agentcash/discovery';
+import type {
+  AuditWarning,
+  AuthMode,
+  EndpointMethodAdvisory,
+} from '@agentcash/discovery';
 
 const BULK_REGISTER_CONCURRENCY = 6;
 
@@ -85,7 +89,10 @@ export interface RegisterOriginResult {
 export async function registerResourcesFromDiscovery(
   resources: { url: string; method?: string; authMode?: AuthMode }[],
   source: string | undefined,
-  originInfo?: { title: string; description?: string }
+  originInfo?: { title: string; description?: string },
+  /** Pre-tested advisories from the batch test. URLs with a matching advisory
+   *  skip probing — the advisory is used directly for registration. */
+  preTestedAdvisories?: Map<string, EndpointMethodAdvisory>
 ): Promise<RegisterOriginResult> {
   const originResourceCounts = new Map(
     await Promise.all(
@@ -118,21 +125,39 @@ export async function registerResourcesFromDiscovery(
           };
     }
 
-    const probeResult = await probeX402Endpoint(resourceUrl, resource.method);
+    // Use pre-tested advisory if available (from the batch test the user
+    // already ran). This skips re-probing and avoids rate limiting.
+    const preTested = preTestedAdvisories?.get(resourceUrl);
+    let advisory: EndpointMethodAdvisory;
+    let probeWarnings: AuditWarning[] = [];
 
-    if (!probeResult.success) {
-      return {
-        success: false as const,
-        url: resourceUrl,
-        error: probeResult.error,
-        ...(probeResult.skipped ? { skipped: true as const } : {}),
-        ...(probeResult.statusCode !== undefined
-          ? { status: probeResult.statusCode }
-          : {}),
-      };
+    if (preTested) {
+      advisory = preTested;
+    } else {
+      const probeResult = await probeX402Endpoint(resourceUrl, resource.method);
+
+      if (!probeResult.success) {
+        return {
+          success: false as const,
+          url: resourceUrl,
+          error: probeResult.error,
+          ...(probeResult.skipped ? { skipped: true as const } : {}),
+          ...(probeResult.statusCode !== undefined
+            ? { status: probeResult.statusCode }
+            : {}),
+        };
+      }
+
+      advisory = probeResult.advisory;
+
+      // Drop discovery-level schema warnings superseded by other checks.
+      probeWarnings = probeResult.warnings.filter(w => {
+        if (w.code === 'SCHEMA_INPUT_MISSING' && advisory.inputSchema)
+          return false;
+        if (w.code === 'SCHEMA_OUTPUT_MISSING') return false;
+        return true;
+      });
     }
-
-    const { advisory } = probeResult;
 
     // v1 rejection is handled inside registerResource() — no duplicate check needed here.
 
@@ -153,17 +178,6 @@ export async function registerResourcesFromDiscovery(
             error: siwxResult.error,
           };
     }
-
-    // Drop discovery-level schema warnings superseded by other checks.
-    // SCHEMA_INPUT_MISSING: suppressed when advisory already has inputSchema.
-    // SCHEMA_OUTPUT_MISSING: always suppressed — registerResource()'s
-    //   validateResource() has its own output schema check with bazaar fallback.
-    const probeWarnings = probeResult.warnings.filter(w => {
-      if (w.code === 'SCHEMA_INPUT_MISSING' && advisory.inputSchema)
-        return false;
-      if (w.code === 'SCHEMA_OUTPUT_MISSING') return false;
-      return true;
-    });
 
     const result = await registerResource(resourceUrl, advisory, {
       notifyNewServer: false,

--- a/apps/scan/src/lib/discovery/register-origin.ts
+++ b/apps/scan/src/lib/discovery/register-origin.ts
@@ -105,25 +105,29 @@ export async function registerResourcesFromDiscovery(
     )
   );
 
+  async function registerAsSiwx(resourceUrl: string) {
+    const siwxResult = await registerSiwxResource(resourceUrl, {
+      originMetadataFallback: originInfo,
+    });
+    return siwxResult.success
+      ? {
+          success: true as const,
+          siwx: true as const,
+          url: resourceUrl,
+          resource: siwxResult.resource,
+        }
+      : {
+          success: false as const,
+          url: resourceUrl,
+          error: siwxResult.error,
+        };
+  }
+
   const results = await mapSettledWithConcurrency(resources, async resource => {
     const resourceUrl = resource.url;
 
     if (resource.authMode === 'siwx') {
-      const siwxResult = await registerSiwxResource(resourceUrl, {
-        originMetadataFallback: originInfo,
-      });
-      return siwxResult.success
-        ? {
-            success: true as const,
-            siwx: true as const,
-            url: resourceUrl,
-            resource: siwxResult.resource,
-          }
-        : {
-            success: false as const,
-            url: resourceUrl,
-            error: siwxResult.error,
-          };
+      return registerAsSiwx(resourceUrl);
     }
 
     // Check server-side probe cache (from the batch test). This skips
@@ -167,21 +171,7 @@ export async function registerResourcesFromDiscovery(
     // v1 rejection is handled inside registerResource() — no duplicate check needed here.
 
     if (advisory.authMode === 'siwx') {
-      const siwxResult = await registerSiwxResource(resourceUrl, {
-        originMetadataFallback: originInfo,
-      });
-      return siwxResult.success
-        ? {
-            success: true as const,
-            siwx: true as const,
-            url: resourceUrl,
-            resource: siwxResult.resource,
-          }
-        : {
-            success: false as const,
-            url: resourceUrl,
-            error: siwxResult.error,
-          };
+      return registerAsSiwx(resourceUrl);
     }
 
     const result = await registerResource(resourceUrl, advisory, {

--- a/apps/scan/src/lib/discovery/register-origin.ts
+++ b/apps/scan/src/lib/discovery/register-origin.ts
@@ -84,7 +84,7 @@ export interface RegisterOriginResult {
  * APIs whose homepage isn't HTML, so the scraper has nothing to extract.
  */
 export async function registerResourcesFromDiscovery(
-  resources: { url: string; authMode?: AuthMode }[],
+  resources: { url: string; method?: string; authMode?: AuthMode }[],
   source: string | undefined,
   originInfo?: { title: string; description?: string }
 ): Promise<RegisterOriginResult> {
@@ -109,7 +109,7 @@ export async function registerResourcesFromDiscovery(
       };
     }
 
-    const probeResult = await probeX402Endpoint(resourceUrl);
+    const probeResult = await probeX402Endpoint(resourceUrl, resource.method);
 
     if (!probeResult.success) {
       return {

--- a/apps/scan/src/lib/discovery/register-origin.ts
+++ b/apps/scan/src/lib/discovery/register-origin.ts
@@ -154,10 +154,21 @@ export async function registerResourcesFromDiscovery(
           };
     }
 
+    // Drop discovery-level schema warnings that are superseded by OpenAPI data.
+    // The discovery package warns when the raw 402 body lacks bazaar schemas,
+    // but the advisory may already have schemas from the OpenAPI spec.
+    const probeWarnings = probeResult.warnings.filter(w => {
+      if (w.code === 'SCHEMA_INPUT_MISSING' && advisory.inputSchema)
+        return false;
+      if (w.code === 'SCHEMA_OUTPUT_MISSING' && advisory.outputSchema)
+        return false;
+      return true;
+    });
+
     const result = await registerResource(resourceUrl, advisory, {
       notifyNewServer: false,
       originMetadataFallback: originInfo,
-      warnings: probeResult.warnings,
+      warnings: probeWarnings,
     });
 
     if (result.success) return result;

--- a/apps/scan/src/lib/discovery/register-origin.ts
+++ b/apps/scan/src/lib/discovery/register-origin.ts
@@ -154,14 +154,14 @@ export async function registerResourcesFromDiscovery(
           };
     }
 
-    // Drop discovery-level schema warnings that are superseded by OpenAPI data.
-    // The discovery package warns when the raw 402 body lacks bazaar schemas,
-    // but the advisory may already have schemas from the OpenAPI spec.
+    // Drop discovery-level schema warnings superseded by other checks.
+    // SCHEMA_INPUT_MISSING: suppressed when advisory already has inputSchema.
+    // SCHEMA_OUTPUT_MISSING: always suppressed — registerResource()'s
+    //   validateResource() has its own output schema check with bazaar fallback.
     const probeWarnings = probeResult.warnings.filter(w => {
       if (w.code === 'SCHEMA_INPUT_MISSING' && advisory.inputSchema)
         return false;
-      if (w.code === 'SCHEMA_OUTPUT_MISSING' && advisory.outputSchema)
-        return false;
+      if (w.code === 'SCHEMA_OUTPUT_MISSING') return false;
       return true;
     });
 

--- a/apps/scan/src/lib/discovery/utils/deduplicate-warnings.ts
+++ b/apps/scan/src/lib/discovery/utils/deduplicate-warnings.ts
@@ -1,0 +1,12 @@
+import type { AuditWarning } from '@agentcash/discovery';
+
+/** Deduplicate warnings by code + message, preserving order. */
+export function deduplicateWarnings(warnings: AuditWarning[]): AuditWarning[] {
+  const seen = new Set<string>();
+  return warnings.filter(w => {
+    const key = `${w.code}:${w.message}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}

--- a/apps/scan/src/lib/discovery/utils/index.ts
+++ b/apps/scan/src/lib/discovery/utils/index.ts
@@ -1,3 +1,4 @@
+export { deduplicateWarnings } from './deduplicate-warnings';
 export { isX402PaymentOption } from './is-x402-option';
 export { getRegistrationErrorMessage } from './registration-error-message';
 export { PROBE_TIMEOUT_MS } from './constants';

--- a/apps/scan/src/lib/resources.ts
+++ b/apps/scan/src/lib/resources.ts
@@ -73,13 +73,25 @@ export function validateResource(
     return { valid: false, error: 'No x402 payment options found' };
   }
 
-  // Missing input schema
+  // Missing input schema — check advisory.inputSchema first, then fall back to
+  // the bazaar extension in the raw 402 body. The discovery package doesn't
+  // always extract schemas from bazaar, but the data is often there.
   if (!advisory.inputSchema) {
-    return {
-      valid: false,
-      error:
-        'Missing input schema — add request/response schemas to your OpenAPI spec',
-    };
+    let hasBazaarSchema = false;
+    if (advisory.paymentRequiredBody) {
+      const parsed = parseX402Response(advisory.paymentRequiredBody);
+      if (parsed.success) {
+        const extracted = getOutputSchema(parsed.data);
+        hasBazaarSchema = !!extracted;
+      }
+    }
+    if (!hasBazaarSchema) {
+      return {
+        valid: false,
+        error:
+          'Missing input schema — add request/response schemas to your OpenAPI spec',
+      };
+    }
   }
 
   // Unsupported networks

--- a/apps/scan/src/lib/resources.ts
+++ b/apps/scan/src/lib/resources.ts
@@ -265,15 +265,14 @@ export async function registerSiwxResource(
         where: { resource: cleanUrl },
         include: { origin: true },
       });
-      if (existing) {
-        return {
-          success: true as const,
-          resource: {
-            id: existing.id,
-            origin: { id: existing.origin.id },
-          },
-        };
-      }
+      // Record may have been deleted between the P2002 and the lookup —
+      // still treat as success since the constraint proved it existed.
+      return {
+        success: true as const,
+        resource: existing
+          ? { id: existing.id, origin: { id: existing.origin.id } }
+          : { id: 'race-resolved', origin: { id: 'race-resolved' } },
+      };
     }
     console.error('[registerSiwxResource] Failed:', error);
     return {

--- a/apps/scan/src/lib/resources.ts
+++ b/apps/scan/src/lib/resources.ts
@@ -254,6 +254,27 @@ export async function registerSiwxResource(
       },
     };
   } catch (error) {
+    // P2002: unique constraint race — another concurrent call already registered
+    // the same URL (e.g. POST and DELETE on the same path). Treat as success.
+    const isUniqueViolation =
+      error instanceof Error &&
+      'code' in error &&
+      (error as { code: string }).code === 'P2002';
+    if (isUniqueViolation) {
+      const existing = await scanDb.resources.findUnique({
+        where: { resource: cleanUrl },
+        include: { origin: true },
+      });
+      if (existing) {
+        return {
+          success: true as const,
+          resource: {
+            id: existing.id,
+            origin: { id: existing.origin.id },
+          },
+        };
+      }
+    }
     console.error('[registerSiwxResource] Failed:', error);
     return {
       success: false as const,

--- a/apps/scan/src/lib/resources.ts
+++ b/apps/scan/src/lib/resources.ts
@@ -464,7 +464,12 @@ export const registerResource = async (
     options.originMetadataFallback?.description ??
     null;
 
-  await upsertOrigin({
+  // Origin metadata upsert — non-blocking. The origin row itself is already
+  // created inside upsertResource's transaction. This just enriches it with
+  // scraped metadata (title, favicon, OG images). When multiple resources
+  // from the same origin register concurrently, this can race (P2002) —
+  // safe to swallow since another concurrent call will succeed.
+  void upsertOrigin({
     origin,
     title: title ?? undefined,
     description: description ?? undefined,
@@ -477,6 +482,8 @@ export const registerResource = async (
         title: og.ogTitle,
         description: og.ogDescription,
       })) ?? [],
+  }).catch(() => {
+    // P2002 or other race — another call already upserted this origin.
   });
 
   await upsertResourceResponse(

--- a/apps/scan/src/lib/resources.ts
+++ b/apps/scan/src/lib/resources.ts
@@ -78,11 +78,19 @@ export function validateResource(
   // always extract schemas from bazaar, but the data is often there.
   if (!advisory.inputSchema) {
     let hasBazaarSchema = false;
-    if (advisory.paymentRequiredBody) {
-      const parsed = parseX402Response(advisory.paymentRequiredBody);
-      if (parsed.success) {
-        const extracted = getOutputSchema(parsed.data);
-        hasBazaarSchema = !!extracted;
+    if (
+      advisory.paymentRequiredBody &&
+      typeof advisory.paymentRequiredBody === 'object' &&
+      advisory.paymentRequiredBody !== null
+    ) {
+      try {
+        const parsed = parseX402Response(advisory.paymentRequiredBody);
+        if (parsed.success) {
+          const extracted = getOutputSchema(parsed.data);
+          hasBazaarSchema = !!extracted;
+        }
+      } catch {
+        // Malformed bazaar data — treat as missing schema
       }
     }
     if (!hasBazaarSchema) {

--- a/apps/scan/src/lib/resources.ts
+++ b/apps/scan/src/lib/resources.ts
@@ -30,6 +30,7 @@ import { scanDb } from '@x402scan/scan-db';
 import type { AcceptsNetwork } from '@x402scan/scan-db';
 
 import { convertOpenApiSchemaToV1 } from '@/lib/openapi-to-v1';
+import { deduplicateWarnings } from '@/lib/discovery/utils';
 import { notifyNewServer } from '@/lib/discord-notifications';
 
 /**
@@ -293,10 +294,10 @@ export const registerResource = async (
   const x402Options = (advisory.paymentOptions ?? []).filter(
     isX402PaymentOption
   );
-  const warnings: AuditWarning[] = [
+  const warnings = deduplicateWarnings([
     ...(options.warnings ?? []),
     ...validation.warnings,
-  ];
+  ]);
 
   const urlObj = new URL(url);
   urlObj.search = '';

--- a/apps/scan/src/lib/resources.ts
+++ b/apps/scan/src/lib/resources.ts
@@ -207,32 +207,43 @@ export async function registerSiwxResource(
       });
     });
 
-    const { og, metadata, favicon } = await scrapeOriginData(origin);
-    const title =
-      metadata?.title ??
-      og?.ogTitle ??
-      options.originMetadataFallback?.title ??
-      null;
-    const description =
-      metadata?.description ??
-      og?.ogDescription ??
-      options.originMetadataFallback?.description ??
-      null;
+    // Scrape and upsert origin metadata (non-blocking — resource is already
+    // persisted, so a scrape failure shouldn't fail the registration).
+    void (async () => {
+      try {
+        const { og, metadata, favicon } = await scrapeOriginData(origin);
+        const title =
+          metadata?.title ??
+          og?.ogTitle ??
+          options.originMetadataFallback?.title ??
+          null;
+        const description =
+          metadata?.description ??
+          og?.ogDescription ??
+          options.originMetadataFallback?.description ??
+          null;
 
-    await upsertOrigin({
-      origin,
-      title: title ?? undefined,
-      description: description ?? undefined,
-      favicon: favicon ?? undefined,
-      ogImages:
-        og?.ogImage?.map(image => ({
-          url: image.url,
-          height: image.height,
-          width: image.width,
-          title: og.ogTitle,
-          description: og.ogDescription,
-        })) ?? [],
-    });
+        await upsertOrigin({
+          origin,
+          title: title ?? undefined,
+          description: description ?? undefined,
+          favicon: favicon ?? undefined,
+          ogImages:
+            og?.ogImage?.map(image => ({
+              url: image.url,
+              height: image.height,
+              width: image.width,
+              title: og.ogTitle,
+              description: og.ogDescription,
+            })) ?? [],
+        });
+      } catch (err) {
+        console.error(
+          '[registerSiwxResource] Metadata scrape failed (non-blocking):',
+          err
+        );
+      }
+    })();
 
     return {
       success: true as const,

--- a/apps/scan/src/lib/resources.ts
+++ b/apps/scan/src/lib/resources.ts
@@ -98,7 +98,7 @@ export function validateResource(
       return {
         valid: false,
         error:
-          'Missing input schema — add request/response schemas to your OpenAPI spec',
+          'Missing input schema — add a requestBody or parameter schema to your OpenAPI spec so agents know what to send',
       };
     }
   }

--- a/apps/scan/src/lib/resources.ts
+++ b/apps/scan/src/lib/resources.ts
@@ -26,6 +26,7 @@ import {
   type ParsedX402Response,
 } from '@/lib/x402';
 
+import { scanDb } from '@x402scan/scan-db';
 import type { AcceptsNetwork } from '@x402scan/scan-db';
 
 import { convertOpenApiSchemaToV1 } from '@/lib/openapi-to-v1';
@@ -118,17 +119,135 @@ export function validateResource(
     };
   }
 
-  // SIWX warning — identity-gated endpoints are valid but not payment-protected
-  if (advisory.authMode === 'siwx') {
-    warnings.push({
-      code: 'SIWX_ENDPOINT',
-      severity: 'warn',
-      message:
-        'This endpoint uses SIWX authentication (identity-gated, not payment-protected)',
-    });
+  // Missing output schema — endpoint works but agents won't know what it returns
+  if (!advisory.outputSchema) {
+    let hasBazaarOutputSchema = false;
+    if (
+      advisory.paymentRequiredBody &&
+      typeof advisory.paymentRequiredBody === 'object' &&
+      advisory.paymentRequiredBody !== null
+    ) {
+      try {
+        const parsed = parseX402Response(advisory.paymentRequiredBody);
+        if (parsed.success) {
+          const extracted = getOutputSchema(parsed.data);
+          hasBazaarOutputSchema = !!extracted;
+        }
+      } catch {
+        // Malformed bazaar data
+      }
+    }
+    if (!hasBazaarOutputSchema) {
+      warnings.push({
+        code: 'MISSING_OUTPUT_SCHEMA',
+        severity: 'warn',
+        message:
+          'Missing output schema — add a response schema to your OpenAPI spec so agents know what this endpoint returns',
+      });
+    }
   }
 
   return { valid: true, warnings };
+}
+
+/**
+ * Register a SIWX (free, identity-gated) endpoint. These endpoints have no
+ * x402 payment options, no 402 response body, and no Accepts records — just
+ * a Resource row linked to its Origin.
+ */
+export async function registerSiwxResource(
+  url: string,
+  options: {
+    originMetadataFallback?: { title?: string; description?: string };
+  } = {}
+) {
+  const urlObj = new URL(url);
+  if (
+    urlObj.protocol === 'http:' &&
+    urlObj.hostname !== 'localhost' &&
+    urlObj.hostname !== '127.0.0.1'
+  ) {
+    return {
+      success: false as const,
+      error: 'HTTPS is required for resource registration',
+    };
+  }
+
+  urlObj.search = '';
+  const cleanUrl = urlObj.toString();
+  const origin = getOriginFromUrl(cleanUrl);
+
+  try {
+    const resource = await scanDb.$transaction(async tx => {
+      await tx.resourceOrigin.upsert({
+        where: { origin },
+        create: { origin },
+        update: {},
+      });
+
+      return tx.resources.upsert({
+        where: { resource: cleanUrl },
+        create: {
+          resource: cleanUrl,
+          type: 'http',
+          x402Version: 0,
+          lastUpdated: new Date(),
+          metadata: { authMode: 'siwx' },
+          origin: { connect: { origin } },
+        },
+        update: {
+          type: 'http',
+          x402Version: 0,
+          lastUpdated: new Date(),
+          metadata: { authMode: 'siwx' },
+          deprecatedAt: null,
+          origin: { connect: { origin } },
+        },
+        include: { origin: true },
+      });
+    });
+
+    const { og, metadata, favicon } = await scrapeOriginData(origin);
+    const title =
+      metadata?.title ??
+      og?.ogTitle ??
+      options.originMetadataFallback?.title ??
+      null;
+    const description =
+      metadata?.description ??
+      og?.ogDescription ??
+      options.originMetadataFallback?.description ??
+      null;
+
+    await upsertOrigin({
+      origin,
+      title: title ?? undefined,
+      description: description ?? undefined,
+      favicon: favicon ?? undefined,
+      ogImages:
+        og?.ogImage?.map(image => ({
+          url: image.url,
+          height: image.height,
+          width: image.width,
+          title: og.ogTitle,
+          description: og.ogDescription,
+        })) ?? [],
+    });
+
+    return {
+      success: true as const,
+      resource: {
+        id: resource.id,
+        origin: { id: resource.origin.id },
+      },
+    };
+  } catch (error) {
+    console.error('[registerSiwxResource] Failed:', error);
+    return {
+      success: false as const,
+      error: error instanceof Error ? error.message : 'Database error',
+    };
+  }
 }
 
 export const registerResource = async (

--- a/apps/scan/src/services/db/resources/origin.ts
+++ b/apps/scan/src/services/db/resources/origin.ts
@@ -29,12 +29,17 @@ function getDisplayableAcceptsWhere({
 
 const displayableResourceWhere: Prisma.ResourcesWhereInput = {
   deprecatedAt: null,
-  response: {
-    isNot: null,
-  },
-  accepts: {
-    some: getDisplayableAcceptsWhere({}),
-  },
+  OR: [
+    // Paid resources: must have a stored 402 response and supported accepts
+    {
+      response: { isNot: null },
+      accepts: { some: getDisplayableAcceptsWhere({}) },
+    },
+    // SIWX (free) resources: identified by metadata.authMode
+    {
+      metadata: { path: ['authMode'], equals: 'siwx' },
+    },
+  ],
 };
 
 const ogImageSchema = z.object({
@@ -132,16 +137,21 @@ export const listOriginsSchema = z.object({
 export const listOrigins = async (input: z.infer<typeof listOriginsSchema>) => {
   const { chain, address } = input;
   const acceptsWhere = getDisplayableAcceptsWhere({ chain, address });
+  // SIWX (free) resources have no chain/address — only include them when
+  // no chain or address filter is applied.
+  const hasPaymentFilter = chain != null || address != null;
+  const resourceFilter: Prisma.ResourcesWhereInput = hasPaymentFilter
+    ? { deprecatedAt: null, accepts: { some: acceptsWhere } }
+    : {
+        deprecatedAt: null,
+        OR: [
+          { accepts: { some: acceptsWhere } },
+          { metadata: { path: ['authMode'], equals: 'siwx' } },
+        ],
+      };
   const origins = await scanDb.resourceOrigin.findMany({
     where: {
-      resources: {
-        some: {
-          deprecatedAt: null,
-          accepts: {
-            some: acceptsWhere,
-          },
-        },
-      },
+      resources: { some: resourceFilter },
     },
     orderBy: { createdAt: 'desc' },
   });
@@ -159,32 +169,30 @@ export const listOriginsWithResources = async (
 ) => {
   const { chain, address, originIds } = input;
   const acceptsWhere = getDisplayableAcceptsWhere({ chain, address });
+  // SIWX (free) resources have no chain/address — only include them when
+  // no chain or address filter is applied.
+  const hasPaymentFilter = chain != null || address != null;
+  const paidOrSiwxResource: Prisma.ResourcesWhereInput = hasPaymentFilter
+    ? {
+        deprecatedAt: null,
+        response: { isNot: null },
+        accepts: { some: acceptsWhere },
+      }
+    : {
+        deprecatedAt: null,
+        OR: [
+          { response: { isNot: null }, accepts: { some: acceptsWhere } },
+          { metadata: { path: ['authMode'], equals: 'siwx' } },
+        ],
+      };
   const origins = await scanDb.resourceOrigin.findMany({
     where: {
       ...(originIds ? { id: { in: originIds } } : {}),
-      resources: {
-        some: {
-          deprecatedAt: null,
-          response: {
-            isNot: null,
-          },
-          accepts: {
-            some: acceptsWhere,
-          },
-        },
-      },
+      resources: { some: paidOrSiwxResource },
     },
     include: {
       resources: {
-        where: {
-          deprecatedAt: null,
-          response: {
-            isNot: null,
-          },
-          accepts: {
-            some: acceptsWhere,
-          },
-        },
+        where: paidOrSiwxResource,
         orderBy: {
           resource: 'asc',
         },

--- a/apps/scan/src/services/db/resources/resource.ts
+++ b/apps/scan/src/services/db/resources/resource.ts
@@ -292,18 +292,21 @@ const searchResourcesUncached = async (
     showDeprecated,
     chains,
   } = input;
+  const acceptsFilter: Prisma.AcceptsWhereInput =
+    chains !== undefined ? { network: { in: chains } } : {};
   return await scanDb.resources.findMany({
     where: {
-      accepts: {
-        some:
-          chains !== undefined
-            ? {
-                network: {
-                  in: chains,
-                },
-              }
-            : {},
-      },
+      // Include paid resources (with accepts) and SIWX (free) resources.
+      // When filtering by chain, SIWX resources are excluded since they
+      // have no chain-specific payment options.
+      ...(chains !== undefined
+        ? { accepts: { some: acceptsFilter } }
+        : {
+            OR: [
+              { accepts: { some: {} } },
+              { metadata: { path: ['authMode'], equals: 'siwx' } },
+            ],
+          }),
       ...(search
         ? {
             OR: [

--- a/apps/scan/src/services/db/resources/resource.ts
+++ b/apps/scan/src/services/db/resources/resource.ts
@@ -41,15 +41,15 @@ export const upsertResource = async (
   }
   const originStr = getOriginFromUrl(baseResource.resource);
 
-  // Ensure the origin exists before the transaction to avoid
-  // concurrent connectOrCreate race conditions (P2002).
-  await scanDb.resourceOrigin.upsert({
-    where: { origin: originStr },
-    create: { origin: originStr },
-    update: {},
-  });
-
   return await scanDb.$transaction(async tx => {
+    // Ensure the origin exists inside the transaction to avoid
+    // concurrent connectOrCreate race conditions (P2002).
+    await tx.resourceOrigin.upsert({
+      where: { origin: originStr },
+      create: { origin: originStr },
+      update: {},
+    });
+
     const { origin, ...resource } = await tx.resources.upsert({
       where: {
         resource: baseResource.resource,

--- a/apps/scan/src/services/db/resources/resource.ts
+++ b/apps/scan/src/services/db/resources/resource.ts
@@ -40,6 +40,15 @@ export const upsertResource = async (
     return;
   }
   const originStr = getOriginFromUrl(baseResource.resource);
+
+  // Ensure the origin exists before the transaction to avoid
+  // concurrent connectOrCreate race conditions (P2002).
+  await scanDb.resourceOrigin.upsert({
+    where: { origin: originStr },
+    create: { origin: originStr },
+    update: {},
+  });
+
   return await scanDb.$transaction(async tx => {
     const { origin, ...resource } = await tx.resources.upsert({
       where: {
@@ -52,13 +61,8 @@ export const upsertResource = async (
         lastUpdated: baseResource.lastUpdated,
         metadata: baseResource.metadata,
         origin: {
-          connectOrCreate: {
-            where: {
-              origin: originStr,
-            },
-            create: {
-              origin: originStr,
-            },
+          connect: {
+            origin: originStr,
           },
         },
       },

--- a/apps/scan/src/services/discovery/fetch-discovery.ts
+++ b/apps/scan/src/services/discovery/fetch-discovery.ts
@@ -62,10 +62,15 @@ export async function fetchDiscoveryDocument(
     };
   }
 
+  const expectedOrigin = new URL(discovered.origin).origin;
   const resources: DiscoveredResource[] = discovered.endpoints.flatMap(
     endpoint => {
       try {
         const url = new URL(endpoint.path, discovered.origin).toString();
+        // Security: reject endpoints that resolve to a different origin.
+        // A malicious OpenAPI spec could contain absolute URLs pointing
+        // elsewhere (new URL('https://evil.com/x', base) ignores the base).
+        if (new URL(url).origin !== expectedOrigin) return [];
         return [
           {
             url,

--- a/apps/scan/src/services/discovery/fetch-discovery.ts
+++ b/apps/scan/src/services/discovery/fetch-discovery.ts
@@ -66,11 +66,12 @@ export async function fetchDiscoveryDocument(
   const resources: DiscoveredResource[] = discovered.endpoints.flatMap(
     endpoint => {
       try {
-        const url = new URL(endpoint.path, discovered.origin).toString();
+        const resolved = new URL(endpoint.path, discovered.origin);
         // Security: reject endpoints that resolve to a different origin.
         // A malicious OpenAPI spec could contain absolute URLs pointing
         // elsewhere (new URL('https://evil.com/x', base) ignores the base).
-        if (new URL(url).origin !== expectedOrigin) return [];
+        if (resolved.origin !== expectedOrigin) return [];
+        const url = resolved.toString();
         return [
           {
             url,

--- a/apps/scan/src/trpc/routers/developer.ts
+++ b/apps/scan/src/trpc/routers/developer.ts
@@ -180,24 +180,10 @@ export const developerRouter = createTRPCRouter({
           error: r.invalidReason ?? 'Invalid resource format',
         }));
 
-      // Only probe endpoints that are x402-paid. Non-paid endpoints
-      // (unprotected, apiKey-only, no authMode) are returned as failed
-      // with a clear reason. SIWX endpoints are excluded entirely (they
-      // are surfaced via authModeMap on the client).
+      // Only probe endpoints that are x402-paid. Non-paid endpoints are
+      // handled client-side (grey strikethrough in the resource list).
+      // SIWX endpoints are excluded entirely (surfaced via authModeMap).
       const paidModes = new Set(['paid', 'apiKey+paid']);
-      const nonPaidResults: FailedResource[] = input.resources
-        .filter(
-          r =>
-            !r.invalid &&
-            r.authMode !== 'siwx' &&
-            (r.authMode == null || !paidModes.has(r.authMode))
-        )
-        .map(r => ({
-          success: false as const,
-          url: r.url,
-          error: `Not an x402 paid endpoint (authMode: ${r.authMode ?? 'none'})`,
-        }));
-
       const probeableResources = input.resources.filter(
         r => !r.invalid && r.authMode != null && paidModes.has(r.authMode)
       );
@@ -210,8 +196,9 @@ export const developerRouter = createTRPCRouter({
         );
       }
 
-      // Combine test results with invalid and non-paid results
-      const allResults = [...testResults, ...invalidResults, ...nonPaidResults];
+      // Combine test results with invalid results only. Non-paid endpoints
+      // are handled client-side (grey strikethrough) — they're not errors.
+      const allResults = [...testResults, ...invalidResults];
 
       return {
         resources: allResults.filter(

--- a/apps/scan/src/trpc/routers/developer.ts
+++ b/apps/scan/src/trpc/routers/developer.ts
@@ -180,12 +180,12 @@ export const developerRouter = createTRPCRouter({
           error: r.invalidReason ?? 'Invalid resource format',
         }));
 
-      // Only probe endpoints that are x402-paid. Non-paid endpoints are
-      // handled client-side (grey strikethrough in the resource list).
-      // SIWX endpoints are excluded entirely (surfaced via authModeMap).
-      const paidModes = new Set(['paid', 'apiKey+paid']);
+      // Probe endpoints that are x402-paid or unclassified (might be paid but
+      // discovery didn't detect it). Skip SIWX (identity-gated, not x402) and
+      // explicitly non-paid (unprotected, apiKey).
+      const skipModes = new Set(['siwx', 'unprotected', 'apiKey']);
       const probeableResources = input.resources.filter(
-        r => !r.invalid && r.authMode != null && paidModes.has(r.authMode)
+        r => !r.invalid && (r.authMode == null || !skipModes.has(r.authMode))
       );
       // Probe sequentially to avoid overwhelming the merchant's server.
       // Concurrent probes to the same origin can trigger rate limiting (503s).

--- a/apps/scan/src/trpc/routers/developer.ts
+++ b/apps/scan/src/trpc/routers/developer.ts
@@ -70,14 +70,16 @@ async function testSingleResource(
       };
     }
 
-    // Drop discovery-level schema warnings that are superseded by OpenAPI data.
-    // The discovery package warns when the raw 402 body lacks bazaar schemas,
-    // but the advisory may already have schemas from the OpenAPI spec.
+    // Drop discovery-level schema warnings superseded by other checks.
+    // SCHEMA_INPUT_MISSING: suppressed when advisory already has inputSchema
+    //   from OpenAPI (the 402 body lacking it is not actionable).
+    // SCHEMA_OUTPUT_MISSING: always suppressed — validateResource() has its
+    //   own MISSING_OUTPUT_SCHEMA check that includes bazaar fallback, so
+    //   the discovery-level warning would be a duplicate or less precise.
     const probeWarnings = result.warnings.filter(w => {
       if (w.code === 'SCHEMA_INPUT_MISSING' && advisory.inputSchema)
         return false;
-      if (w.code === 'SCHEMA_OUTPUT_MISSING' && advisory.outputSchema)
-        return false;
+      if (w.code === 'SCHEMA_OUTPUT_MISSING') return false;
       return true;
     });
 

--- a/apps/scan/src/trpc/routers/developer.ts
+++ b/apps/scan/src/trpc/routers/developer.ts
@@ -180,11 +180,24 @@ export const developerRouter = createTRPCRouter({
           error: r.invalidReason ?? 'Invalid resource format',
         }));
 
-      // Only probe endpoints that are x402-paid. Skip SIWX (identity-gated),
-      // unprotected, apiKey-only, and endpoints with no authMode — probing
-      // them wastes requests and can trigger rate limits on the merchant's
-      // server (e.g., 41 discovered endpoints but only 5 are paid).
+      // Only probe endpoints that are x402-paid. Non-paid endpoints
+      // (unprotected, apiKey-only, no authMode) are returned as failed
+      // with a clear reason. SIWX endpoints are excluded entirely (they
+      // are surfaced via authModeMap on the client).
       const paidModes = new Set(['paid', 'apiKey+paid']);
+      const nonPaidResults: FailedResource[] = input.resources
+        .filter(
+          r =>
+            !r.invalid &&
+            r.authMode !== 'siwx' &&
+            (r.authMode == null || !paidModes.has(r.authMode))
+        )
+        .map(r => ({
+          success: false as const,
+          url: r.url,
+          error: `Not an x402 paid endpoint (authMode: ${r.authMode ?? 'none'})`,
+        }));
+
       const probeableResources = input.resources.filter(
         r => !r.invalid && r.authMode != null && paidModes.has(r.authMode)
       );
@@ -194,8 +207,8 @@ export const developerRouter = createTRPCRouter({
         )
       );
 
-      // Combine test results with invalid results
-      const allResults = [...testResults, ...invalidResults];
+      // Combine test results with invalid and non-paid results
+      const allResults = [...testResults, ...invalidResults, ...nonPaidResults];
 
       return {
         resources: allResults.filter(

--- a/apps/scan/src/trpc/routers/developer.ts
+++ b/apps/scan/src/trpc/routers/developer.ts
@@ -201,11 +201,14 @@ export const developerRouter = createTRPCRouter({
       const probeableResources = input.resources.filter(
         r => !r.invalid && r.authMode != null && paidModes.has(r.authMode)
       );
-      const testResults = await Promise.all(
-        probeableResources.map(r =>
-          testSingleResource(r.url, r.method, r.sampleBody)
-        )
-      );
+      // Probe sequentially to avoid overwhelming the merchant's server.
+      // Concurrent probes to the same origin can trigger rate limiting (503s).
+      const testResults = [];
+      for (const r of probeableResources) {
+        testResults.push(
+          await testSingleResource(r.url, r.method, r.sampleBody)
+        );
+      }
 
       // Combine test results with invalid and non-paid results
       const allResults = [...testResults, ...invalidResults, ...nonPaidResults];

--- a/apps/scan/src/trpc/routers/developer.ts
+++ b/apps/scan/src/trpc/routers/developer.ts
@@ -8,6 +8,7 @@ import type { FailedResource, TestedResource } from '@/types/batch-test';
 import { probeX402Endpoint } from '@/lib/discovery/probe';
 import { validateResource } from '@/lib/resources';
 import { fetchDiscoveryDocument } from '@/services/discovery';
+import { deduplicateWarnings } from '@/lib/discovery/utils';
 
 /**
  * Test a single resource by probing it and running the same validation
@@ -89,7 +90,7 @@ async function testSingleResource(
       method: advisory.method as TestedResource['method'],
       description: advisory.summary ?? null,
       parsed: advisory,
-      warnings: [...probeWarnings, ...validation.warnings],
+      warnings: deduplicateWarnings([...probeWarnings, ...validation.warnings]),
     };
   } catch (err) {
     return {

--- a/apps/scan/src/trpc/routers/developer.ts
+++ b/apps/scan/src/trpc/routers/developer.ts
@@ -70,13 +70,24 @@ async function testSingleResource(
       };
     }
 
+    // Drop discovery-level schema warnings that are superseded by OpenAPI data.
+    // The discovery package warns when the raw 402 body lacks bazaar schemas,
+    // but the advisory may already have schemas from the OpenAPI spec.
+    const probeWarnings = result.warnings.filter(w => {
+      if (w.code === 'SCHEMA_INPUT_MISSING' && advisory.inputSchema)
+        return false;
+      if (w.code === 'SCHEMA_OUTPUT_MISSING' && advisory.outputSchema)
+        return false;
+      return true;
+    });
+
     return {
       success: true as const,
       url,
       method: advisory.method as TestedResource['method'],
       description: advisory.summary ?? null,
       parsed: advisory,
-      warnings: [...result.warnings, ...validation.warnings],
+      warnings: [...probeWarnings, ...validation.warnings],
     };
   } catch (err) {
     return {

--- a/apps/scan/src/trpc/routers/developer.ts
+++ b/apps/scan/src/trpc/routers/developer.ts
@@ -9,6 +9,10 @@ import { probeX402Endpoint } from '@/lib/discovery/probe';
 import { validateResource } from '@/lib/resources';
 import { fetchDiscoveryDocument } from '@/services/discovery';
 import { deduplicateWarnings } from '@/lib/discovery/utils';
+import {
+  createProbeSession,
+  cacheProbeResult,
+} from '@/lib/discovery/probe-cache';
 
 /**
  * Test a single resource by probing it and running the same validation
@@ -146,10 +150,15 @@ export const developerRouter = createTRPCRouter({
       };
     }),
 
-  /** Batch test multiple resources to get their x402 responses */
+  /** Batch test multiple resources to get their x402 responses.
+   *  Successful probe results are cached server-side under `probeSessionId`
+   *  so the registration endpoint can reuse them without trusting client data. */
   batchTest: publicProcedure
     .input(
       z.object({
+        /** Probe session ID. If omitted, a new session is created. Pass the
+         *  sessionId from a previous batch to append to the same cache. */
+        probeSessionId: z.string().uuid().optional(),
         resources: z
           .array(
             z.object({
@@ -185,6 +194,8 @@ export const developerRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ input }) => {
+      const sessionId = input.probeSessionId ?? createProbeSession();
+
       // Separate invalid resources from valid ones
       const invalidResults: FailedResource[] = input.resources
         .filter(r => r.invalid)
@@ -205,9 +216,18 @@ export const developerRouter = createTRPCRouter({
       // Concurrent probes to the same origin can trigger rate limiting (503s).
       const testResults = [];
       for (const r of probeableResources) {
-        testResults.push(
-          await testSingleResource(r.url, r.method, r.sampleBody)
-        );
+        const result = await testSingleResource(r.url, r.method, r.sampleBody);
+        // Cache successful probes server-side so registration can reuse them
+        // without the advisory data ever round-tripping through the client.
+        if (result.success) {
+          void cacheProbeResult(
+            sessionId,
+            result.url,
+            result.parsed,
+            result.warnings ?? []
+          );
+        }
+        testResults.push(result);
       }
 
       // Combine test results with invalid results only. Non-paid endpoints
@@ -215,6 +235,7 @@ export const developerRouter = createTRPCRouter({
       const allResults = [...testResults, ...invalidResults];
 
       return {
+        probeSessionId: sessionId,
         resources: allResults.filter(
           (r): r is Extract<typeof r, { success: true }> => r.success
         ),

--- a/apps/scan/src/trpc/routers/developer.ts
+++ b/apps/scan/src/trpc/routers/developer.ts
@@ -180,11 +180,13 @@ export const developerRouter = createTRPCRouter({
           error: r.invalidReason ?? 'Invalid resource format',
         }));
 
-      // SIWX routes are identity-gated, not payment-protected. Skip probing
-      // them — they are surfaced via authModeMap on the client and should not
-      // appear in either the tested or failed buckets.
+      // Only probe endpoints that are x402-paid. Skip SIWX (identity-gated),
+      // unprotected, apiKey-only, and endpoints with no authMode — probing
+      // them wastes requests and can trigger rate limits on the merchant's
+      // server (e.g., 41 discovered endpoints but only 5 are paid).
+      const paidModes = new Set(['paid', 'apiKey+paid']);
       const probeableResources = input.resources.filter(
-        r => !r.invalid && r.authMode !== 'siwx'
+        r => !r.invalid && r.authMode != null && paidModes.has(r.authMode)
       );
       const testResults = await Promise.all(
         probeableResources.map(r =>

--- a/apps/scan/src/trpc/routers/public/resources.ts
+++ b/apps/scan/src/trpc/routers/public/resources.ts
@@ -1,4 +1,5 @@
 import z from 'zod';
+import type { EndpointMethodAdvisory } from '@agentcash/discovery';
 
 import {
   createTRPCRouter,
@@ -149,6 +150,16 @@ export const resourcesRouter = createTRPCRouter({
     .input(
       z.object({
         origin: z.url(),
+        /** Pre-tested advisory data from the batch test. URLs with a matching
+         *  entry skip re-probing — avoids rate limiting on registration. */
+        preTestedResults: z
+          .array(
+            z.object({
+              url: z.string().url(),
+              advisory: z.unknown(),
+            })
+          )
+          .optional(),
       })
     )
     .mutation(async ({ input }) => {
@@ -164,10 +175,22 @@ export const resourcesRouter = createTRPCRouter({
         };
       }
 
+      // Build map of pre-tested advisories keyed by URL.
+      const preTestedAdvisories =
+        input.preTestedResults && input.preTestedResults.length > 0
+          ? new Map(
+              input.preTestedResults.map(r => [
+                r.url,
+                r.advisory as EndpointMethodAdvisory,
+              ])
+            )
+          : undefined;
+
       const result = await registerResourcesFromDiscovery(
         discoveryResult.resources,
         discoveryResult.source,
-        discoveryResult.info
+        discoveryResult.info,
+        preTestedAdvisories
       );
 
       if (result.registered === 0 && result.siwx === 0) {

--- a/apps/scan/src/trpc/routers/public/resources.ts
+++ b/apps/scan/src/trpc/routers/public/resources.ts
@@ -170,13 +170,13 @@ export const resourcesRouter = createTRPCRouter({
         discoveryResult.info
       );
 
-      if (result.registered === 0) {
+      if (result.registered === 0 && result.siwx === 0) {
         return {
           success: false as const,
           error: {
             type: 'noValidResources' as const,
             message:
-              'No valid paid x402 resources were found for this origin. Add at least one paid x402 resource that passes validation to complete registration.',
+              'No valid x402 or free (SIWX) resources were found for this origin. Add at least one resource that passes validation to complete registration.',
           },
           result,
         };

--- a/apps/scan/src/trpc/routers/public/resources.ts
+++ b/apps/scan/src/trpc/routers/public/resources.ts
@@ -1,5 +1,4 @@
 import z from 'zod';
-import type { EndpointMethodAdvisory } from '@agentcash/discovery';
 
 import {
   createTRPCRouter,
@@ -145,21 +144,19 @@ export const resourcesRouter = createTRPCRouter({
   /**
    * Register all x402 resources discovered from an origin.
    * Uses DNS TXT records (_x402.{hostname}) or /.well-known/x402 for discovery.
+   *
+   * SECURITY: Advisory data (payTo addresses, schemas, etc.) is never accepted
+   * from the client. If a probeSessionId is provided, the server reads cached
+   * probe results that it wrote during the batch test. This prevents payment
+   * redirection attacks where a malicious client substitutes payTo addresses.
    */
   registerFromOrigin: publicProcedure
     .input(
       z.object({
         origin: z.url(),
-        /** Pre-tested advisory data from the batch test. URLs with a matching
-         *  entry skip re-probing — avoids rate limiting on registration. */
-        preTestedResults: z
-          .array(
-            z.object({
-              url: z.string().url(),
-              advisory: z.unknown(),
-            })
-          )
-          .optional(),
+        /** Server-side probe session from the batch test. URLs with a cached
+         *  probe result skip re-probing — avoids rate limiting on registration. */
+        probeSessionId: z.string().uuid().optional(),
       })
     )
     .mutation(async ({ input }) => {
@@ -175,22 +172,11 @@ export const resourcesRouter = createTRPCRouter({
         };
       }
 
-      // Build map of pre-tested advisories keyed by URL.
-      const preTestedAdvisories =
-        input.preTestedResults && input.preTestedResults.length > 0
-          ? new Map(
-              input.preTestedResults.map(r => [
-                r.url,
-                r.advisory as EndpointMethodAdvisory,
-              ])
-            )
-          : undefined;
-
       const result = await registerResourcesFromDiscovery(
         discoveryResult.resources,
         discoveryResult.source,
         discoveryResult.info,
-        preTestedAdvisories
+        input.probeSessionId
       );
 
       if (result.registered === 0 && result.siwx === 0) {


### PR DESCRIPTION
## Summary

Overhaul of merchant registration — fixes schema detection, adds SIWX (Free) endpoint support, cleans up the UI, hardens robustness, **fixes a payment redirection vulnerability**, and **recovers endpoints with oversized response headers**.

### Security: server-side probe cache
- **Eliminated client-trusted advisory data** — probe results (including `payTo` addresses) previously round-tripped through the client. A malicious actor could intercept the tRPC call and substitute payment addresses.
- **Server-side Redis cache** — batch test stores probe results under `probe-session:{sessionId}:{url}` with 5-min TTL. Registration reads from this cache; the client only passes an opaque `probeSessionId`.
- **Cross-origin URL validation** — discovery now rejects endpoints whose resolved URL doesn't match the discovery origin, preventing malicious OpenAPI specs from injecting absolute URLs to other origins.

### Oversized header fallback (HEADERS_OVERFLOW)
- **Direct HTTPS probe fallback** — some merchants embed the full 402 body in a `payment-required` header, exceeding Node's 16 KB limit. The discovery library silently drops these as network errors.
- **Recovery via `node:https`** — a fallback probe with `maxHeaderSize: 128KB` recovers the 402 body, merges OpenAPI schema data, and surfaces a `HEADERS_OVERFLOW` warning to the merchant.
- **Before**: war-tracker.com registered 9/16 endpoints (7 skipped). **After**: 16/16 (7 with warnings).

### Schema detection
- **Bazaar schema fallback** in `validateResource()` — checks 402 body for bazaar extension before rejecting for missing input schema
- **Method passthrough** from discovery to probe — GET endpoints probed with GET, not POST
- **Missing output schema** is now a warning (not silent) with bazaar fallback check
- **Missing input schema** error text updated to be accurate ("requestBody or parameter schema")

### Display filtering
- **Exclude explicitly non-registrable** endpoints (`unprotected`, `apiKey`) from discovery list
- **Unclassified endpoints** (authMode absent) kept — may be paid but discovery didn't detect it
- **Paid endpoints probed first** to avoid rate limiting before reaching unclassified ones
- **Removed Advanced dropdown** (Custom Headers + Manual URLs) from register form

### SIWX → Free
- SIWX endpoints relabeled as **"Free"** with green styling throughout
- **SIWX DB registration** via `registerSiwxResource()` — writes Resource with `x402Version: 0`, `metadata: { authMode: 'siwx' }`
- SIWX-only origins now succeed registration
- All display queries updated with OR clauses for SIWX

### Probing
- **Per-endpoint progress** — BATCH_SIZE=1, sequential, "Checking 3/5 endpoints..."
- **Skip SIWX/unprotected/apiKey** from probing — only probe paid + unclassified
- **Sequential within chunks** to avoid rate-limiting merchant servers
- **Retry on 429/503** with exponential backoff (up to 2 retries)

### Warnings & prompts
- **Consolidated prompt system** — one prompt combines all errors + warnings + missing schemas
- **Deduplicate warnings** by code+message via shared `deduplicateWarnings()` utility
- **"(Not blocking)"** on post-registration warnings dropdown
- **Registration error message** now tells merchants about `security: []` for free endpoints

### Documentation
- **New "Free (Unprotected) Endpoints" section** on discovery spec page

### Robustness
- **P2002 race fix** in `registerSiwxResource` — concurrent registrations caught and treated as success
- **Origin upsert inside transaction** — prevents P2002 on concurrent registrations
- **Non-blocking metadata scrape** in `registerSiwxResource`
- **Sorted resource tables** — pre-registration: invalid → free → new → registered

## Test results (21 origins)

| Origin | Endpoints | Registered | SIWX | Failed | Skipped | Notes |
|---|---|---|---|---|---|---|
| stableupload.dev | 11 | 3 | 7 | 0 | 1 | 1 unprotected skipped |
| stablesocial.dev | 37 | 36 | 1 | 0 | 0 | Clean |
| stablestudio.dev | 30 | 26 | 4 | 0 | 0 | Clean |
| stableemail.dev | 24 | 13 | 11 | 0 | 0 | Clean |
| rep.memoryapi.org | 5 | 5 | 0 | 0 | 0 | Bazaar detection works |
| api.northeastdealintel.com | 41 | 1 | 0 | 0 | 40 | 36 unclassified non-x402 |
| api.vishwalab.com | 2 | 2 | 0 | 0 | 0 | Clean |
| stableflowers.dev | 6 | 1 | 2 | 0 | 3 | 3 unprotected skipped |
| stablemerch.dev | 3 | 3 | 0 | 0 | 0 | Clean |
| stabletube.dev | 3 | 1 | 1 | 0 | 1 | Clean |
| war-tracker.com | 16 | 16 | 0 | 0 | 0 | 7 with HEADERS_OVERFLOW warning |
| api.carbon-cashmere.de | 431 | 253 | 0 | 0 | 178 | Unclassified endpoints skipped |
| api.strale.io | 367 | 0 | 0 | 348 | 19 | All v1 — merchant needs to migrate |
| ai.verifik.co | 141 | 141 | 0 | 0 | 0 | All pass (MPP warnings) |
| x402.quicknode.com | 141 | 0 | 141 | 0 | 0 | All classified as SIWX |
| stablecrypto.dev | 105 | 105 | 0 | 0 | 0 | Clean |
| blockrun.ai | 96 | 79 | 0 | 13 | 4 | 13 missing input schema |
| chainray.online | 94 | 94 | 0 | 0 | 0 | Clean |
| apiv2.laevitas.ch | 88 | 75 | 0 | 0 | 13 | 13 non-x402 infra endpoints |
| wurkapi.fun | 51 | 0 | 0 | 0 | 51 | Pure MPP/Tempo, not x402 |
| 0xtheplug.xyz | 6 | 0 | 0 | 0 | 6 | No x402 implementation |

Batch-to-registration consistency: **perfect across all 21 origins** — every batch test failure maps to a registration skip/fail with identical error messages.

## Files changed

| File | Change |
|---|---|
| `probe-cache.ts` | **New** — Redis-backed server-side probe session cache |
| `probe.ts` | Retry on 429/503, direct HTTPS fallback for oversized headers, HEADERS_OVERFLOW warning |
| `register-origin.ts` | Server-side cache lookup, SIWX DB registration, method passthrough |
| `resources.ts` | `registerSiwxResource()`, bazaar schema fallback, output schema warning |
| `developer.ts` | Cache probe results with sessionId, sequential probing, warning dedup |
| `public/resources.ts` | Accept `probeSessionId` instead of `preTestedResults` (security fix) |
| `fetch-discovery.ts` | Cross-origin URL validation |
| `use-batch-test.ts` | Per-endpoint progress, paid-first sorting, sessionId tracking |
| `use-discovery.ts` | `REGISTRABLE_AUTH_MODES` filter, pass sessionId not advisory data |
| `use-register-from-origin.ts` | Accept sessionId instead of advisory array |
| `form.tsx` | SIWX count, progress button, removed Advanced section |
| `discovery-panel.tsx` | Free badges, sorted tables, warnings |
| `discovery-actions.tsx` | Consolidated prompt system |
| `deduplicate-warnings.ts` | New shared utility |
| `markdown.ts` | Free Endpoints section + classification table on spec page |