### PR TITLE
fix(resources): use the declared max from the price string for dynamic pricing

### DIFF
--- a/apps/scan/src/app/(app)/_components/resources/utils.test.ts
+++ b/apps/scan/src/app/(app)/_components/resources/utils.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { parseMinFromPriceString, formatPricingLabel } from './utils';
+import {
+  parseMinFromPriceString,
+  parseMaxFromPriceString,
+  formatPricingLabel,
+} from './utils';
 
 describe('parseMinFromPriceString', () => {
   it('parses integer min from range', () => {
@@ -36,6 +40,44 @@ describe('parseMinFromPriceString', () => {
 
   it('handles whitespace around dash', () => {
     expect(parseMinFromPriceString('50 -300.00 USD')).toBe(50);
+  });
+});
+
+describe('parseMaxFromPriceString', () => {
+  it('parses integer max from range', () => {
+    expect(parseMaxFromPriceString('50-300.00 USD')).toBe(300);
+  });
+
+  it('parses decimal max from range', () => {
+    expect(parseMaxFromPriceString('0.01-5.00 USD')).toBe(5);
+  });
+
+  it('parses max when min is 0', () => {
+    expect(parseMaxFromPriceString('0-300.00 USD')).toBe(300);
+  });
+
+  it('returns null for fixed price (no range)', () => {
+    expect(parseMaxFromPriceString('300.00 USD')).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(parseMaxFromPriceString('')).toBeNull();
+  });
+
+  it('returns null for garbage input', () => {
+    expect(parseMaxFromPriceString('not a price')).toBeNull();
+  });
+
+  it('returns null when string starts with dash (no leading min)', () => {
+    expect(parseMaxFromPriceString('-5.00 USD')).toBeNull();
+  });
+
+  it('handles no currency suffix', () => {
+    expect(parseMaxFromPriceString('10-100')).toBe(100);
+  });
+
+  it('handles whitespace around dash', () => {
+    expect(parseMaxFromPriceString('50 - 300.00 USD')).toBe(300);
   });
 });
 
@@ -100,5 +142,25 @@ describe('formatPricingLabel', () => {
         price: '50-300.00 USD',
       })
     ).toBe('$300.00');
+  });
+
+  it('prefers the declared max over maxAmount in a range (per-row probe returns only the floor)', () => {
+    expect(
+      formatPricingLabel({
+        maxAmount: 50, // observed 402 (e.g. the floor of a usage-priced endpoint)
+        isDynamic: true,
+        price: '50-300.00 USD',
+      })
+    ).toBe('$50.00–$300.00');
+  });
+
+  it('prefers the declared max over maxAmount in "Up to" when min is 0', () => {
+    expect(
+      formatPricingLabel({
+        maxAmount: 1, // observed floor; the declared ceiling is 300
+        isDynamic: true,
+        price: '0-300.00 USD',
+      })
+    ).toBe('Up to $300.00');
   });
 });

--- a/apps/scan/src/app/(app)/_components/resources/utils.ts
+++ b/apps/scan/src/app/(app)/_components/resources/utils.ts
@@ -12,10 +12,24 @@ export function parseMinFromPriceString(price: string): number {
 }
 
 /**
+ * Parse the max value from a discovery price string like "50-300.00 USD".
+ * Returns the numeric max, or null when the string declares no range (e.g. a fixed "300.00 USD").
+ */
+export function parseMaxFromPriceString(price: string): number | null {
+  const match = /^\d+(?:\.\d+)?\s*-\s*(\d+(?:\.\d+)?)/.exec(price);
+  return match?.[1] ? parseFloat(match[1]) : null;
+}
+
+/**
  * Build the display label for a resource's pricing.
  * - Fixed pricing → "$300.00"
  * - Dynamic with range → "$50.00–$300.00"
  * - Dynamic without range → "Up to $300.00"
+ *
+ * For dynamic pricing the upper bound is taken from the declared price string when it states a range,
+ * falling back to `maxAmount` (the observed 402 amount). A per-row / usage-priced endpoint's probe
+ * typically returns only its floor, so the declared max is the accurate ceiling to display — otherwise
+ * the range collapses (e.g. a "0.001-0.126 USD" endpoint would render "< $0.01–< $0.01").
  */
 export function formatPricingLabel(opts: {
   maxAmount: number;
@@ -24,10 +38,12 @@ export function formatPricingLabel(opts: {
 }): string {
   if (!opts.isDynamic) return formatCurrency(opts.maxAmount);
   const minAmount = opts.price ? parseMinFromPriceString(opts.price) : 0;
+  const declaredMax = opts.price ? parseMaxFromPriceString(opts.price) : null;
+  const maxAmount = declaredMax ?? opts.maxAmount;
   if (minAmount > 0) {
-    return `${formatCurrency(minAmount)}–${formatCurrency(opts.maxAmount)}`;
+    return `${formatCurrency(minAmount)}–${formatCurrency(maxAmount)}`;
   }
-  return `Up to ${formatCurrency(opts.maxAmount)}`;
+  return `Up to ${formatCurrency(maxAmount)}`;
 }
 
 export function isSiwxResource(resource: Pick<Resources, 'metadata'>): boolean {


### PR DESCRIPTION
Fixes #937.

## Problem

`formatPricingLabel` parses the **min** from the discovery price string (`parseMinFromPriceString`) but takes the **max** from `maxAmount` (the observed 402 amount). There's no `parseMaxFromPriceString`, so the max declared in the price string is discarded.

For usage-/per-row-priced endpoints, the scanner's probe returns only the floor, so a declared range like `"0.001000-0.126000 USD"` renders as **`< $0.01 – < $0.01`** instead of **`< $0.01 – $0.13`** — the declared ceiling never shows. (Live example: [hyperextend](https://www.x402scan.com/server/5ba6fbb8-c759-4612-b6e6-15d95e0c9b96).)

## Change

- Add `parseMaxFromPriceString` mirroring `parseMinFromPriceString`.
- In `formatPricingLabel`, use the declared max when the price string states a range, falling back to `maxAmount` otherwise (`declaredMax ?? maxAmount`).

## Compatibility

Strictly additive to behaviour: every existing test uses `maxAmount == the string's max`, so all pass unchanged. Fixed pricing and the "no price"/garbage/zero-min paths are untouched. Adds 9 `parseMaxFromPriceString` tests + 2 `formatPricingLabel` tests covering "declared max wins over a floor `maxAmount`".

> Note: I verified the parsing/selection logic locally against the existing + new cases but didn't spin up the full pnpm monorepo to run vitest — relying on CI for the test run. Happy to adjust naming/placement to fit your conventions.