### PR TITLE
Display dynamic pricing + merge resource metadata on upsert

### DIFF
--- a/apps/scan/src/app/(app)/_components/resources/resource-card.tsx
+++ b/apps/scan/src/app/(app)/_components/resources/resource-card.tsx
@@ -79,8 +79,9 @@ export const ResourceCard: React.FC<Props> = ({
                 pricingMode={
                   resource.metadata != null &&
                   typeof resource.metadata === 'object' &&
-                  'pricingMode' in resource.metadata
-                    ? (resource.metadata.pricingMode as string)
+                  'pricingMode' in resource.metadata &&
+                  resource.metadata.pricingMode === 'dynamic'
+                    ? 'dynamic'
                     : undefined
                 }
               />

--- a/apps/scan/src/app/(app)/_components/resources/resource-card.tsx
+++ b/apps/scan/src/app/(app)/_components/resources/resource-card.tsx
@@ -84,6 +84,14 @@ export const ResourceCard: React.FC<Props> = ({
                     ? 'dynamic'
                     : undefined
                 }
+                price={
+                  resource.metadata != null &&
+                  typeof resource.metadata === 'object' &&
+                  'price' in resource.metadata &&
+                  typeof resource.metadata.price === 'string'
+                    ? resource.metadata.price
+                    : undefined
+                }
               />
             ) : isSiwxResource(resource) ? (
               <span className="text-xs font-semibold text-green-600 font-mono shrink-0">
@@ -142,18 +150,37 @@ export const ResourceCard: React.FC<Props> = ({
   );
 };
 
+/**
+ * Parse the min value from a discovery price string like "50-300.00 USD".
+ * Returns the numeric min, or 0 if unparseable.
+ */
+function parseMinFromPriceString(price: string): number {
+  const match = /^(\d+(?:\.\d+)?)\s*-/.exec(price);
+  return match?.[1] ? parseFloat(match[1]) : 0;
+}
+
 const ResourcePricing: React.FC<{
   accepts: SerializedAccept[];
   pricingMode?: string;
-}> = ({ accepts, pricingMode }) => {
+  price?: string;
+}> = ({ accepts, pricingMode, price }) => {
   const isDynamic =
     pricingMode === 'dynamic' || accepts.some(a => a.scheme !== 'exact');
   const maxAmount = Math.max(...accepts.map(a => a.maxAmountRequired));
+  const minAmount = price ? parseMinFromPriceString(price) : 0;
+
+  let label: string;
+  if (!isDynamic) {
+    label = formatCurrency(maxAmount);
+  } else if (minAmount > 0) {
+    label = `${formatCurrency(minAmount)}–${formatCurrency(maxAmount)}`;
+  } else {
+    label = `Up to ${formatCurrency(maxAmount)}`;
+  }
+
   return (
     <span className="text-xs font-semibold text-primary font-mono shrink-0">
-      {isDynamic
-        ? `Up to ${formatCurrency(maxAmount)}`
-        : formatCurrency(maxAmount)}
+      {label}
     </span>
   );
 };

--- a/apps/scan/src/app/(app)/_components/resources/resource-card.tsx
+++ b/apps/scan/src/app/(app)/_components/resources/resource-card.tsx
@@ -12,9 +12,9 @@ import {
 } from '@/components/ui/tooltip';
 
 import { Header } from './header/index';
-import { isSiwxResource } from './utils';
+import { formatPricingLabel, isSiwxResource } from './utils';
 
-import { cn, formatCurrency } from '@/lib/utils';
+import { cn } from '@/lib/utils';
 import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard';
 import { toast } from 'sonner';
 
@@ -150,15 +150,6 @@ export const ResourceCard: React.FC<Props> = ({
   );
 };
 
-/**
- * Parse the min value from a discovery price string like "50-300.00 USD".
- * Returns the numeric min, or 0 if unparseable.
- */
-function parseMinFromPriceString(price: string): number {
-  const match = /^(\d+(?:\.\d+)?)\s*-/.exec(price);
-  return match?.[1] ? parseFloat(match[1]) : 0;
-}
-
 const ResourcePricing: React.FC<{
   accepts: SerializedAccept[];
   pricingMode?: string;
@@ -167,16 +158,7 @@ const ResourcePricing: React.FC<{
   const isDynamic =
     pricingMode === 'dynamic' || accepts.some(a => a.scheme !== 'exact');
   const maxAmount = Math.max(...accepts.map(a => a.maxAmountRequired));
-  const minAmount = price ? parseMinFromPriceString(price) : 0;
-
-  let label: string;
-  if (!isDynamic) {
-    label = formatCurrency(maxAmount);
-  } else if (minAmount > 0) {
-    label = `${formatCurrency(minAmount)}–${formatCurrency(maxAmount)}`;
-  } else {
-    label = `Up to ${formatCurrency(maxAmount)}`;
-  }
+  const label = formatPricingLabel({ maxAmount, isDynamic, price });
 
   return (
     <span className="text-xs font-semibold text-primary font-mono shrink-0">

--- a/apps/scan/src/app/(app)/_components/resources/resource-card.tsx
+++ b/apps/scan/src/app/(app)/_components/resources/resource-card.tsx
@@ -74,7 +74,16 @@ export const ResourceCard: React.FC<Props> = ({
           />
           <div className="flex items-center gap-2">
             {accepts && accepts.length > 0 ? (
-              <ResourcePricing accepts={accepts} />
+              <ResourcePricing
+                accepts={accepts}
+                pricingMode={
+                  resource.metadata != null &&
+                  typeof resource.metadata === 'object' &&
+                  'pricingMode' in resource.metadata
+                    ? (resource.metadata.pricingMode as string)
+                    : undefined
+                }
+              />
             ) : isSiwxResource(resource) ? (
               <span className="text-xs font-semibold text-green-600 font-mono shrink-0">
                 Free
@@ -132,10 +141,12 @@ export const ResourceCard: React.FC<Props> = ({
   );
 };
 
-const ResourcePricing: React.FC<{ accepts: SerializedAccept[] }> = ({
-  accepts,
-}) => {
-  const isDynamic = accepts.some(a => a.scheme !== 'exact');
+const ResourcePricing: React.FC<{
+  accepts: SerializedAccept[];
+  pricingMode?: string;
+}> = ({ accepts, pricingMode }) => {
+  const isDynamic =
+    pricingMode === 'dynamic' || accepts.some(a => a.scheme !== 'exact');
   const maxAmount = Math.max(...accepts.map(a => a.maxAmountRequired));
   return (
     <span className="text-xs font-semibold text-primary font-mono shrink-0">

--- a/apps/scan/src/app/(app)/_components/resources/utils.test.ts
+++ b/apps/scan/src/app/(app)/_components/resources/utils.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { parseMinFromPriceString, formatPricingLabel } from './utils';
+
+describe('parseMinFromPriceString', () => {
+  it('parses integer min from range', () => {
+    expect(parseMinFromPriceString('50-300.00 USD')).toBe(50);
+  });
+
+  it('parses decimal min from range', () => {
+    expect(parseMinFromPriceString('0.01-5.00 USD')).toBe(0.01);
+  });
+
+  it('returns 0 when min is 0', () => {
+    expect(parseMinFromPriceString('0-300.00 USD')).toBe(0);
+  });
+
+  it('returns 0 for fixed price (no dash after number)', () => {
+    expect(parseMinFromPriceString('300.00 USD')).toBe(0);
+  });
+
+  it('returns 0 for empty string', () => {
+    expect(parseMinFromPriceString('')).toBe(0);
+  });
+
+  it('returns 0 for garbage input', () => {
+    expect(parseMinFromPriceString('not a price')).toBe(0);
+  });
+
+  it('returns 0 when string starts with dash', () => {
+    expect(parseMinFromPriceString('-5.00 USD')).toBe(0);
+  });
+
+  it('handles no currency suffix', () => {
+    expect(parseMinFromPriceString('10-100')).toBe(10);
+  });
+
+  it('handles whitespace around dash', () => {
+    expect(parseMinFromPriceString('50 -300.00 USD')).toBe(50);
+  });
+});
+
+describe('formatPricingLabel', () => {
+  it('shows exact price for non-dynamic', () => {
+    expect(formatPricingLabel({ maxAmount: 300, isDynamic: false })).toBe(
+      '$300.00'
+    );
+  });
+
+  it('shows "Up to" for dynamic without price', () => {
+    expect(formatPricingLabel({ maxAmount: 300, isDynamic: true })).toBe(
+      'Up to $300.00'
+    );
+  });
+
+  it('shows "Up to" for dynamic with zero min', () => {
+    expect(
+      formatPricingLabel({
+        maxAmount: 300,
+        isDynamic: true,
+        price: '0-300.00 USD',
+      })
+    ).toBe('Up to $300.00');
+  });
+
+  it('shows range for dynamic with nonzero min', () => {
+    expect(
+      formatPricingLabel({
+        maxAmount: 300,
+        isDynamic: true,
+        price: '50-300.00 USD',
+      })
+    ).toBe('$50.00–$300.00');
+  });
+
+  it('shows range with small decimals', () => {
+    expect(
+      formatPricingLabel({
+        maxAmount: 5,
+        isDynamic: true,
+        price: '0.01-5.00 USD',
+      })
+    ).toBe('$0.01–$5.00');
+  });
+
+  it('shows "Up to" for dynamic with unparseable price', () => {
+    expect(
+      formatPricingLabel({
+        maxAmount: 300,
+        isDynamic: true,
+        price: 'garbage',
+      })
+    ).toBe('Up to $300.00');
+  });
+
+  it('ignores price when not dynamic', () => {
+    expect(
+      formatPricingLabel({
+        maxAmount: 300,
+        isDynamic: false,
+        price: '50-300.00 USD',
+      })
+    ).toBe('$300.00');
+  });
+});

--- a/apps/scan/src/app/(app)/_components/resources/utils.ts
+++ b/apps/scan/src/app/(app)/_components/resources/utils.ts
@@ -1,5 +1,34 @@
+import { formatCurrency } from '@/lib/utils';
 import { Methods } from '@/types/x402';
 import type { Resources } from '@x402scan/scan-db';
+
+/**
+ * Parse the min value from a discovery price string like "50-300.00 USD".
+ * Returns the numeric min, or 0 if unparseable.
+ */
+export function parseMinFromPriceString(price: string): number {
+  const match = /^(\d+(?:\.\d+)?)\s*-/.exec(price);
+  return match?.[1] ? parseFloat(match[1]) : 0;
+}
+
+/**
+ * Build the display label for a resource's pricing.
+ * - Fixed pricing → "$300.00"
+ * - Dynamic with range → "$50.00–$300.00"
+ * - Dynamic without range → "Up to $300.00"
+ */
+export function formatPricingLabel(opts: {
+  maxAmount: number;
+  isDynamic: boolean;
+  price?: string;
+}): string {
+  if (!opts.isDynamic) return formatCurrency(opts.maxAmount);
+  const minAmount = opts.price ? parseMinFromPriceString(opts.price) : 0;
+  if (minAmount > 0) {
+    return `${formatCurrency(minAmount)}–${formatCurrency(opts.maxAmount)}`;
+  }
+  return `Up to ${formatCurrency(opts.maxAmount)}`;
+}
 
 export function isSiwxResource(resource: Pick<Resources, 'metadata'>): boolean {
   return (

--- a/apps/scan/src/lib/discovery/register-origin.ts
+++ b/apps/scan/src/lib/discovery/register-origin.ts
@@ -93,6 +93,7 @@ export async function registerResourcesFromDiscovery(
     method?: string;
     authMode?: AuthMode;
     pricingMode?: string;
+    price?: string;
   }[],
   source: string | undefined,
   originInfo?: { title: string; description?: string },
@@ -110,10 +111,15 @@ export async function registerResourcesFromDiscovery(
     )
   );
 
-  async function registerAsSiwx(resourceUrl: string, pricingMode?: string) {
+  async function registerAsSiwx(
+    resourceUrl: string,
+    pricingMode?: string,
+    price?: string
+  ) {
     const siwxResult = await registerSiwxResource(resourceUrl, {
       originMetadataFallback: originInfo,
       pricingMode,
+      price,
     });
     return siwxResult.success
       ? {
@@ -144,7 +150,7 @@ export async function registerResourcesFromDiscovery(
     }
 
     if (resource.authMode === 'siwx') {
-      return registerAsSiwx(resourceUrl, resource.pricingMode);
+      return registerAsSiwx(resourceUrl, resource.pricingMode, resource.price);
     }
 
     // Check server-side probe cache (from the batch test). This skips
@@ -188,7 +194,7 @@ export async function registerResourcesFromDiscovery(
     // v1 rejection is handled inside registerResource() — no duplicate check needed here.
 
     if (advisory.authMode === 'siwx') {
-      return registerAsSiwx(resourceUrl, resource.pricingMode);
+      return registerAsSiwx(resourceUrl, resource.pricingMode, resource.price);
     }
 
     const result = await registerResource(resourceUrl, advisory, {
@@ -196,6 +202,7 @@ export async function registerResourcesFromDiscovery(
       originMetadataFallback: originInfo,
       warnings: probeWarnings,
       pricingMode: resource.pricingMode,
+      price: resource.price,
     });
 
     if (result.success) return result;

--- a/apps/scan/src/lib/discovery/register-origin.ts
+++ b/apps/scan/src/lib/discovery/register-origin.ts
@@ -88,7 +88,12 @@ export interface RegisterOriginResult {
  * APIs whose homepage isn't HTML, so the scraper has nothing to extract.
  */
 export async function registerResourcesFromDiscovery(
-  resources: { url: string; method?: string; authMode?: AuthMode }[],
+  resources: {
+    url: string;
+    method?: string;
+    authMode?: AuthMode;
+    pricingMode?: string;
+  }[],
   source: string | undefined,
   originInfo?: { title: string; description?: string },
   /** Server-side probe session ID. URLs with a cached probe result in Redis
@@ -105,9 +110,10 @@ export async function registerResourcesFromDiscovery(
     )
   );
 
-  async function registerAsSiwx(resourceUrl: string) {
+  async function registerAsSiwx(resourceUrl: string, pricingMode?: string) {
     const siwxResult = await registerSiwxResource(resourceUrl, {
       originMetadataFallback: originInfo,
+      pricingMode,
     });
     return siwxResult.success
       ? {
@@ -138,7 +144,7 @@ export async function registerResourcesFromDiscovery(
     }
 
     if (resource.authMode === 'siwx') {
-      return registerAsSiwx(resourceUrl);
+      return registerAsSiwx(resourceUrl, resource.pricingMode);
     }
 
     // Check server-side probe cache (from the batch test). This skips
@@ -182,13 +188,14 @@ export async function registerResourcesFromDiscovery(
     // v1 rejection is handled inside registerResource() — no duplicate check needed here.
 
     if (advisory.authMode === 'siwx') {
-      return registerAsSiwx(resourceUrl);
+      return registerAsSiwx(resourceUrl, resource.pricingMode);
     }
 
     const result = await registerResource(resourceUrl, advisory, {
       notifyNewServer: false,
       originMetadataFallback: originInfo,
       warnings: probeWarnings,
+      pricingMode: resource.pricingMode,
     });
 
     if (result.success) return result;

--- a/apps/scan/src/lib/resources.ts
+++ b/apps/scan/src/lib/resources.ts
@@ -160,6 +160,7 @@ export async function registerSiwxResource(
   url: string,
   options: {
     originMetadataFallback?: { title?: string; description?: string };
+    pricingMode?: string;
   } = {}
 ) {
   const urlObj = new URL(url);
@@ -186,6 +187,11 @@ export async function registerSiwxResource(
         update: {},
       });
 
+      const siwxMetadata = {
+        authMode: 'siwx' as const,
+        ...(options.pricingMode ? { pricingMode: options.pricingMode } : {}),
+      };
+
       return tx.resources.upsert({
         where: { resource: cleanUrl },
         create: {
@@ -193,14 +199,14 @@ export async function registerSiwxResource(
           type: 'http',
           x402Version: 0,
           lastUpdated: new Date(),
-          metadata: { authMode: 'siwx' },
+          metadata: siwxMetadata,
           origin: { connect: { origin } },
         },
         update: {
           type: 'http',
           x402Version: 0,
           lastUpdated: new Date(),
-          metadata: { authMode: 'siwx' },
+          metadata: siwxMetadata,
           deprecatedAt: null,
           origin: { connect: { origin } },
         },
@@ -295,6 +301,8 @@ export const registerResource = async (
     originMetadataFallback?: { title?: string; description?: string };
     /** Warnings from probeX402Endpoint — merged into the result. */
     warnings?: AuditWarning[];
+    /** Pricing mode from discovery document ("fixed" | "dynamic"). */
+    pricingMode?: string;
   } = {}
 ) => {
   const validation = validateResource(url, advisory);
@@ -437,6 +445,9 @@ export const registerResource = async (
     x402Version,
     lastUpdated: new Date(),
     accepts: mappedAccepts,
+    ...(options.pricingMode
+      ? { metadata: { pricingMode: options.pricingMode } }
+      : {}),
   });
 
   if (!resource) {

--- a/apps/scan/src/lib/resources.ts
+++ b/apps/scan/src/lib/resources.ts
@@ -161,6 +161,7 @@ export async function registerSiwxResource(
   options: {
     originMetadataFallback?: { title?: string; description?: string };
     pricingMode?: string;
+    price?: string;
   } = {}
 ) {
   const urlObj = new URL(url);
@@ -190,6 +191,7 @@ export async function registerSiwxResource(
       const siwxMetadata = {
         authMode: 'siwx' as const,
         ...(options.pricingMode ? { pricingMode: options.pricingMode } : {}),
+        ...(options.price ? { price: options.price } : {}),
       };
 
       // Merge with existing metadata to avoid clobbering fields set by
@@ -317,6 +319,8 @@ export const registerResource = async (
     warnings?: AuditWarning[];
     /** Pricing mode from discovery document ("fixed" | "dynamic"). */
     pricingMode?: string;
+    /** Price string from discovery document (e.g. "50-300.00 USD"). */
+    price?: string;
   } = {}
 ) => {
   const validation = validateResource(url, advisory);
@@ -459,8 +463,15 @@ export const registerResource = async (
     x402Version,
     lastUpdated: new Date(),
     accepts: mappedAccepts,
-    ...(options.pricingMode
-      ? { metadata: { pricingMode: options.pricingMode } }
+    ...(options.pricingMode || options.price
+      ? {
+          metadata: {
+            ...(options.pricingMode
+              ? { pricingMode: options.pricingMode }
+              : {}),
+            ...(options.price ? { price: options.price } : {}),
+          },
+        }
       : {}),
   });
 

--- a/apps/scan/src/lib/resources.ts
+++ b/apps/scan/src/lib/resources.ts
@@ -192,6 +192,20 @@ export async function registerSiwxResource(
         ...(options.pricingMode ? { pricingMode: options.pricingMode } : {}),
       };
 
+      // Merge with existing metadata to avoid clobbering fields set by
+      // a different registration path (e.g. paid sets pricingMode on the
+      // same URL-keyed row).
+      const existing = await tx.resources.findUnique({
+        where: { resource: cleanUrl },
+        select: { metadata: true },
+      });
+      const mergedMetadata =
+        existing?.metadata &&
+        typeof existing.metadata === 'object' &&
+        !Array.isArray(existing.metadata)
+          ? { ...existing.metadata, ...siwxMetadata }
+          : siwxMetadata;
+
       return tx.resources.upsert({
         where: { resource: cleanUrl },
         create: {
@@ -206,7 +220,7 @@ export async function registerSiwxResource(
           type: 'http',
           x402Version: 0,
           lastUpdated: new Date(),
-          metadata: siwxMetadata,
+          metadata: mergedMetadata,
           deprecatedAt: null,
           origin: { connect: { origin } },
         },

--- a/apps/scan/src/services/db/resources/resource.ts
+++ b/apps/scan/src/services/db/resources/resource.ts
@@ -50,6 +50,24 @@ export const upsertResource = async (
       update: {},
     });
 
+    // Merge new metadata with existing to avoid clobbering fields set by
+    // a different registration path (e.g. paid sets pricingMode, siwx sets
+    // authMode — both target the same URL-keyed row).
+    let mergedMetadata = baseResource.metadata;
+    if (baseResource.metadata) {
+      const existing = await tx.resources.findUnique({
+        where: { resource: baseResource.resource },
+        select: { metadata: true },
+      });
+      if (
+        existing?.metadata &&
+        typeof existing.metadata === 'object' &&
+        !Array.isArray(existing.metadata)
+      ) {
+        mergedMetadata = { ...existing.metadata, ...baseResource.metadata };
+      }
+    }
+
     const { origin, ...resource } = await tx.resources.upsert({
       where: {
         resource: baseResource.resource,
@@ -70,7 +88,7 @@ export const upsertResource = async (
         type: baseResource.type,
         x402Version: baseResource.x402Version,
         lastUpdated: baseResource.lastUpdated,
-        metadata: baseResource.metadata,
+        metadata: mergedMetadata,
         // Clear deprecatedAt when resource is re-registered (un-deprecate)
         deprecatedAt: null,
         origin: {

--- a/apps/scan/src/services/discovery/fetch-discovery.ts
+++ b/apps/scan/src/services/discovery/fetch-discovery.ts
@@ -80,6 +80,7 @@ export async function fetchDiscoveryDocument(
             ...(endpoint.pricingMode
               ? { pricingMode: endpoint.pricingMode }
               : {}),
+            ...(endpoint.price ? { price: endpoint.price } : {}),
           },
         ];
       } catch {

--- a/apps/scan/src/services/discovery/fetch-discovery.ts
+++ b/apps/scan/src/services/discovery/fetch-discovery.ts
@@ -77,6 +77,9 @@ export async function fetchDiscoveryDocument(
             url,
             method: endpoint.method,
             ...(endpoint.authMode ? { authMode: endpoint.authMode } : {}),
+            ...(endpoint.pricingMode
+              ? { pricingMode: endpoint.pricingMode }
+              : {}),
           },
         ];
       } catch {

--- a/apps/scan/src/types/discovery.ts
+++ b/apps/scan/src/types/discovery.ts
@@ -23,6 +23,8 @@ export interface DiscoveredResource {
   authMode?: AuthMode;
   /** Pricing mode from discovery doc ("fixed" | "dynamic"). */
   pricingMode?: string;
+  /** Price string from discovery doc (e.g. "50-300.00 USD"). */
+  price?: string;
   /** If true, this resource failed validation */
   invalid?: boolean;
   /** Error message if resource is invalid */

--- a/apps/scan/src/types/discovery.ts
+++ b/apps/scan/src/types/discovery.ts
@@ -21,6 +21,8 @@ export interface DiscoveredResource {
     | 'TRACE';
   /** Auth classification from discovery (paid, siwx, apiKey, apiKey+paid, unprotected). */
   authMode?: AuthMode;
+  /** Pricing mode from discovery doc ("fixed" | "dynamic"). */
+  pricingMode?: string;
   /** If true, this resource failed validation */
   invalid?: boolean;
   /** Error message if resource is invalid */


### PR DESCRIPTION
## Summary

### Dynamic pricing display (cherry-picked from #921)
- Store `pricingMode` from discovery docs in `Resources.metadata` during registration
- Display "Up to $X" for endpoints with `pricingMode: "dynamic"`, even when the 402 probe returns `scheme: exact`
- Falls back gracefully for old resources and single-endpoint registrations

### Metadata merge fix
- Same-URL resources registered via different paths (e.g. GET /api/orders is siwx, POST /api/orders is paid) were clobbering each other's metadata — whichever ran last won
- Now reads existing metadata inside the transaction and merges before writing
- Affects both `upsertResource` (paid path) and `registerSiwxResource` (siwx path)

### Price range display
- Also extract `price` from discovery L2Route (e.g. `"50-300.00 USD"`) and store in metadata alongside `pricingMode`
- Parse the min value from the price string, use `maxAmountRequired` from Accepts for the max
- Display "$50.00–$300.00" when a range is available, "Up to $300.00" when only max is known

### Pricing logic extracted and tested
- `parseMinFromPriceString` and `formatPricingLabel` extracted into `utils.ts` for testability
- 16 unit tests covering all display cases:

| Scenario | Input | Expected |
|---|---|---|
| **parseMinFromPriceString** | |
| Integer min | `"50-300.00 USD"` | `50` |
| Decimal min | `"0.01-5.00 USD"` | `0.01` |
| Zero min | `"0-300.00 USD"` | `0` |
| Fixed price (no dash) | `"300.00 USD"` | `0` |
| Empty string | `""` | `0` |
| Garbage | `"not a price"` | `0` |
| Leading dash | `"-5.00 USD"` | `0` |
| No currency suffix | `"10-100"` | `10` |
| Whitespace around dash | `"50 -300.00 USD"` | `50` |
| **formatPricingLabel** | |
| Fixed pricing | `isDynamic: false` | `$300.00` |
| Dynamic, no price | `isDynamic: true` | `Up to $300.00` |
| Dynamic, zero min | `price: "0-300.00 USD"` | `Up to $300.00` |
| Dynamic, nonzero min | `price: "50-300.00 USD"` | `$50.00–$300.00` |
| Dynamic, small decimals | `price: "0.01-5.00 USD"` | `$0.01–$5.00` |
| Dynamic, garbage price | `price: "garbage"` | `Up to $300.00` |
| Fixed ignores price | `isDynamic: false, price: "50-..."` | `$300.00` |

## Test plan
- [x] Deploy to Vercel preview
- [x] Re-register stableflowers.dev
- [x] Query DB: `SELECT resource, metadata FROM "Resources" WHERE resource LIKE '%stableflowers%'`
  - POST /api/orders should have `{ "pricingMode": "dynamic", "price": "50-300.00 USD" }` (or similar)
  - GET /api/orders should have `{ "authMode": "siwx" }` merged in
- [x] Server page should show "$50.00–$300.00" for POST /api/orders (if price range available) or "Up to $300.00"
- [x] SIWX resources should still show "Free"
- [x] Check stablevoice — exact-priced resources should still show "$1.00"
- [x] All 16 unit tests pass (`pnpm test:run`)
- [x] `pnpm check` passes (types + lint + format)