### PR TITLE
fix: normalize URLs in deprecation allow-list to match DB storage

### DIFF
--- a/apps/scan/src/lib/discovery/register-origin.ts
+++ b/apps/scan/src/lib/discovery/register-origin.ts
@@ -5,7 +5,7 @@ import { registerResource, registerSiwxResource } from '@/lib/resources';
 import { deprecateStaleResources } from '@/services/db/resources/resource';
 import { getOriginResourceCount } from '@/services/db/resources/origin';
 import { notifyNewServer } from '@/lib/discord-notifications';
-import { getOriginFromUrl } from '@/lib/url';
+import { getOriginFromUrl, normalizeResourceUrl } from '@/lib/url';
 import { scanDb } from '@x402scan/scan-db';
 
 import type {
@@ -326,7 +326,7 @@ export async function registerResourcesFromDiscovery(
 
   let deprecated = 0;
   if (originId) {
-    const activeResourceUrls = resources.map(r => r.url);
+    const activeResourceUrls = resources.map(r => normalizeResourceUrl(r.url));
     deprecated = await deprecateStaleResources(originId, activeResourceUrls);
   }
 

--- a/apps/scan/src/lib/resources.ts
+++ b/apps/scan/src/lib/resources.ts
@@ -11,7 +11,7 @@ import type {
 } from '@agentcash/discovery';
 import { isX402PaymentOption } from '@/lib/discovery/utils';
 
-import { getOriginFromUrl } from '@/lib/url';
+import { getOriginFromUrl, normalizeResourceUrl } from '@/lib/url';
 
 import { upsertResourceResponse } from '@/services/db/resources/response';
 import { formatTokenAmount } from './token';
@@ -176,8 +176,7 @@ export async function registerSiwxResource(
     };
   }
 
-  urlObj.search = '';
-  const cleanUrl = urlObj.toString();
+  const cleanUrl = normalizeResourceUrl(url);
   const origin = getOriginFromUrl(cleanUrl);
 
   try {
@@ -345,9 +344,7 @@ export const registerResource = async (
     ...validation.warnings,
   ]);
 
-  const urlObj = new URL(url);
-  urlObj.search = '';
-  const cleanUrl = urlObj.toString();
+  const cleanUrl = normalizeResourceUrl(url);
   const origin = getOriginFromUrl(cleanUrl);
   const shouldNotifyNewServer = options.notifyNewServer ?? true;
 

--- a/apps/scan/src/lib/url.ts
+++ b/apps/scan/src/lib/url.ts
@@ -3,6 +3,18 @@ export const getOriginFromUrl = (url: string) => {
 };
 
 /**
+ * Normalize a resource URL to the canonical form stored in the DB.
+ * Applies URL-encoding (via the URL constructor) and strips the query string.
+ * Both registerResource and the deprecation allow-list must use this so their
+ * string comparisons agree.
+ */
+export const normalizeResourceUrl = (url: string): string => {
+  const u = new URL(url);
+  u.search = '';
+  return u.toString();
+};
+
+/**
  * Normalize a URL for comparison by removing trailing slashes
  * and normalizing the path.
  *

--- a/apps/scan/src/services/db/resources/resource.ts
+++ b/apps/scan/src/services/db/resources/resource.ts
@@ -407,16 +407,42 @@ export const listResourcesForTools = async (resourceIds: string[]) => {
  * Deprecate resources that are no longer in the discovery document.
  * Sets deprecatedAt to now() for resources not in the provided URLs list.
  *
- * Note: If activeResourceUrls is empty, no deprecation occurs to avoid accidentally
- * deprecating all resources when discovery is empty or fails.
+ * Safety checks:
+ * - If activeResourceUrls is empty, no deprecation occurs (discovery failure).
+ * - If ALL active resources would be deprecated, no deprecation occurs (likely
+ *   a URL normalization mismatch rather than a legitimate removal of every endpoint).
  */
 export const deprecateStaleResources = async (
   originId: string,
   activeResourceUrls: string[]
 ) => {
-  // If no active resources were discovered, don't deprecate anything
-  // (could indicate discovery failure or incomplete data)
   if (activeResourceUrls.length === 0) {
+    return 0;
+  }
+
+  // Count how many active resources exist vs how many would be deprecated.
+  // If we'd wipe everything, it's almost certainly a bug (URL mismatch),
+  // not the origin legitimately removing all endpoints.
+  const activeCount = await scanDb.resources.count({
+    where: { originId, deprecatedAt: null },
+  });
+
+  if (activeCount === 0) {
+    return 0;
+  }
+
+  const wouldDeprecateCount = await scanDb.resources.count({
+    where: {
+      originId,
+      deprecatedAt: null,
+      resource: { notIn: activeResourceUrls },
+    },
+  });
+
+  if (wouldDeprecateCount === activeCount) {
+    console.warn(
+      `[deprecateStaleResources] Skipping: would deprecate all ${activeCount} active resources for origin ${originId}. Likely a URL normalization mismatch.`
+    );
     return 0;
   }
 
@@ -424,13 +450,9 @@ export const deprecateStaleResources = async (
     where: {
       originId,
       deprecatedAt: null,
-      resource: {
-        notIn: activeResourceUrls,
-      },
+      resource: { notIn: activeResourceUrls },
     },
-    data: {
-      deprecatedAt: new Date(),
-    },
+    data: { deprecatedAt: new Date() },
   });
 
   return result.count;


### PR DESCRIPTION
## Summary

- Extract `normalizeResourceUrl()` as single source of truth for the DB key transform (URL-encode via `new URL()` + strip query)
- Use it in both `registerResource`/`registerSiwxResource` and the deprecation allow-list so they can't drift
- Add safety check: `deprecateStaleResources` bails if it would wipe ALL active resources for an origin (likely a URL mismatch, not legitimate removal)

## Context

#939 changed `fetch-discovery` to emit raw template braces (`/v1/candles/{coin}/{interval}`), but `registerResource` stores the key via `new URL().toString()` which encodes them to `%7Bcoin%7D`. The deprecation allow-list was built from the raw URLs, so the encoded DB keys never matched — every templated resource was deprecated on every registration.

Supersedes #942 with the same core fix plus the extracted helper and safety net.

Regression from #939.

## Test plan
- [x] Register a templated-path origin (e.g. hyperextend) twice → second run reports `0 deprecated`, resources stay active
- [x] Register a non-templated origin → unchanged behaviour
- [x] Simulate URL mismatch (force different encoding) → safety check logs warning and skips deprecation instead of wiping the origin