### PR TITLE
Pause facilitator sync route

### DIFF
--- a/apps/scan/src/app/api/resources/sync/route.ts
+++ b/apps/scan/src/app/api/resources/sync/route.ts
@@ -27,6 +27,21 @@ export const GET = async (request: NextRequest) => {
     return cronCheck;
   }
 
+  // Facilitator sync is temporarily paused
+  const FACILITATOR_SYNC_PAUSED = true;
+  if (FACILITATOR_SYNC_PAUSED) {
+    console.log('Facilitator sync route is paused — returning early');
+    return NextResponse.json(
+      {
+        success: true as const,
+        message: 'Facilitator sync is temporarily paused',
+        resourcesProcessed: 0,
+        originsProcessed: 0,
+      },
+      { status: 200 }
+    );
+  }
+
   try {
     // Step 1: Fetch facilitator resources
     console.log('Fetching facilitator resources');


### PR DESCRIPTION
## Summary
- Temporarily pauses the facilitator resource sync cron route (`/api/resources/sync`)
- Route returns a 200 with "Facilitator sync is temporarily paused" without fetching or processing any resources
- Existing sync logic is preserved — flip the `FACILITATOR_SYNC_PAUSED` flag to re-enable

## Test plan
- [ ] Verify the cron route returns 200 with paused message
- [ ] Confirm no facilitator resources are fetched or upserted while paused