### PR TITLE
fix: stop deprecating templated resources on every registration (#939 regression)

### DIFF
--- a/apps/scan/src/lib/discovery/register-origin.ts
+++ b/apps/scan/src/lib/discovery/register-origin.ts
@@ -326,7 +326,17 @@ export async function registerResourcesFromDiscovery(
 
   let deprecated = 0;
   if (originId) {
-    const activeResourceUrls = resources.map(r => r.url);
+    // Match the key registerResource actually stores: cleanUrl =
+    // new URL(url) with the query stripped. Discovery hands us raw template
+    // braces (e.g. /candles/{coin}); new URL() percent-encodes them to
+    // %7Bcoin%7D, which is what lands in the DB. Building the allow-list from
+    // the raw r.url means the stored (encoded) keys never match, so every
+    // templated resource is deprecated on every registration.
+    const activeResourceUrls = resources.map(r => {
+      const u = new URL(r.url);
+      u.search = '';
+      return u.toString();
+    });
     deprecated = await deprecateStaleResources(originId, activeResourceUrls);
   }
 


### PR DESCRIPTION
## Summary
#939 changed `fetch-discovery` to emit raw template braces (e.g. `/v1/candles/{coin}/{interval}`), but `registerResource` still stores the resource key as `new URL(url).toString()`, which **percent-encodes** the braces to `%7Bcoin%7D` (`apps/scan/src/lib/resources.ts:348-350,461`). The deprecation allow-list in `register-origin.ts:329` was built from the **raw** `r.url`, so the encoded stored keys never matched it — and `deprecateStaleResources` deprecated **every templated resource on every registration**, including the ones just registered. Origins whose OpenAPI paths contain `{param}` templates end up with an empty listing (each re-register reports `N registered / N deprecated`, nothing stays active).

Before #939, `fetch-discovery` emitted `resolved.toString()` (encoded) so both sides matched and registration was idempotent. Fixed-price / non-templated origins are unaffected (no braces → `new URL()` is a no-op), which is why this slipped through.

## Fix
Normalise the deprecation allow-list with the same transform `registerResource` uses for the stored key (`new URL(r.url)`, query stripped), so the comparison matches. Minimal and targeted — preserves #939's raw-brace emission and the dynamic price-range fix.

Follow-up worth doing (not in this PR): extract a single `normalizeResourceUrl()` helper used by both the key write and the allow-list so they can't drift again.

## Reproduction
1. Register an origin whose OpenAPI paths contain `{param}` templates (e.g. `https://api.hyperextend.xyz/openapi.json`).
2. Re-register it unchanged.
3. **Before:** every run reports `7 registered / 7 deprecated`; no resource stays active; the server page is empty.
4. **After:** re-registering an unchanged discovery doc reports `0 deprecated` and resources remain active.

## Test plan
- [ ] Register a templated-path origin twice → second run reports `0 deprecated`, resources stay active.
- [ ] Register a fixed-price / non-templated origin → unchanged behaviour.
- [ ] Previously-deprecated templated rows are re-activated on next register (upsert clears `deprecatedAt`, and they're now in the allow-list).

Regression from #939.
