### PR TITLE
Revalidate server pages after registration + display dynamic pricing

### DIFF
--- a/apps/scan/src/app/api/x402/_handlers/registry-register-origin.ts
+++ b/apps/scan/src/app/api/x402/_handlers/registry-register-origin.ts
@@ -2,6 +2,7 @@ import type { registryRegisterOriginBodySchema } from '@/app/api/x402/_lib/schem
 import { jsonResponse } from '@/app/api/x402/_lib/utils';
 import { fetchDiscoveryDocument } from '@/services/discovery';
 import { registerResourcesFromDiscovery } from '@/lib/discovery/register-origin';
+import { revalidatePath } from 'next/cache';
 
 import type { z } from 'zod';
 
@@ -29,6 +30,12 @@ export async function handleRegistryRegisterOrigin(
     discoveryResult.source,
     discoveryResult.info
   );
+
+  try {
+    if (result.originId) {
+      revalidatePath(`/server/${result.originId}`);
+    }
+  } catch {}
 
   if (result.registered === 0) {
     return jsonResponse(

--- a/apps/scan/src/app/api/x402/_handlers/registry-register-origin.ts
+++ b/apps/scan/src/app/api/x402/_handlers/registry-register-origin.ts
@@ -35,7 +35,9 @@ export async function handleRegistryRegisterOrigin(
     if (result.originId) {
       revalidatePath(`/server/${result.originId}`);
     }
-  } catch {}
+  } catch (e) {
+    console.error('revalidatePath failed:', e);
+  }
 
   if (result.registered === 0) {
     return jsonResponse(

--- a/apps/scan/src/app/api/x402/_handlers/registry-register.ts
+++ b/apps/scan/src/app/api/x402/_handlers/registry-register.ts
@@ -1,12 +1,19 @@
 import type { registryRegisterBodySchema } from '@/app/api/x402/_lib/schemas';
 import { jsonResponse } from '@/app/api/x402/_lib/utils';
 import { registerEndpoint } from '@/lib/discovery/register-endpoint';
+import { revalidatePath } from 'next/cache';
 import type { z } from 'zod';
 
 export async function handleRegistryRegister(
   body: z.infer<typeof registryRegisterBodySchema>
 ) {
   const result = await registerEndpoint(body.url);
+
+  try {
+    if (result.success && result.resource?.origin?.id) {
+      revalidatePath(`/server/${result.resource.origin.id}`);
+    }
+  } catch {}
 
   if (!result.success) {
     return jsonResponse(result, 422);

--- a/apps/scan/src/app/api/x402/_handlers/registry-register.ts
+++ b/apps/scan/src/app/api/x402/_handlers/registry-register.ts
@@ -13,7 +13,9 @@ export async function handleRegistryRegister(
     if (result.success && result.resource?.origin?.id) {
       revalidatePath(`/server/${result.resource.origin.id}`);
     }
-  } catch {}
+  } catch (e) {
+    console.error('revalidatePath failed:', e);
+  }
 
   if (!result.success) {
     return jsonResponse(result, 422);

--- a/apps/scan/src/trpc/routers/public/resources.ts
+++ b/apps/scan/src/trpc/routers/public/resources.ts
@@ -144,7 +144,9 @@ export const resourcesRouter = createTRPCRouter({
         if (result.success && result.resource?.origin?.id) {
           revalidatePath(`/server/${result.resource.origin.id}`);
         }
-      } catch {}
+      } catch (e) {
+        console.error('revalidatePath failed:', e);
+      }
       return result;
     }),
 
@@ -202,7 +204,9 @@ export const resourcesRouter = createTRPCRouter({
         if (result.originId) {
           revalidatePath(`/server/${result.originId}`);
         }
-      } catch {}
+      } catch (e) {
+        console.error('revalidatePath failed:', e);
+      }
 
       return { success: true as const, ...result };
     }),

--- a/apps/scan/src/trpc/routers/public/resources.ts
+++ b/apps/scan/src/trpc/routers/public/resources.ts
@@ -1,4 +1,5 @@
 import z from 'zod';
+import { revalidatePath } from 'next/cache';
 
 import {
   createTRPCRouter,
@@ -138,7 +139,13 @@ export const resourcesRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ input }) => {
-      return await registerEndpoint(input.url.toString());
+      const result = await registerEndpoint(input.url.toString());
+      try {
+        if (result.success && result.resource?.origin?.id) {
+          revalidatePath(`/server/${result.resource.origin.id}`);
+        }
+      } catch {}
+      return result;
     }),
 
   /**
@@ -190,6 +197,12 @@ export const resourcesRouter = createTRPCRouter({
           result,
         };
       }
+
+      try {
+        if (result.originId) {
+          revalidatePath(`/server/${result.originId}`);
+        }
+      } catch {}
 
       return { success: true as const, ...result };
     }),


### PR DESCRIPTION
## Summary

Two fixes for server page display issues:

### 1. Revalidate server pages after registration
- Server pages (`/server/[id]`) were serving stale data because Next.js cached the SSR output
- Added `revalidatePath` calls after successful registration in all four registration paths (tRPC register, tRPC registerFromOrigin, REST register, REST register-origin)
- Pages remain statically cached for fast loads — only invalidated when data actually changes

### 2. Display dynamic pricing from discovery metadata
- Endpoints with dynamic pricing (e.g. stableflowers `/api/orders`) showed "$300.00" instead of "Up to $300.00"
- Root cause: the 402 probe has no body, so the router falls back to maxPrice with `scheme: exact`. The discovery doc correctly says `pricingMode: "dynamic"` but this was discarded during registration
- Fix: extract `pricingMode` from the discovery document, store it in `Resources.metadata`, and use it in `ResourcePricing` to detect dynamic pricing regardless of the 402 scheme
- Falls back gracefully for old resources and single-endpoint registrations (no discovery doc)

## Test plan

- [ ] Deploy to Vercel preview
- [ ] Re-register stableflowers.dev → server page should show "Up to $300.00" for POST /api/orders
- [ ] Check stablevoice.dev → paid resources should still show exact prices, SIWX should show "Free"
- [ ] Register a new origin → resource count should update immediately on server page
- [ ] Click refresh button on server page → should still work (no regression)