### PR TITLE
Fix P2002 race in concurrent origin registration

### DIFF
--- a/apps/scan/src/lib/discovery/register-origin.ts
+++ b/apps/scan/src/lib/discovery/register-origin.ts
@@ -6,6 +6,7 @@ import { deprecateStaleResources } from '@/services/db/resources/resource';
 import { getOriginResourceCount } from '@/services/db/resources/origin';
 import { notifyNewServer } from '@/lib/discord-notifications';
 import { getOriginFromUrl } from '@/lib/url';
+import { scanDb } from '@x402scan/scan-db';
 
 import type {
   AuditWarning,
@@ -101,13 +102,29 @@ export async function registerResourcesFromDiscovery(
    *  skip re-probing — avoids rate limiting on registration. */
   probeSessionId?: string
 ): Promise<RegisterOriginResult> {
+  const uniqueOrigins = [
+    ...new Set(resources.map(resource => getOriginFromUrl(resource.url))),
+  ];
+
   const originResourceCounts = new Map(
     await Promise.all(
-      [
-        ...new Set(resources.map(resource => getOriginFromUrl(resource.url))),
-      ].map(
+      uniqueOrigins.map(
         async origin => [origin, await getOriginResourceCount(origin)] as const
       )
+    )
+  );
+
+  // Pre-create origin rows outside transactions to prevent P2002 races.
+  // When multiple resources from the same origin register concurrently,
+  // each transaction's resourceOrigin.upsert() can race on INSERT.
+  // Top-level upserts use native INSERT ON CONFLICT, which is safe.
+  await Promise.all(
+    uniqueOrigins.map(origin =>
+      scanDb.resourceOrigin.upsert({
+        where: { origin },
+        create: { origin },
+        update: {},
+      })
     )
   );
 


### PR DESCRIPTION
## Summary
- Pre-creates origin rows outside interactive transactions before concurrent resource registration
- Fixes unique constraint violation (`P2002`) on `resourceOrigin.upsert()` when multiple resources from the same origin (e.g. `stableschedule.dev`) register concurrently
- Top-level Prisma upserts use native `INSERT ON CONFLICT`, which is safe from the race that interactive transactions hit (SELECT → INSERT race)

## Context
Reported via Discord: registering `stableschedule.dev` (8 resources, 1 origin) fails on 2 resources with `Invalid prisma.resourceOrigin.upsert() invocation: Unique constraint failed on the fields: ('origin')`. The same origin works fine on mppscan.
