### PR TITLE
Register all single-shot EVM client schemes (exact, upto, auth-capture) in the scan wallet

### DIFF
--- a/apps/scan/src/app/(app)/_hooks/x402/evm.ts
+++ b/apps/scan/src/app/(app)/_hooks/x402/evm.ts
@@ -5,7 +5,7 @@ import { useX402Fetch } from './use-fetch';
 import {
   x402Client,
   wrapFetchWithPayment,
-  registerExactEvmScheme,
+  registerEvmSchemes,
   toEvmSigner,
 } from '@/lib/x402/wrap-fetch';
 
@@ -26,7 +26,7 @@ export const useEvmPaymentWrapper = (chain: Chain) => {
     const signer = toEvmSigner(
       walletClient as Parameters<typeof toEvmSigner>[0]
     );
-    registerExactEvmScheme(client, { signer });
+    registerEvmSchemes(client, { signer });
 
     return wrapFetchWithPayment(baseFetch, client);
   };

--- a/apps/scan/src/lib/x402/wrap-fetch.ts
+++ b/apps/scan/src/lib/x402/wrap-fetch.ts
@@ -6,7 +6,9 @@
  */
 import type { x402Client as X402Client } from '@x402/core/client';
 import type { ClientSvmSigner } from '@x402/svm';
+import { AuthCaptureEvmScheme } from '@x402/evm/auth-capture/client';
 import { registerExactEvmScheme } from '@x402/evm/exact/client';
+import { UptoEvmScheme } from '@x402/evm/upto/client';
 import { x402Client, wrapFetchWithPayment } from '@x402/fetch';
 import { ExactSvmScheme } from '@x402/svm/exact/client';
 import { ExactSvmSchemeV1 } from '@x402/svm/exact/v1/client';
@@ -49,6 +51,35 @@ export function toEvmSigner(walletClient: {
       });
     },
   };
+}
+
+/**
+ * Register every single-shot EVM client scheme on a client.
+ *
+ * - `exact`        — direct ERC-3009 / Permit2 transfer.
+ * - `upto`         — variable-amount (metered) payment up to a cap.
+ * - `auth-capture` — escrow-backed authorize/capture used by x402r
+ *   refundable endpoints; signs ERC-3009 (default) or Permit2
+ *   (`assetTransferMethod: "permit2"`).
+ *
+ * All three are stateless and take the same `ClientEvmSigner`, so one signer
+ * wires up every path. Registering a scheme an endpoint doesn't use is
+ * harmless — the client matches on the `scheme` of each `accepts` entry.
+ *
+ * `batch-settlement` is intentionally omitted: it is stateful (per-channel
+ * deposits, vouchers, on-chain channel recovery) and needs persistent client
+ * channel storage. The wallet builds a fresh per-request `x402Client`, so the
+ * scheme's default in-memory storage would silently lose channel state
+ * between requests. Wiring it up correctly is separate work.
+ */
+export function registerEvmSchemes(
+  client: X402Client,
+  { signer }: { signer: ClientEvmSigner }
+): X402Client {
+  registerExactEvmScheme(client, { signer });
+  client.register('eip155:*', new UptoEvmScheme(signer));
+  client.register('eip155:*', new AuthCaptureEvmScheme(signer));
+  return client;
 }
 
 export function registerSvmX402Client(params: {

--- a/apps/scan/src/trpc/routers/user/server-wallet.ts
+++ b/apps/scan/src/trpc/routers/user/server-wallet.ts
@@ -15,7 +15,7 @@ import { Chain, SUPPORTED_CHAINS } from '@/types/chain';
 import {
   x402Client,
   wrapFetchWithPayment,
-  registerExactEvmScheme,
+  registerEvmSchemes,
   registerSvmX402Client,
 } from '@/lib/x402/wrap-fetch';
 import { env } from '@/env';
@@ -161,7 +161,7 @@ export const serverWalletRouter = createTRPCRouter({
         });
       } else {
         client = new x402Client();
-        registerExactEvmScheme(client, {
+        registerEvmSchemes(client, {
           signer: signer as ClientEvmSigner,
         });
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,20 +193,20 @@ catalogs:
       version: 11.8.1
   x402:
     '@x402/core':
-      specifier: ^2.11.0
-      version: 2.11.0
+      specifier: ^2.14.0
+      version: 2.14.0
     '@x402/evm':
-      specifier: ^2.11.0
-      version: 2.11.0
+      specifier: ^2.14.0
+      version: 2.14.0
     '@x402/extensions':
-      specifier: ^2.11.0
-      version: 2.11.0
+      specifier: ^2.14.0
+      version: 2.14.0
     '@x402/fetch':
-      specifier: ^2.11.0
-      version: 2.11.0
+      specifier: ^2.14.0
+      version: 2.14.0
     '@x402/svm':
-      specifier: ^2.11.0
-      version: 2.11.0
+      specifier: ^2.14.0
+      version: 2.14.0
   x402-v1:
     x402-express:
       specifier: ^0.7.1
@@ -485,19 +485,19 @@ importers:
         version: 1.0.1(react-dom@19.2.2(react@19.2.2))(react@19.2.2)
       '@x402/core':
         specifier: catalog:x402
-        version: 2.11.0
+        version: 2.14.0
       '@x402/evm':
         specifier: catalog:x402
-        version: 2.11.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
+        version: 2.14.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@x402/extensions':
         specifier: catalog:x402
-        version: 2.11.0(bufferutil@4.0.9)(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typescript@5.9.3)(utf-8-validate@5.0.10)
+        version: 2.14.0(bufferutil@4.0.9)(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@x402/fetch':
         specifier: catalog:x402
-        version: 2.11.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
+        version: 2.14.0
       '@x402/svm':
         specifier: catalog:x402
-        version: 2.11.0(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
+        version: 2.14.0(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
       '@x402scan/analytics-db':
         specifier: workspace:*
         version: link:../../packages/internal/databases/analytics
@@ -819,13 +819,13 @@ importers:
         version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       '@x402/core':
         specifier: catalog:x402
-        version: 2.11.0
+        version: 2.14.0
       '@x402/evm':
         specifier: catalog:x402
-        version: 2.11.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
+        version: 2.14.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@x402/extensions':
         specifier: catalog:x402
-        version: 2.11.0(bufferutil@4.0.9)(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typescript@5.9.3)(utf-8-validate@5.0.10)
+        version: 2.14.0(bufferutil@4.0.9)(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typescript@5.9.3)(utf-8-validate@5.0.10)
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -1004,8 +1004,6 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
-  packages/internal/databases/scan/generated/client: {}
-
   packages/internal/databases/transfers:
     dependencies:
       '@neondatabase/serverless':
@@ -1051,8 +1049,6 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
-
-  packages/internal/databases/transfers/generated/client: {}
 
   packages/internal/neverthrow:
     dependencies:
@@ -2915,9 +2911,11 @@ packages:
 
   '@metamask/sdk-analytics@0.0.5':
     resolution: {integrity: sha512-fDah+keS1RjSUlC8GmYXvx6Y26s3Ax1U9hGpWb6GSY5SAdmTSIqp2CvYy6yW0WgLhnYhW+6xERuD0eVqV63QIQ==}
+    deprecated: No longer maintained, superseded by @metamask/connect-analytics
 
   '@metamask/sdk-communication-layer@0.33.1':
     resolution: {integrity: sha512-0bI9hkysxcfbZ/lk0T2+aKVo1j0ynQVTuB3sJ5ssPWlz+Z3VwveCkP1O7EVu1tsVVCb0YV5WxK9zmURu2FIiaA==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
     peerDependencies:
       cross-fetch: ^4.0.0
       eciesjs: '*'
@@ -2927,9 +2925,11 @@ packages:
 
   '@metamask/sdk-install-modal-web@0.32.1':
     resolution: {integrity: sha512-MGmAo6qSjf1tuYXhCu2EZLftq+DSt5Z7fsIKr2P+lDgdTPWgLfZB1tJKzNcwKKOdf6q9Qmmxn7lJuI/gq5LrKw==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
 
   '@metamask/sdk@0.33.1':
     resolution: {integrity: sha512-1mcOQVGr9rSrVcbKPNVzbZ8eCl1K0FATsYH3WJ/MH4WcZDWGECWrXJPNMZoEAkLxWiMe8jOQBumg2pmcDa9zpQ==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
 
   '@metamask/superstruct@3.2.1':
     resolution: {integrity: sha512-fLgJnDOXFmuVlB38rUN5SmU7hAFQcCjrg3Vrxz67KTY7YHFnSNEKvX4avmEBdOI0yTCxZjwMCFEqsC8k2+Wd3g==}
@@ -3618,7 +3618,7 @@ packages:
 
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
-    deprecated: 'The package is now available as "qr": npm install qr'
+    deprecated: 'Switch to "qr" (new package name) for security updates: npm install qr'
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
@@ -4434,6 +4434,7 @@ packages:
   '@safe-global/safe-gateway-typescript-sdk@3.23.1':
     resolution: {integrity: sha512-6ORQfwtEJYpalCeVO21L4XXGSdbEMfyp2hEv6cP82afKXSwvse6d3sdelgaPWUxHIsFRkWvHDdzh8IyyKHZKxw==}
     engines: {node: '>=16'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@scalar/openapi-types@0.8.0':
     resolution: {integrity: sha512-WmaxVSfvY5K/TwcG2B2TU1WOe1As1uc2s7myswtP6dBlcjU3hM08SApxv/jmyGaCE8t4gO5BBhmHY4pDUfmr2g==}
@@ -6159,6 +6160,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -6526,23 +6528,23 @@ packages:
   '@walletconnect/window-metadata@1.0.1':
     resolution: {integrity: sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==}
 
-  '@x402/core@2.10.0':
-    resolution: {integrity: sha512-n9Exnt1HN4LFaINaPYhk6Cy3ICBt0e46XN1Uo5i6efIZfIoqP6pY8ONSX/M9bU4F1fpvMj0JZ3xdcBZCiGInfw==}
-
   '@x402/core@2.11.0':
     resolution: {integrity: sha512-aqTfZc/BULrlWnd3I0lsqRQaH4gjJd8CsPcL16XqK2Lx5c6QDm+zCljgUVS1yj9BGJoZeQWTzI5hE+SVFkqMTw==}
 
-  '@x402/evm@2.11.0':
-    resolution: {integrity: sha512-F8uU1txDZA+wc/sEnmaHAyYvoTi/w39r7K3a44MmQHSxECDTEuB3A0FwbxOxUPLN1eyCxTAFKEiqlGe3bwybKA==}
+  '@x402/core@2.14.0':
+    resolution: {integrity: sha512-+xTM6hfGduYvFcQ7QwKvCwommL6+zqzqmr5IuPojbt+RZjo4QUjSkHW+arMtPoIKRLxWAI+e6P4UJMMblwG+Dw==}
 
-  '@x402/extensions@2.11.0':
-    resolution: {integrity: sha512-S0SOoUsx4WtWqiWZuqslSzhopW/JcrEbnEC5l2sIQH/TABWzR0DgJLy36C43tD6TOJc0tEPN9bHuD+V8DYWomA==}
+  '@x402/evm@2.14.0':
+    resolution: {integrity: sha512-Qrm0+hN1gMK1vrX4vW4sdcx5txYTx8J2uDNulcNoIdtz15kTU5hjNUyZaCpI3i6x0MXnUBGfyar9Ut9uoAoPMw==}
 
-  '@x402/fetch@2.11.0':
-    resolution: {integrity: sha512-sDkoq1ZZt10/UVa75bCXTbWkXMbPOOQpkdSxWB0ybHtlmqT7PM6hU4DVCov4iL792W1Oi38VtxfUw5EkvdvYtw==}
+  '@x402/extensions@2.14.0':
+    resolution: {integrity: sha512-2zu8hxf0j4BRvSWNPRKziQLdubnQpzzmU9xopKK5ZyXa434hvmGEUPMBOA2NIYvaTkyZjQH3JZ3GPDyzjBvFqA==}
 
-  '@x402/svm@2.11.0':
-    resolution: {integrity: sha512-MmhLlEeb3FtgTxO4n3RkZszKEBBnYLfNnX8P3TvqVYP1u9gY2SgbYW4K3TsPAv00edCxoCOqYixI2JurYjW4Sw==}
+  '@x402/fetch@2.14.0':
+    resolution: {integrity: sha512-GSCnxdrbmtuKeki2MTy2vnJq4e6PrA7XfF1yX23VxKvASIYaXUioW1HtRzNYU7imeMe13YcwefRH1jO7Ei7Tyg==}
+
+  '@x402/svm@2.14.0':
+    resolution: {integrity: sha512-doMYoY5hLpD+CowihYDOi0IJfcCIG2BTDe89a0v4GAvpF3mFn5ewIPgsz6VE249sK2vgBEp3nTtb98kswC2nZw==}
     peerDependencies:
       '@solana/kit': '>=5.1.0'
 
@@ -10659,6 +10661,7 @@ packages:
   recharts@2.15.4:
     resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
     engines: {node: '>=14'}
+    deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -11783,10 +11786,12 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   valibot@1.2.0:
@@ -12362,10 +12367,10 @@ snapshots:
   '@agentcash/router@1.10.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.0.9)(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(express@5.2.1)(fastestsmallesttextencoderdecoder@1.0.22)(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2))(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.4.3)':
     dependencies:
       '@coinbase/x402': 2.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@x402/core': 2.11.0
-      '@x402/evm': 2.11.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@x402/extensions': 2.11.0(bufferutil@4.0.9)(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@x402/svm': 2.11.0(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
+      '@x402/core': 2.14.0
+      '@x402/evm': 2.14.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@x402/extensions': 2.14.0(bufferutil@4.0.9)(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@x402/svm': 2.14.0(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
       mppx: 0.6.28(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(typescript@5.9.3)(viem@2.51.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
       next: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2)
       viem: 2.51.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
@@ -13130,7 +13135,7 @@ snapshots:
   '@coinbase/x402@2.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@coinbase/cdp-sdk': 1.40.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@x402/core': 2.10.0
+      '@x402/core': 2.11.0
       viem: 2.51.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -19989,17 +19994,17 @@ snapshots:
       '@walletconnect/window-getters': 1.0.1
       tslib: 1.14.1
 
-  '@x402/core@2.10.0':
-    dependencies:
-      zod: 3.25.76
-
   '@x402/core@2.11.0':
     dependencies:
       zod: 3.25.76
 
-  '@x402/evm@2.11.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+  '@x402/core@2.14.0':
     dependencies:
-      '@x402/core': 2.11.0
+      zod: 3.25.76
+
+  '@x402/evm@2.14.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@x402/core': 2.14.0
       viem: 2.51.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -20007,12 +20012,12 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@x402/extensions@2.11.0(bufferutil@4.0.9)(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typescript@5.9.3)(utf-8-validate@5.0.10)':
+  '@x402/extensions@2.14.0(bufferutil@4.0.9)(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@noble/curves': 1.9.7
       '@scure/base': 1.2.6
       '@signinwithethereum/siwe': 4.2.0(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(viem@2.51.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
-      '@x402/core': 2.11.0
+      '@x402/core': 2.14.0
       ajv: 8.17.1
       jose: 5.10.0
       tweetnacl: 1.0.3
@@ -20024,23 +20029,17 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@x402/fetch@2.11.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+  '@x402/fetch@2.14.0':
     dependencies:
-      '@x402/core': 2.11.0
-      viem: 2.51.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - bufferutil
-      - typescript
-      - utf-8-validate
+      '@x402/core': 2.14.0
 
-  '@x402/svm@2.11.0(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
+  '@x402/svm@2.14.0(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
     dependencies:
       '@solana-program/compute-budget': 0.11.0(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana-program/token': 0.9.0(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana-program/token-2022': 0.6.1(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
       '@solana/kit': 5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@x402/core': 2.11.0
+      '@x402/core': 2.14.0
     transitivePeerDependencies:
       - '@solana/sysvars'
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -64,7 +64,7 @@ catalogs:
     'x402-express': *X402_VERSION
     'x402-hono': *X402_VERSION
   x402:
-    '@x402/core': &X402_CORE_VERSION ^2.11.0
+    '@x402/core': &X402_CORE_VERSION ^2.14.0
     '@x402/evm': *X402_CORE_VERSION
     '@x402/extensions': *X402_CORE_VERSION
     '@x402/fetch': *X402_CORE_VERSION


### PR DESCRIPTION
At [x402r.org](https://x402r.org), we've been working on refundable payments for x402. This PR wires the scan wallet up to actually pay them — and, while we're here, every other single-shot EVM scheme the SDK supports.

## What

Lets the scan wallet pay endpoints advertising **any single-shot EVM scheme the SDK supports** — `exact`, `upto`, and `auth-capture` (our escrow-backed / refundable payments) — instead of only `exact`.

Today both EVM payment sites register only the exact scheme, so the wallet can't match a non-exact entry in a 402's `accepts`:

- `apps/scan/src/trpc/routers/user/server-wallet.ts` — the custodial server wallet (`sendUsdc`)
- `apps/scan/src/app/(app)/_hooks/x402/evm.ts` — the browser wagmi wallet hook

## Changes

- **`apps/scan/src/lib/x402/wrap-fetch.ts`** — new shared `registerEvmSchemes(client, { signer })` that registers:
  - `exact` (existing `registerExactEvmScheme`)
  - `upto` (`UptoEvmScheme`) — variable-amount / metered
  - `auth-capture` (`AuthCaptureEvmScheme`, from `@x402/evm/auth-capture/client`) — our escrow-backed / refundable scheme

  All three are single-shot and take the same `ClientEvmSigner`, so one signer wires up every path. Registering a scheme an endpoint doesn't use is harmless — the client routes on each `accepts` entry's `scheme`.
- Both EVM call sites switched from `registerExactEvmScheme(...)` to `registerEvmSchemes(...)`.
- **`pnpm-workspace.yaml`** — bump the shared `@x402/*` catalog `^2.11.0` → `^2.14.0` (the `upto/client` and `auth-capture/client` subpaths ship in [`@x402/evm@2.14.0`](https://www.npmjs.com/package/@x402/evm/v/2.14.0)); lockfile regenerated. All five `@x402/*` packages publish in lockstep at 2.14.0.

`registerExactEvmScheme` stays exported for compatibility. This is purely additive — endpoints that only advertise `exact` behave exactly as before.

### Deliberately excluded: `batch-settlement`

The SDK also exposes a `batch-settlement` client scheme, but it's intentionally **not** registered here. Unlike the others it's stateful — per-channel deposits, signed vouchers, on-chain channel recovery — and needs persistent client channel storage. The wallet builds a fresh per-request `x402Client`, so the scheme's default in-memory storage would silently lose channel state between requests. Wiring it up correctly (durable channel storage + lifecycle) is separate work.

## Why now

The `auth-capture` client scheme landed upstream in x402-foundation/x402#2486 and is published in `@x402/evm@2.14.0`. This is the wallet-side wiring to consume it (and `upto`, which the SDK already shipped). `AuthCaptureEvmScheme` is pure signing — no on-chain reads/calls.

Demand: #663 — our x402r escrow endpoints (36 live in production) that the scan wallet currently can't pay.

## Notes

- This is the **payment (client)** path only. The **indexing/registration** path from #663 is already resolved on `main` — the `AcceptsScheme` enum was dropped in favor of a free-string `scheme` (Prisma `scheme String`, zod `z.string().min(1)`, plus a "accepts non-exact x402 schemes" upsert test), so non-exact schemes already index. This PR doesn't touch that path.
- Scheme naming follows the canonical merged SDK name `auth-capture`. Endpoints advertising the older `escrow` name should move to `auth-capture` to match.

## Test plan

- [ ] `pnpm install` resolves `@x402/evm@2.14.0` with the `upto/client` + `auth-capture/client` subpaths
- [ ] Typecheck / build pass
- [ ] Server wallet + browser wallet pay an `auth-capture` (and `upto`) endpoint end-to-end on Base

🤖 Generated with [Claude Code](https://claude.com/claude-code)
