### PR TITLE
feat(facilitator): add Ace Data Cloud

### DIFF
--- a/packages/external/facilitators/src/facilitators/acedatacloud.ts
+++ b/packages/external/facilitators/src/facilitators/acedatacloud.ts
@@ -1,0 +1,40 @@
+import { Network } from '../types';
+import { USDC_BASE_TOKEN, USDC_SOLANA_TOKEN } from '../constants';
+
+import type { Facilitator, FacilitatorConfig } from '../types';
+
+export const acedatacloud: FacilitatorConfig = {
+  url: 'https://facilitator.acedata.cloud',
+};
+
+export const acedatacloudDiscovery: FacilitatorConfig = {
+  url: 'https://facilitator.acedata.cloud',
+};
+
+export const acedatacloudFacilitator = {
+  id: 'acedatacloud',
+  metadata: {
+    name: 'Ace Data Cloud',
+    image: 'https://cdn.acedata.cloud/favicon.png',
+    docsUrl: 'https://platform.acedata.cloud/.well-known/x402',
+    color: '#15CDCE',
+  },
+  config: acedatacloud,
+  discoveryConfig: acedatacloudDiscovery,
+  addresses: {
+    [Network.BASE]: [
+      {
+        address: '0x4F0E2D3477a1B94CF33d16E442CEe4733dadCeE7',
+        tokens: [USDC_BASE_TOKEN],
+        dateOfFirstTransaction: new Date('2026-04-30'),
+      },
+    ],
+    [Network.SOLANA]: [
+      {
+        address: '5iVXFrYaYWX2GUTbkQj8mDBoBhAX8bneYigS2LJTia43',
+        tokens: [USDC_SOLANA_TOKEN],
+        dateOfFirstTransaction: new Date('2026-04-30'),
+      },
+    ],
+  },
+} as const satisfies Facilitator;

--- a/packages/external/facilitators/src/facilitators/index.ts
+++ b/packages/external/facilitators/src/facilitators/index.ts
@@ -28,3 +28,4 @@ export { relai, relaiFacilitator } from './relai';
 export { bitrefill, bitrefillFacilitator } from './bitrefill';
 export { cascade, cascadeFacilitator } from './cascade';
 export { fluxa, fluxaFacilitator } from './fluxa';
+export { acedatacloud, acedatacloudFacilitator } from './acedatacloud';

--- a/packages/external/facilitators/src/lists/all.ts
+++ b/packages/external/facilitators/src/lists/all.ts
@@ -28,6 +28,7 @@ import {
   bitrefillFacilitator,
   cascadeFacilitator,
   fluxaFacilitator,
+  acedatacloudFacilitator,
 } from '../facilitators';
 
 import { validateUniqueFacilitators } from './validate';
@@ -64,6 +65,7 @@ const FACILITATORS = validateUniqueFacilitators([
   bitrefillFacilitator,
   cascadeFacilitator,
   fluxaFacilitator,
+  acedatacloudFacilitator,
 ]);
 
 export const allFacilitators: Facilitator[] =


### PR DESCRIPTION
## What

Registers **Ace Data Cloud** as a facilitator entry in `packages/external/facilitators`.

Ace Data Cloud is a unified API gateway over a broad range of generative-AI workloads — Midjourney, Flux, Suno, Sora, Kling, Hailuo, Veo, Wan, NanoBanana, GPT / Claude / Gemini / Grok chat, web search, etc. All of these are callable via x402 today.

## Files

- New: `packages/external/facilitators/src/facilitators/acedatacloud.ts`
- Registered in `facilitators/index.ts` and `lists/all.ts`

## Facilitator details

- **URL:** `https://facilitator.acedata.cloud`
- **Docs / live resource list:** [`https://platform.acedata.cloud/.well-known/x402`](https://platform.acedata.cloud/.well-known/x402) — currently lists 70 paid resources.
- **`discoveryConfig`** points at the same host, which serves `GET /discovery/resources` (`x402Version: 2`, paginated `items[]` with embedded `accepts[]`) plus a 308 redirect from `/list`. So once this is merged x402scan should pick up newly-launched APIs automatically — no need for us to re-submit through the resource-register form for each one.
- **Brand color** `#15CDCE` matches the existing logo palette.

## On-chain addresses

Receiving addresses are verifiable on-chain:

| Network | Address | Explorer |
| --- | --- | --- |
| Base    | `0x4F0E2D3477a1B94CF33d16E442CEe4733dadCeE7` | [BaseScan](https://basescan.org/address/0x4F0E2D3477a1B94CF33d16E442CEe4733dadCeE7) |
| Solana  | `5iVXFrYaYWX2GUTbkQj8mDBoBhAX8bneYigS2LJTia43` | [Solscan](https://solscan.io/account/5iVXFrYaYWX2GUTbkQj8mDBoBhAX8bneYigS2LJTia43) |

(SKALE is also accepted on the facilitator side but is omitted here because the `Network` enum doesn't currently include SKALE — happy to follow up with a small enum-extension PR if that's something you'd like to support.)

## Validation

```
pnpm install
pnpm --filter facilitators run types:check   # ok
pnpm --filter facilitators run lint          # ok
pnpm --filter facilitators run build         # ok
pnpm --filter facilitators run format:check  # ok
```

Context: opened on behalf of the Ace Data Cloud team after the question on the merit-systems thread. Happy to iterate on anything — branding, addresses, dates, copy. Thanks!