### PR TITLE
Fix dynamic pricing display for sub-cent ranges

### DIFF
--- a/apps/scan/src/app/(app)/_components/resources/utils.test.ts
+++ b/apps/scan/src/app/(app)/_components/resources/utils.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { parseMinFromPriceString, formatPricingLabel } from './utils';
+import {
+  parseMinFromPriceString,
+  parseMaxFromPriceString,
+  formatPricingLabel,
+} from './utils';
 
 describe('parseMinFromPriceString', () => {
   it('parses integer min from range', () => {
@@ -36,6 +40,40 @@ describe('parseMinFromPriceString', () => {
 
   it('handles whitespace around dash', () => {
     expect(parseMinFromPriceString('50 -300.00 USD')).toBe(50);
+  });
+});
+
+describe('parseMaxFromPriceString', () => {
+  it('parses integer max from range', () => {
+    expect(parseMaxFromPriceString('50-300.00 USD')).toBe(300);
+  });
+
+  it('parses decimal max from range', () => {
+    expect(parseMaxFromPriceString('0.001000-0.126000 USD')).toBe(0.126);
+  });
+
+  it('returns 0 for fixed price (no dash)', () => {
+    expect(parseMaxFromPriceString('300.00 USD')).toBe(0);
+  });
+
+  it('returns 0 for empty string', () => {
+    expect(parseMaxFromPriceString('')).toBe(0);
+  });
+
+  it('returns 0 for garbage input', () => {
+    expect(parseMaxFromPriceString('not a price')).toBe(0);
+  });
+
+  it('returns 0 when string starts with dash', () => {
+    expect(parseMaxFromPriceString('-5.00 USD')).toBe(0);
+  });
+
+  it('handles no currency suffix', () => {
+    expect(parseMaxFromPriceString('10-100')).toBe(100);
+  });
+
+  it('handles whitespace around dash', () => {
+    expect(parseMaxFromPriceString('50 - 300.00 USD')).toBe(300);
   });
 });
 
@@ -100,5 +138,27 @@ describe('formatPricingLabel', () => {
         price: '50-300.00 USD',
       })
     ).toBe('$300.00');
+  });
+
+  it('uses price string max when probed maxAmount is lower (dynamic pricing)', () => {
+    // Probe only sees min price for an empty request ($0.001), but the
+    // discovery price string has the real max ($0.126).
+    expect(
+      formatPricingLabel({
+        maxAmount: 0.001,
+        isDynamic: true,
+        price: '0.001000-0.126000 USD',
+      })
+    ).toBe('< $0.01–$0.13');
+  });
+
+  it('uses probed maxAmount when it exceeds price string max', () => {
+    expect(
+      formatPricingLabel({
+        maxAmount: 500,
+        isDynamic: true,
+        price: '50-300.00 USD',
+      })
+    ).toBe('$50.00–$500.00');
   });
 });

--- a/apps/scan/src/app/(app)/_components/resources/utils.ts
+++ b/apps/scan/src/app/(app)/_components/resources/utils.ts
@@ -12,6 +12,15 @@ export function parseMinFromPriceString(price: string): number {
 }
 
 /**
+ * Parse the max value from a discovery price string like "50-300.00 USD".
+ * Returns the numeric max, or 0 if unparseable.
+ */
+export function parseMaxFromPriceString(price: string): number {
+  const match = /^\d+(?:\.\d+)?\s*-\s*(\d+(?:\.\d+)?)/.exec(price);
+  return match?.[1] ? parseFloat(match[1]) : 0;
+}
+
+/**
  * Build the display label for a resource's pricing.
  * - Fixed pricing → "$300.00"
  * - Dynamic with range → "$50.00–$300.00"
@@ -24,10 +33,15 @@ export function formatPricingLabel(opts: {
 }): string {
   if (!opts.isDynamic) return formatCurrency(opts.maxAmount);
   const minAmount = opts.price ? parseMinFromPriceString(opts.price) : 0;
+  // For dynamic pricing the probed maxAmountRequired may only reflect the
+  // minimum request (empty params). Prefer the max from the discovery price
+  // string when it's larger.
+  const parsedMax = opts.price ? parseMaxFromPriceString(opts.price) : 0;
+  const effectiveMax = Math.max(opts.maxAmount, parsedMax);
   if (minAmount > 0) {
-    return `${formatCurrency(minAmount)}–${formatCurrency(opts.maxAmount)}`;
+    return `${formatCurrency(minAmount)}–${formatCurrency(effectiveMax)}`;
   }
-  return `Up to ${formatCurrency(opts.maxAmount)}`;
+  return `Up to ${formatCurrency(effectiveMax)}`;
 }
 
 export function isSiwxResource(resource: Pick<Resources, 'metadata'>): boolean {

--- a/apps/scan/src/services/discovery/fetch-discovery.ts
+++ b/apps/scan/src/services/discovery/fetch-discovery.ts
@@ -74,7 +74,7 @@ export async function fetchDiscoveryDocument(
         // Build the URL without URL-encoding so OpenAPI path templates
         // like /v1/candles/{coin}/{interval} keep raw braces instead of
         // being encoded to %7Bcoin%7D.
-        const url = endpoint.path.startsWith('http')
+        const url = endpoint.path.includes('://')
           ? endpoint.path
           : `${expectedOrigin}${endpoint.path.startsWith('/') ? '' : '/'}${endpoint.path}`;
         return [

--- a/apps/scan/src/services/discovery/fetch-discovery.ts
+++ b/apps/scan/src/services/discovery/fetch-discovery.ts
@@ -71,7 +71,12 @@ export async function fetchDiscoveryDocument(
         // A malicious OpenAPI spec could contain absolute URLs pointing
         // elsewhere (new URL('https://evil.com/x', base) ignores the base).
         if (resolved.origin !== expectedOrigin) return [];
-        const url = resolved.toString();
+        // Build the URL without URL-encoding so OpenAPI path templates
+        // like /v1/candles/{coin}/{interval} keep raw braces instead of
+        // being encoded to %7Bcoin%7D.
+        const url = endpoint.path.startsWith('http')
+          ? endpoint.path
+          : `${expectedOrigin}${endpoint.path.startsWith('/') ? '' : '/'}${endpoint.path}`;
         return [
           {
             url,


### PR DESCRIPTION
## Summary
- For dynamic pricing endpoints (e.g. hyperextend's `$0.001–$0.126`), the price range was displaying as `< $0.01–< $0.01` because `maxAmountRequired` stores the probed price (minimal request = floor), not the actual maximum
- Added `parseMaxFromPriceString()` to extract the max from the discovery price string, and `formatPricingLabel` now uses `Math.max(probedMax, parsedMax)` as the effective upper bound
- Before: `< $0.01–< $0.01` → After: `< $0.01–$0.13`

## Test plan
- [x] Added `parseMaxFromPriceString` unit tests (8 cases including edge cases)
- [x] Added `formatPricingLabel` tests for probed-max-lower-than-parsed and probed-max-higher-than-parsed scenarios
- [x] All 120 tests pass
- [x] Verify on deployed preview that hyperextend origin shows correct price range