### PR TITLE
Fix Discord notifications not firing for new signups

### DIFF
--- a/apps/scan/src/app/api/resources/sync/route.ts
+++ b/apps/scan/src/app/api/resources/sync/route.ts
@@ -178,12 +178,15 @@ export const GET = async (request: NextRequest) => {
           const upsertedOrigin = await upsertOrigin(originData);
 
           if (!preexistingOrigins.has(origin) && upsertedOrigin) {
-            notifyNewServer({
-              originId: upsertedOrigin.id,
-              origin,
-              title: originData.title ?? null,
-              description: originData.description ?? null,
-            });
+            notifyNewServer(
+              {
+                originId: upsertedOrigin.id,
+                origin,
+                title: originData.title ?? null,
+                description: originData.description ?? null,
+              },
+              { merchantResearch: false }
+            );
           }
 
           return { origin, success: true };

--- a/apps/scan/src/app/api/resources/sync/route.ts
+++ b/apps/scan/src/app/api/resources/sync/route.ts
@@ -1,10 +1,14 @@
 import { NextResponse } from 'next/server';
 
 import { scrapeOriginData } from '@/services/scraper';
-import { upsertOrigin } from '@/services/db/resources/origin';
+import {
+  getOriginResourceCount,
+  upsertOrigin,
+} from '@/services/db/resources/origin';
 import { upsertResource } from '@/services/db/resources/resource';
 
 import { checkCronSecret } from '@/lib/cron';
+import { notifyNewServer } from '@/lib/discord-notifications';
 import { getOriginFromUrl } from '@/lib/url';
 import { normalizeChainId } from '@/lib/x402';
 
@@ -55,6 +59,24 @@ export const GET = async (request: NextRequest) => {
         { status: 200 }
       );
     }
+
+    // Step 1.5: Snapshot current resource counts per origin so we can detect
+    // new origins after upserts (origins that go from 0 → >0 active resources).
+    const preexistingOrigins = new Set<string>();
+    const allOrigins = new Set<string>();
+    for (const resource of resources) {
+      try {
+        allOrigins.add(getOriginFromUrl(resource.resource));
+      } catch {
+        // Origin extraction failed, skip
+      }
+    }
+    await Promise.all(
+      Array.from(allOrigins).map(async origin => {
+        const count = await getOriginResourceCount(origin);
+        if (count > 0) preexistingOrigins.add(origin);
+      })
+    );
 
     // Step 2: Process resources (upsert to database)
     console.log('Starting resource processing');
@@ -153,7 +175,16 @@ export const GET = async (request: NextRequest) => {
           };
 
           // Upsert origin to database
-          await upsertOrigin(originData);
+          const upsertedOrigin = await upsertOrigin(originData);
+
+          if (!preexistingOrigins.has(origin) && upsertedOrigin) {
+            notifyNewServer({
+              originId: upsertedOrigin.id,
+              origin,
+              title: originData.title ?? null,
+              description: originData.description ?? null,
+            });
+          }
 
           return { origin, success: true };
         } catch (error) {

--- a/apps/scan/src/lib/discord-notifications.ts
+++ b/apps/scan/src/lib/discord-notifications.ts
@@ -18,18 +18,23 @@ interface DiscordConfig {
   appUrl: string;
 }
 
-export function notifyNewServer(notification: NewServerNotification) {
+export function notifyNewServer(
+  notification: NewServerNotification,
+  options?: { merchantResearch?: boolean }
+) {
   scheduleDiscordNotification({
     webhookUrl: env.DISCORD_NOTIFICATIONS_WEBHOOK_URL,
     username: NEW_SERVER_USERNAME,
     embed: config => buildNewServerEmbed(notification, config),
   });
 
-  scheduleDiscordNotification({
-    webhookUrl: env.DISCORD_MERCHANT_RESEARCH_WEBHOOK_URL,
-    username: NEW_SERVER_USERNAME,
-    embed: config => buildMerchantResearchEmbed(notification, config),
-  });
+  if (options?.merchantResearch ?? true) {
+    scheduleDiscordNotification({
+      webhookUrl: env.DISCORD_MERCHANT_RESEARCH_WEBHOOK_URL,
+      username: NEW_SERVER_USERNAME,
+      embed: config => buildMerchantResearchEmbed(notification, config),
+    });
+  }
 }
 
 function scheduleDiscordNotification(options: {

--- a/apps/scan/src/services/db/resources/origin.ts
+++ b/apps/scan/src/services/db/resources/origin.ts
@@ -129,7 +129,7 @@ export const getOriginResourceCount = async (origin: string) => {
     select: {
       _count: {
         select: {
-          resources: true,
+          resources: { where: { deprecatedAt: null } },
         },
       },
     },


### PR DESCRIPTION
## Summary
- **`getOriginResourceCount` now excludes deprecated resources** — previously counted all resources including deprecated ones, so re-registrations of origins with only deprecated resources were silently treated as existing and skipped the notification.
- **Facilitator sync job now fires notifications for new origins** — the cron job was pre-seeding origin records without notifications, which meant origins first discovered via facilitator sync would already exist when the merchant later registered manually, preventing the notification from ever firing. Sync-discovered origins only go to the notifications webhook, not merchant research.
- **`notifyNewServer` now accepts a `merchantResearch` option** — defaults to `true` (existing behavior unchanged), but the sync job passes `false` since facilitator-discovered origins aren't real signups.

## Test plan
- [ ] Verify `DISCORD_NOTIFICATIONS_WEBHOOK_URL` is set in Vercel for x402scan
- [ ] Register a new origin — Discord notification should fire to both webhooks
- [ ] Re-register an origin with only deprecated resources — notification should fire again
- [ ] Verify facilitator sync discovers a new origin — notification fires only to the notifications webhook, not merchant research