### PR TITLE
fix: resolve relative OG image URLs in origin metadata upsert

### DIFF
--- a/apps/scan/src/app/api/resources/sync/route.ts
+++ b/apps/scan/src/app/api/resources/sync/route.ts
@@ -180,13 +180,21 @@ export const GET = async (request: NextRequest) => {
             description: metadata?.description ?? og?.ogDescription,
             favicon: favicon ?? undefined,
             ogImages:
-              og?.ogImage?.map(image => ({
-                url: image.url,
-                height: image.height,
-                width: image.width,
-                title: og.ogTitle,
-                description: og.ogDescription,
-              })) ?? [],
+              og?.ogImage?.flatMap(image => {
+                try {
+                  return [
+                    {
+                      url: new URL(image.url, origin).toString(),
+                      height: image.height,
+                      width: image.width,
+                      title: og.ogTitle,
+                      description: og.ogDescription,
+                    },
+                  ];
+                } catch {
+                  return [];
+                }
+              }) ?? [],
           };
 
           // Upsert origin to database

--- a/apps/scan/src/lib/resources.ts
+++ b/apps/scan/src/lib/resources.ts
@@ -258,13 +258,21 @@ export async function registerSiwxResource(
           description: description ?? undefined,
           favicon: favicon ?? undefined,
           ogImages:
-            og?.ogImage?.map(image => ({
-              url: image.url,
-              height: image.height,
-              width: image.width,
-              title: og.ogTitle,
-              description: og.ogDescription,
-            })) ?? [],
+            og?.ogImage?.flatMap(image => {
+              try {
+                return [
+                  {
+                    url: new URL(image.url, origin).toString(),
+                    height: image.height,
+                    width: image.width,
+                    title: og.ogTitle,
+                    description: og.ogDescription,
+                  },
+                ];
+              } catch {
+                return [];
+              }
+            }) ?? [],
         });
       } catch (err) {
         console.error(
@@ -524,15 +532,31 @@ export const registerResource = async (
     description: description ?? undefined,
     favicon: favicon ?? undefined,
     ogImages:
-      og?.ogImage?.map(image => ({
-        url: image.url,
-        height: image.height,
-        width: image.width,
-        title: og.ogTitle,
-        description: og.ogDescription,
-      })) ?? [],
-  }).catch(() => {
-    // P2002 or other race — another call already upserted this origin.
+      og?.ogImage?.flatMap(image => {
+        try {
+          return [
+            {
+              url: new URL(image.url, origin).toString(),
+              height: image.height,
+              width: image.width,
+              title: og.ogTitle,
+              description: og.ogDescription,
+            },
+          ];
+        } catch {
+          return [];
+        }
+      }) ?? [],
+  }).catch(err => {
+    // P2002: another concurrent call already upserted this origin — safe to ignore.
+    // Log anything else so metadata failures aren't silent.
+    const isP2002 =
+      err instanceof Error &&
+      'code' in err &&
+      (err as { code: string }).code === 'P2002';
+    if (!isP2002) {
+      console.error('[registerResource] Origin metadata upsert failed:', err);
+    }
   });
 
   await upsertResourceResponse(

--- a/apps/scan/src/services/db/resources/resource.ts
+++ b/apps/scan/src/services/db/resources/resource.ts
@@ -441,9 +441,7 @@ export const deprecateStaleResources = async (
     return 0;
   }
 
-  const activeKeys = new Set(
-    activeResources.map(r => `${r.method}::${r.url}`)
-  );
+  const activeKeys = new Set(activeResources.map(r => `${r.method}::${r.url}`));
   const staleIds = allResources
     .filter(r => !activeKeys.has(`${r.method}::${r.resource}`))
     .map(r => r.id);


### PR DESCRIPTION
## Summary

- **Bug**: When an origin's `og:image` meta tag uses a relative URL (e.g. `/favicon.ico`), the raw path failed `z.url()` validation in `upsertOrigin`'s Zod schema. This caused the entire `originSchema.parse()` to throw, and the `.catch(() => {})` silently swallowed the error — so title, description, and favicon all stayed null even though they were scraped successfully.
- **Fix**: Resolve OG image URLs to absolute via `new URL(image.url, origin)` before passing to `upsertOrigin`. Use `flatMap` + try-catch so one bad URL skips that image instead of nuking the entire metadata write. Also log non-P2002 errors in `registerResource`'s catch handler.
- Fixed in all 3 call sites: `registerResource`, `registerSiwxResource`, and the sync route.

## Test plan

- [x] Re-register `https://nectarpay.crypto-dreamr.com` on preview — title, description, and favicon all populated correctly
- [x] Register `https://stableenrich.dev` on preview (absolute og:image URLs) — 38 resources registered, no regression
- [ ] Check Vercel logs for any `[registerResource] Origin metadata upsert failed` entries on existing origins (would indicate other origins affected by this bug)