### PR TITLE
Fix chart overflow on stats cards

### DIFF
--- a/apps/scan/src/app/(app)/(home)/(overview)/_components/stats/card.tsx
+++ b/apps/scan/src/app/(app)/(home)/(overview)/_components/stats/card.tsx
@@ -81,6 +81,7 @@ export const OverallStatsCard = <T extends Record<string, number>>({
           bars={items.bars}
           height={100}
           tooltipRows={tooltipRows}
+          cursor={false}
         />
       ) : (
         <BaseAreaChart
@@ -88,6 +89,7 @@ export const OverallStatsCard = <T extends Record<string, number>>({
           areas={items.areas}
           height={100}
           tooltipRows={tooltipRows}
+          cursor={false}
         />
       )}
     </OverallStatsCardContainer>

--- a/apps/scan/src/app/(app)/(home)/resources/(overview)/_components/charts/card.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/(overview)/_components/charts/card.tsx
@@ -83,6 +83,7 @@ export const OverallStatsCard = <T extends Record<string, number>>({
           bars={items.bars}
           height={75}
           tooltipRows={tooltipRows}
+          cursor={false}
         />
       ) : (
         <BaseAreaChart
@@ -90,6 +91,7 @@ export const OverallStatsCard = <T extends Record<string, number>>({
           areas={items.areas}
           height={75}
           tooltipRows={tooltipRows}
+          cursor={false}
         />
       )}
     </OverallStatsCardContainer>

--- a/apps/scan/src/app/(app)/composer/(home)/_components/stats/card.tsx
+++ b/apps/scan/src/app/(app)/composer/(home)/_components/stats/card.tsx
@@ -76,6 +76,7 @@ export const OverallStatsCard = <T extends Record<string, number>>({
           bars={items.bars}
           height={100}
           tooltipRows={tooltipRows}
+          cursor={false}
         />
       ) : (
         <BaseAreaChart
@@ -83,6 +84,7 @@ export const OverallStatsCard = <T extends Record<string, number>>({
           areas={items.areas}
           height={100}
           tooltipRows={tooltipRows}
+          cursor={false}
         />
       )}
     </OverallStatsCardContainer>

--- a/apps/scan/src/app/(app)/server/[id]/(overview)/_components/activity/card.tsx
+++ b/apps/scan/src/app/(app)/server/[id]/(overview)/_components/activity/card.tsx
@@ -83,6 +83,7 @@ export const OverallStatsCard = <T extends Record<string, number>>({
           bars={items.bars}
           height={75}
           tooltipRows={tooltipRows}
+          cursor={false}
         />
       ) : (
         <BaseAreaChart
@@ -90,6 +91,7 @@ export const OverallStatsCard = <T extends Record<string, number>>({
           areas={items.areas}
           height={75}
           tooltipRows={tooltipRows}
+          cursor={false}
         />
       )}
     </OverallStatsCardContainer>

--- a/apps/scan/src/components/ui/charts/chart/area/index.tsx
+++ b/apps/scan/src/components/ui/charts/chart/area/index.tsx
@@ -20,6 +20,7 @@ export const BaseAreaChart = <
   height = 350,
   margin = { top: 4, right: 0, left: 0, bottom: 4 },
   dataMax,
+  cursor,
 }: AreaChartProps<T>) => {
   return (
     <BaseChart
@@ -29,6 +30,7 @@ export const BaseAreaChart = <
       tooltipRows={tooltipRows}
       margin={margin}
       dataMax={dataMax}
+      cursor={cursor}
     >
       <defs>
         {areas.map(({ dataKey, color }) => (

--- a/apps/scan/src/components/ui/charts/chart/bar/index.tsx
+++ b/apps/scan/src/components/ui/charts/chart/bar/index.tsx
@@ -65,7 +65,7 @@ export const BaseBarChart = <
             fillOpacity={solid ? 0.2 : undefined}
             stroke={color}
             strokeWidth={0.5}
-            activeBar={{ strokeWidth: 1.5 }}
+
             radius={
               index === bars.length - 1 || !stacked ? [4, 4, 0, 0] : undefined
             }

--- a/apps/scan/src/components/ui/charts/chart/bar/index.tsx
+++ b/apps/scan/src/components/ui/charts/chart/bar/index.tsx
@@ -22,6 +22,7 @@ export const BaseBarChart = <
   solid = false,
   stackOffset,
   xAxis,
+  cursor,
 }: BarChartProps<T>) => {
   return (
     <BaseChart
@@ -32,6 +33,7 @@ export const BaseBarChart = <
       margin={margin}
       stackOffset={stackOffset}
       xAxis={xAxis}
+      cursor={cursor}
     >
       {!solid && (
         <defs>

--- a/apps/scan/src/components/ui/charts/chart/bar/index.tsx
+++ b/apps/scan/src/components/ui/charts/chart/bar/index.tsx
@@ -65,6 +65,7 @@ export const BaseBarChart = <
             fillOpacity={solid ? 0.2 : undefined}
             stroke={color}
             strokeWidth={0.5}
+            activeBar={{ strokeWidth: 1.5 }}
             radius={
               index === bars.length - 1 || !stacked ? [4, 4, 0, 0] : undefined
             }

--- a/apps/scan/src/components/ui/charts/chart/bar/index.tsx
+++ b/apps/scan/src/components/ui/charts/chart/bar/index.tsx
@@ -65,7 +65,6 @@ export const BaseBarChart = <
             fillOpacity={solid ? 0.2 : undefined}
             stroke={color}
             strokeWidth={0.5}
-
             radius={
               index === bars.length - 1 || !stacked ? [4, 4, 0, 0] : undefined
             }

--- a/apps/scan/src/components/ui/charts/chart/chart.tsx
+++ b/apps/scan/src/components/ui/charts/chart/chart.tsx
@@ -24,6 +24,7 @@ export const BaseChart = <T extends Omit<Record<string, number>, 'timestamp'>>({
   dataMax = 'dataMax',
   stackOffset,
   xAxis,
+  cursor = true,
 }: ChartProps<T> & { type: 'bar' | 'area' | 'line' | 'composed' }) => {
   const Container = useMemo(() => {
     switch (type) {
@@ -83,11 +84,15 @@ export const BaseChart = <T extends Omit<Record<string, number>, 'timestamp'>>({
               }
               return null;
             }}
-            cursor={{
-              fill: 'var(--color-primary)',
-              opacity: 0.2,
-              radius: 4,
-            }}
+            cursor={
+              cursor
+                ? {
+                    fill: 'var(--color-primary)',
+                    opacity: 0.2,
+                    radius: 4,
+                  }
+                : false
+            }
           />
         )}
       </Container>

--- a/apps/scan/src/components/ui/charts/chart/types.ts
+++ b/apps/scan/src/components/ui/charts/chart/types.ts
@@ -36,6 +36,7 @@ export interface ChartProps<T extends Record<string, number>> {
     angle?: number;
     height?: number;
   };
+  cursor?: boolean;
 }
 
 export type Series<T extends Record<string, number>, S> = S & {


### PR DESCRIPTION
## Summary
- Add `overflow-hidden` to the stats card container so charts clip to the card's rounded border instead of bleeding past the shadow