### PR TITLE
Display SIWX (Free) resources on server pages

### DIFF
--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -590,6 +590,49 @@ export const RegisterResourceForm = () => {
         );
       })()}
 
+      {/* Unprotected endpoints — skipped, not an error */}
+      {(() => {
+        if (activeBulkResult || isBatchTestLoading || !batchTestComplete)
+          return null;
+        const unprotectedUrls = Object.entries(authModeMap)
+          .filter(([, mode]) => mode === 'unprotected' || mode === 'apiKey')
+          .map(([url]) => url);
+        if (unprotectedUrls.length === 0) return null;
+
+        return (
+          <Collapsible>
+            <CollapsibleTrigger asChild>
+              <button className="text-xs text-yellow-600 dark:text-yellow-500 flex items-center gap-1 hover:text-yellow-700 transition-colors">
+                <ChevronDown className="size-3" />
+                {unprotectedUrls.length} unprotected endpoint
+                {unprotectedUrls.length === 1 ? '' : 's'} skipped
+              </button>
+            </CollapsibleTrigger>
+            <CollapsibleContent className="pt-2 space-y-2">
+              <p className="text-xs text-muted-foreground">
+                These endpoints have no x402 paywall and won&apos;t be
+                registered. If they should be paid, add x402 payment middleware.
+                If they are intentionally free, add{' '}
+                <code className="font-mono bg-muted px-1 rounded text-[11px]">
+                  &quot;security&quot;: []
+                </code>{' '}
+                to their OpenAPI definition to suppress this notice.
+              </p>
+              <div className="space-y-1 max-h-[200px] overflow-y-auto">
+                {unprotectedUrls.map((url, idx) => (
+                  <div
+                    key={idx}
+                    className="px-2 py-1 bg-muted/50 rounded text-xs font-mono text-muted-foreground"
+                  >
+                    {toPathLabel(url)}
+                  </div>
+                ))}
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
+        );
+      })()}
+
       {/* Bulk result */}
       {activeBulkResult && activeSummaryOrigin ? (
         <DiscoveryPanel

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -137,6 +137,7 @@ export const RegisterResourceForm = () => {
     retryResource,
     authModeMap,
     invalidResourcesMap,
+    skippedResources,
   } = useDiscovery({
     url,
   });
@@ -591,47 +592,38 @@ export const RegisterResourceForm = () => {
       })()}
 
       {/* Unprotected endpoints — skipped, not an error */}
-      {(() => {
-        if (activeBulkResult || isBatchTestLoading || !batchTestComplete)
-          return null;
-        const unprotectedUrls = Object.entries(authModeMap)
-          .filter(([, mode]) => mode === 'unprotected' || mode === 'apiKey')
-          .map(([url]) => url);
-        if (unprotectedUrls.length === 0) return null;
-
-        return (
-          <Collapsible>
-            <CollapsibleTrigger asChild>
-              <button className="text-xs text-yellow-600 dark:text-yellow-500 flex items-center gap-1 hover:text-yellow-700 transition-colors">
-                <ChevronDown className="size-3" />
-                {unprotectedUrls.length} unprotected endpoint
-                {unprotectedUrls.length === 1 ? '' : 's'} skipped
-              </button>
-            </CollapsibleTrigger>
-            <CollapsibleContent className="pt-2 space-y-2">
-              <p className="text-xs text-muted-foreground">
-                These endpoints have no x402 paywall and won&apos;t be
-                registered. If they should be paid, add x402 payment middleware.
-                If they are intentionally free, add{' '}
-                <code className="font-mono bg-muted px-1 rounded text-[11px]">
-                  &quot;security&quot;: []
-                </code>{' '}
-                to their OpenAPI definition to suppress this notice.
-              </p>
-              <div className="space-y-1 max-h-[200px] overflow-y-auto">
-                {unprotectedUrls.map((url, idx) => (
-                  <div
-                    key={idx}
-                    className="px-2 py-1 bg-muted/50 rounded text-xs font-mono text-muted-foreground"
-                  >
-                    {toPathLabel(url)}
-                  </div>
-                ))}
-              </div>
-            </CollapsibleContent>
-          </Collapsible>
-        );
-      })()}
+      {!activeBulkResult && skippedResources.length > 0 && (
+        <Collapsible>
+          <CollapsibleTrigger asChild>
+            <button className="text-xs text-yellow-600 dark:text-yellow-500 flex items-center gap-1 hover:text-yellow-700 transition-colors">
+              <ChevronDown className="size-3" />
+              {skippedResources.length} unprotected endpoint
+              {skippedResources.length === 1 ? '' : 's'} skipped
+            </button>
+          </CollapsibleTrigger>
+          <CollapsibleContent className="pt-2 space-y-2">
+            <p className="text-xs text-muted-foreground">
+              These endpoints have no x402 paywall and won&apos;t be registered.
+              If they should be paid, add x402 payment middleware. If they are
+              intentionally free, add{' '}
+              <code className="font-mono bg-muted px-1 rounded text-[11px]">
+                &quot;security&quot;: []
+              </code>{' '}
+              to their OpenAPI definition to suppress this notice.
+            </p>
+            <div className="space-y-1 max-h-[200px] overflow-y-auto">
+              {skippedResources.map((r, idx) => (
+                <div
+                  key={idx}
+                  className="px-2 py-1 bg-muted/50 rounded text-xs font-mono text-muted-foreground"
+                >
+                  {toPathLabel(r.url)}
+                </div>
+              ))}
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
+      )}
 
       {/* Bulk result */}
       {activeBulkResult && activeSummaryOrigin ? (

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -151,11 +151,13 @@ export const RegisterResourceForm = () => {
 
   // After batch test completes, count passing paid resources + SIWX (free) endpoints.
   // SIWX endpoints aren't probed, so they aren't in testedResources — add them separately.
+  // Exclude SIWX URLs that were also probed (same URL, different method) to avoid double-counting.
   // Before batch test, fall back to total discovered count.
   const batchTestComplete =
     testedResources.length > 0 || failedResources.length > 0;
+  const testedUrls = new Set(testedResources.map(r => r.url));
   const siwxCount = actualDiscoveredResources.filter(
-    url => authModeMap[url] === 'siwx'
+    url => authModeMap[url] === 'siwx' && !testedUrls.has(url)
   ).length;
   const registrableResourceCount = batchTestComplete
     ? testedResources.length + siwxCount
@@ -326,6 +328,7 @@ export const RegisterResourceForm = () => {
               disabled={
                 isLoading ||
                 isBatchTestLoading ||
+                !!activeBulkResult ||
                 (failedResources.length > 0 && testedResources.length === 0)
               }
               onClick={handleRegisterDiscovered}

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -826,7 +826,7 @@ function ProbeResult({
                 ) : invalidUrls.has(resource) ? (
                   <X className="size-3 text-red-500 shrink-0" />
                 ) : siwxUrls.has(resource) ? (
-                  <Check className="size-3 text-green-600 shrink-0" />
+                  <Check className="size-3 text-blue-500 shrink-0" />
                 ) : warningUrls.has(resource) ? (
                   <TriangleAlert className="size-3 text-yellow-500 shrink-0" />
                 ) : testedUrls.has(resource) ? (

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -138,6 +138,7 @@ export const RegisterResourceForm = () => {
     authModeMap,
     invalidResourcesMap,
     skippedResources,
+    siwxResourceCount,
   } = useDiscovery({
     url,
   });
@@ -150,17 +151,12 @@ export const RegisterResourceForm = () => {
     discoveryFound && actualDiscoveredResources.length > 0;
 
   // After batch test completes, count passing paid resources + SIWX (free) endpoints.
-  // SIWX endpoints aren't probed, so they aren't in testedResources — add them separately.
-  // Exclude SIWX URLs that were also probed (same URL, different method) to avoid double-counting.
+  // SIWX endpoints aren't probed — they're counted separately from discovery data.
   // Before batch test, fall back to total discovered count.
   const batchTestComplete =
     testedResources.length > 0 || failedResources.length > 0;
-  const testedUrls = new Set(testedResources.map(r => r.url));
-  const siwxCount = actualDiscoveredResources.filter(
-    url => authModeMap[url] === 'siwx' && !testedUrls.has(url)
-  ).length;
   const registrableResourceCount = batchTestComplete
-    ? testedResources.length + siwxCount
+    ? testedResources.length + siwxResourceCount
     : actualDiscoveredResources.length;
 
   const canUseManualMode = isValidUrl && !isOriginOnly;

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
@@ -327,7 +327,10 @@ export function DiscoveryPanel({
           <div>
             <p className="text-sm font-medium">
               Successfully registered {bulkResult.registered + siwxCount} of{' '}
-              {bulkResult.total} resources
+              {bulkResult.registered +
+                siwxCount +
+                (bulkResult.failedDetails?.length ?? 0)}{' '}
+              resources
               {notRegisteredCount > 0 && (
                 <span className="text-red-600">
                   {' '}

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
@@ -421,8 +421,9 @@ export function DiscoveryPanel({
         {/* Skipped — unprotected/non-registrable endpoints */}
         {skippedDetails.length > 0 && (
           <details className="border rounded-md group">
-            <summary className="p-3 cursor-pointer hover:bg-muted/50 font-medium text-sm flex items-center gap-2 text-muted-foreground">
+            <summary className="p-3 cursor-pointer hover:bg-muted/50 font-medium text-sm flex items-center gap-2 text-yellow-600">
               <ChevronDown className="size-4 transition-transform group-open:rotate-180" />
+              <AlertCircle className="size-4 shrink-0" />
               {skippedDetails.length} unprotected endpoint
               {skippedDetails.length === 1 ? '' : 's'} skipped
             </summary>

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
@@ -314,10 +314,7 @@ export function DiscoveryPanel({
     }
 
     // Show success state if some/all resources were registered
-    const allNotRegistered = [
-      ...skippedDetails,
-      ...(bulkResult.failedDetails ?? []),
-    ];
+    const allNotRegistered = bulkResult.failedDetails ?? [];
     const notRegisteredCount = allNotRegistered.length;
 
     return (

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
@@ -146,10 +146,6 @@ export interface DiscoveryPanelProps {
       warnings: { code: string; severity: string; message: string }[];
     }[];
   } | null;
-  /** Client-side count of unique registrable endpoints (deduped by URL).
-   *  When provided, used as the denominator in the success banner instead
-   *  of computing from the server response (which counts method variants). */
-  registrableCount?: number;
   /** Called when "Register All" is clicked (required in register mode) */
   onRegisterAll?: () => void;
   /** Whether to show the Register All button */

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
@@ -418,7 +418,45 @@ export function DiscoveryPanel({
           </details>
         )}
 
-        {/* Not registered — consolidated skipped + failed */}
+        {/* Skipped — unprotected/non-registrable endpoints */}
+        {skippedDetails.length > 0 && (
+          <details className="border rounded-md group">
+            <summary className="p-3 cursor-pointer hover:bg-muted/50 font-medium text-sm flex items-center gap-2 text-muted-foreground">
+              <ChevronDown className="size-4 transition-transform group-open:rotate-180" />
+              {skippedDetails.length} unprotected endpoint
+              {skippedDetails.length === 1 ? '' : 's'} skipped
+            </summary>
+            <div className="p-4 pt-2 border-t space-y-2">
+              <p className="text-xs text-muted-foreground">
+                These endpoints were identified as unprotected (no x402
+                paywall). They are not registered. If they should be paid, add
+                x402 payment middleware. If they are intentionally free, add{' '}
+                <code className="font-mono bg-muted px-1 rounded">
+                  &quot;security&quot;: []
+                </code>{' '}
+                to their OpenAPI definition to suppress this notice.
+              </p>
+              <div className="space-y-1 max-h-[200px] overflow-y-auto">
+                {skippedDetails.map((skipped, idx) => (
+                  <div
+                    key={idx}
+                    className="px-3 py-1.5 bg-muted/50 rounded text-xs font-mono text-muted-foreground"
+                  >
+                    {(() => {
+                      try {
+                        return new URL(skipped.url).pathname;
+                      } catch {
+                        return skipped.url;
+                      }
+                    })()}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </details>
+        )}
+
+        {/* Not registered — actual probe failures */}
         {notRegisteredCount > 0 && (
           <details className="border rounded-md group" open>
             <summary className="p-3 cursor-pointer hover:bg-muted/50 font-medium text-sm flex items-center gap-2">

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
@@ -242,7 +242,11 @@ export function DiscoveryPanel({
                 Registration Failed
               </h2>
               <p className="text-sm text-muted-foreground">
-                Failed to register all {bulkResult.total} resources
+                Failed to register all{' '}
+                {bulkResult.registered +
+                  siwxCount +
+                  (bulkResult.failedDetails?.length ?? 0)}{' '}
+                resources
               </p>
               <DiscoveryFixHint
                 className="mt-1"

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
@@ -146,6 +146,10 @@ export interface DiscoveryPanelProps {
       warnings: { code: string; severity: string; message: string }[];
     }[];
   } | null;
+  /** Client-side count of unique registrable endpoints (deduped by URL).
+   *  When provided, used as the denominator in the success banner instead
+   *  of computing from the server response (which counts method variants). */
+  registrableCount?: number;
   /** Called when "Register All" is clicked (required in register mode) */
   onRegisterAll?: () => void;
   /** Whether to show the Register All button */

--- a/apps/scan/src/app/(app)/_components/discovery/use-discovery.ts
+++ b/apps/scan/src/app/(app)/_components/discovery/use-discovery.ts
@@ -229,9 +229,10 @@ export function useDiscovery({
     () => effectiveResources.map(r => r.url),
     [effectiveResources]
   );
-  // Only the actually discovered resources (not the prepended user-entered URL)
+  // Only the actually discovered resources (not the prepended user-entered URL).
+  // Deduplicated — the same URL can appear with different methods (e.g. GET siwx + POST paid).
   const actualDiscoveredUrls = useMemo(
-    () => discoveryResources.map(r => r.url),
+    () => [...new Set(discoveryResources.map(r => r.url))],
     [discoveryResources]
   );
   // Create map of URL -> invalid status for displaying badges

--- a/apps/scan/src/app/(app)/_components/discovery/use-discovery.ts
+++ b/apps/scan/src/app/(app)/_components/discovery/use-discovery.ts
@@ -68,6 +68,7 @@ export interface UseDiscoveryReturn {
   discoveryResources: string[];
   actualDiscoveredResources: string[];
   skippedResources: { url: string; authMode?: string }[];
+  siwxResourceCount: number;
   discoveryResourceCount: number;
   discoveryError?: string;
   invalidResourcesMap: Record<string, { invalid: boolean; reason?: string }>;
@@ -229,10 +230,9 @@ export function useDiscovery({
     () => effectiveResources.map(r => r.url),
     [effectiveResources]
   );
-  // Only the actually discovered resources (not the prepended user-entered URL).
-  // Deduplicated — the same URL can appear with different methods (e.g. GET siwx + POST paid).
+  // Only the actually discovered resources (not the prepended user-entered URL)
   const actualDiscoveredUrls = useMemo(
-    () => [...new Set(discoveryResources.map(r => r.url))],
+    () => discoveryResources.map(r => r.url),
     [discoveryResources]
   );
   // Create map of URL -> invalid status for displaying badges
@@ -332,6 +332,8 @@ export function useDiscovery({
     discoveryResources: resourceUrls,
     actualDiscoveredResources: actualDiscoveredUrls,
     skippedResources,
+    siwxResourceCount: discoveryResources.filter(r => r.authMode === 'siwx')
+      .length,
     discoveryResourceCount: effectiveResources.length,
     discoveryError:
       discoveryQuery.data?.found === false

--- a/apps/scan/src/app/(app)/_components/discovery/use-discovery.ts
+++ b/apps/scan/src/app/(app)/_components/discovery/use-discovery.ts
@@ -67,6 +67,7 @@ export interface UseDiscoveryReturn {
   discoverySource?: DiscoverySource;
   discoveryResources: string[];
   actualDiscoveredResources: string[];
+  skippedResources: { url: string; authMode?: string }[];
   discoveryResourceCount: number;
   discoveryError?: string;
   invalidResourcesMap: Record<string, { invalid: boolean; reason?: string }>;
@@ -169,6 +170,12 @@ export function useDiscovery({
     // detect it (e.g. bazaar-only endpoints).
     return raw.filter(
       r => r.authMode == null || REGISTRABLE_AUTH_MODES.has(r.authMode)
+    );
+  }, [discoveryQuery.data]);
+  const skippedResources: DiscoveredResource[] = useMemo(() => {
+    const raw = discoveryQuery.data?.found ? discoveryQuery.data.resources : [];
+    return raw.filter(
+      r => r.authMode != null && !REGISTRABLE_AUTH_MODES.has(r.authMode)
     );
   }, [discoveryQuery.data]);
   const discoveryCheckComplete =
@@ -323,6 +330,7 @@ export function useDiscovery({
       : undefined,
     discoveryResources: resourceUrls,
     actualDiscoveredResources: actualDiscoveredUrls,
+    skippedResources,
     discoveryResourceCount: effectiveResources.length,
     discoveryError:
       discoveryQuery.data?.found === false

--- a/apps/scan/src/app/(app)/_components/resources/origin-resources.tsx
+++ b/apps/scan/src/app/(app)/_components/resources/origin-resources.tsx
@@ -10,7 +10,7 @@ import {
 
 import { ResourceCard, LoadingResourceCard } from './resource-card';
 
-import { getBazaarMethod } from './utils';
+import { getBazaarMethod, isSiwxResource } from './utils';
 import { serializeAccepts } from '@/lib/token';
 
 import type { RouterOutputs } from '@/trpc/client';
@@ -28,7 +28,9 @@ export const OriginResources: React.FC<Props> = ({
 }) => {
   const successfulResources = resources.filter(
     resource =>
-      resource.success && resource.accepts && resource.accepts.length > 0
+      resource.success &&
+      ((resource.accepts && resource.accepts.length > 0) ||
+        isSiwxResource(resource))
   );
 
   if (successfulResources.length === 0) {
@@ -47,8 +49,8 @@ export const OriginResources: React.FC<Props> = ({
 
   return (
     <div className="border-b-0 gap-0">
-      {resources
-        .filter(resource => resource.success)
+      {successfulResources
+        .filter(r => r.success)
         .map(resource => {
           const rawOutputSchema = resource.accepts.find(
             accept => accept.outputSchema

--- a/apps/scan/src/app/(app)/_components/resources/resource-card.tsx
+++ b/apps/scan/src/app/(app)/_components/resources/resource-card.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/tooltip';
 
 import { Header } from './header/index';
+import { isSiwxResource } from './utils';
 
 import { cn, formatCurrency } from '@/lib/utils';
 import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard';
@@ -71,9 +72,13 @@ export const ResourceCard: React.FC<Props> = ({
             hideOrigin={hideOrigin}
           />
           <div className="flex items-center gap-2">
-            {accepts && accepts.length > 0 && (
+            {accepts && accepts.length > 0 ? (
               <ResourcePricing accepts={accepts} />
-            )}
+            ) : isSiwxResource(resource) ? (
+              <span className="text-xs font-semibold text-green-600 font-mono shrink-0">
+                Free
+              </span>
+            ) : null}
             {ownershipVerified && (
               <Tooltip>
                 <TooltipTrigger asChild>

--- a/apps/scan/src/app/(app)/_components/resources/resource-card.tsx
+++ b/apps/scan/src/app/(app)/_components/resources/resource-card.tsx
@@ -25,6 +25,7 @@ import type { Resources, Tag } from '@x402scan/scan-db';
 interface SerializedAccept {
   maxAmountRequired: number;
   network: string;
+  scheme: string;
 }
 
 interface Props {
@@ -134,10 +135,13 @@ export const ResourceCard: React.FC<Props> = ({
 const ResourcePricing: React.FC<{ accepts: SerializedAccept[] }> = ({
   accepts,
 }) => {
-  const minAmount = Math.min(...accepts.map(a => a.maxAmountRequired));
+  const isDynamic = accepts.some(a => a.scheme !== 'exact');
+  const maxAmount = Math.max(...accepts.map(a => a.maxAmountRequired));
   return (
     <span className="text-xs font-semibold text-primary font-mono shrink-0">
-      {formatCurrency(minAmount)}
+      {isDynamic
+        ? `Up to ${formatCurrency(maxAmount)}`
+        : formatCurrency(maxAmount)}
     </span>
   );
 };

--- a/apps/scan/src/app/(app)/_components/resources/utils.ts
+++ b/apps/scan/src/app/(app)/_components/resources/utils.ts
@@ -1,4 +1,14 @@
 import { Methods } from '@/types/x402';
+import type { Resources } from '@x402scan/scan-db';
+
+export function isSiwxResource(resource: Pick<Resources, 'metadata'>): boolean {
+  return (
+    resource.metadata != null &&
+    typeof resource.metadata === 'object' &&
+    'authMode' in resource.metadata &&
+    resource.metadata.authMode === 'siwx'
+  );
+}
 
 export function getBazaarMethod(outputSchema: unknown): Methods {
   if (

--- a/apps/scan/src/lib/discovery/register-origin.ts
+++ b/apps/scan/src/lib/discovery/register-origin.ts
@@ -123,8 +123,19 @@ export async function registerResourcesFromDiscovery(
         };
   }
 
+  const SKIP_AUTH_MODES = new Set(['unprotected', 'apiKey']);
+
   const results = await mapSettledWithConcurrency(resources, async resource => {
     const resourceUrl = resource.url;
+
+    if (resource.authMode && SKIP_AUTH_MODES.has(resource.authMode)) {
+      return {
+        success: false as const,
+        url: resourceUrl,
+        error: 'Non-registrable endpoint',
+        skipped: true as const,
+      };
+    }
 
     if (resource.authMode === 'siwx') {
       return registerAsSiwx(resourceUrl);

--- a/apps/scan/src/services/db/resources/origin.ts
+++ b/apps/scan/src/services/db/resources/origin.ts
@@ -2,11 +2,20 @@ import { z } from 'zod';
 
 import { scanDb } from '@x402scan/scan-db';
 
-import { parseX402Response } from '@/lib/x402';
+import { parseX402Response, type ParsedX402Response } from '@/lib/x402';
 import { mixedAddressSchema, optionalChainSchema } from '@/lib/schemas';
 import { SUPPORTED_CHAINS } from '@/types/chain';
 
-import type { AcceptsNetwork, Prisma } from '@x402scan/scan-db';
+import type { AcceptsNetwork, Prisma, Resources } from '@x402scan/scan-db';
+
+function isSiwxResource(resource: Pick<Resources, 'metadata'>): boolean {
+  return (
+    resource.metadata != null &&
+    typeof resource.metadata === 'object' &&
+    'authMode' in resource.metadata &&
+    resource.metadata.authMode === 'siwx'
+  );
+}
 
 const SUPPORTED_ACCEPT_NETWORKS = SUPPORTED_CHAINS.map(
   chain => chain as AcceptsNetwork
@@ -220,6 +229,15 @@ export const listOriginsWithResources = async (
     .map(origin => ({
       ...origin,
       resources: origin.resources.map(resource => {
+        // SIWX (free) resources have no 402 response — they're identity-gated,
+        // not paid. Treat them as successful with empty payment data.
+        if (isSiwxResource(resource)) {
+          return {
+            ...resource,
+            success: true as const,
+            data: {} as ParsedX402Response,
+          };
+        }
         const response = parseX402Response(resource.response?.response);
         if (!response.success) {
           console.error(


### PR DESCRIPTION
## Summary

- **SIWX (Free) resources on server pages** — were registered to DB but hidden from display. Now show with green "Free" label.
- **Dynamic pricing** — endpoints with `scheme !== 'exact'` now show "Up to $X" instead of a misleading flat price.
- **Skip unprotected endpoints** — registration no longer probes `unprotected`/`apiKey` endpoints, eliminating misleading "No valid x402 response" failures.
- **Banner count fix** — success banner denominator now excludes skipped endpoints, matching the pre-registration button count.
