### PR TITLE
feat(facilitators): add claw-pay facilitator

### DIFF
--- a/packages/external/facilitators/src/facilitators/claw-pay.ts
+++ b/packages/external/facilitators/src/facilitators/claw-pay.ts
@@ -1,0 +1,28 @@
+import { Network } from '../types';
+import { USDC_BASE_TOKEN } from '../constants';
+
+import type { Facilitator, FacilitatorConfig } from '../types';
+
+export const clawpay: FacilitatorConfig = {
+  url: 'https://claw-pay.org',
+};
+
+export const clawpayFacilitator = {
+  id: 'claw-pay',
+  metadata: {
+    name: 'claw-pay',
+    image: 'https://clawpay.eu/logo.png',
+    docsUrl: 'https://clawpay.eu',
+    color: '#7C3AED',
+  },
+  config: clawpay,
+  addresses: {
+    [Network.BASE]: [
+      {
+        address: '0xee94AB6c6c201E6069bB017E4d23200A60f5aB65',
+        tokens: [USDC_BASE_TOKEN],
+        dateOfFirstTransaction: new Date('2026-03-01'),
+      },
+    ],
+  },
+} as const satisfies Facilitator;

--- a/packages/external/facilitators/src/facilitators/index.ts
+++ b/packages/external/facilitators/src/facilitators/index.ts
@@ -28,3 +28,4 @@ export { relai, relaiFacilitator } from './relai';
 export { bitrefill, bitrefillFacilitator } from './bitrefill';
 export { cascade, cascadeFacilitator } from './cascade';
 export { fluxa, fluxaFacilitator } from './fluxa';
+export { clawpay, clawpayFacilitator } from './claw-pay';


### PR DESCRIPTION
## New Facilitator - claw-pay

**Website:** https://clawpay.eu
**API:** https://claw-pay.org
**Source:** https://github.com/orca-labs-sudo/claw-pay

### Details

- **Network:** Base Mainnet
- **Asset:** USDC (ERC-3009 / EIP-712)
- **Scheme:** `exact`
- **Fee:** 3% per settled transaction
- **Wallet:** `0xee94AB6c6c201E6069bB017E4d23200A60f5aB65`
- **Status:** Live since March 2026

### What is claw-pay?

x402 payment facilitator built for OpenClaw agents. Enables autonomous USDC micropayments on Base L2 - agents pay for x402-gated services automatically within user-defined spending limits.

- OpenClaw Skill: 569 downloads on ClawHub
- WooCommerce Plugin: live on WordPress.org ([claw-pay-gateway](https://wordpress.org/plugins/claw-pay-gateway/))
- Security review: v0.3.4