### PR TITLE
Add TWZRD Agent Intel — Solana-native x402 trust receipt MCP server

### DIFF
--- a/apps/scan/src/lib/ecosystem/list.ts
+++ b/apps/scan/src/lib/ecosystem/list.ts
@@ -298,7 +298,7 @@ export const ecosystemItems: EcosystemItem[] = [
     description:
       'Solana-native trust scoring and x402 receipt layer for AI agents. Provides free preflight checks (trust score, activity flags) and paid signed V5 trust receipts — enabling AI agents to verify Solana wallet reputation before transacting. MCP endpoint at intel.twzrd.xyz.',
     logoUrl: 'https://intel.twzrd.xyz/favicon.ico',
-    websiteUrl: 'https://github.com/twzrd-sol/wzrd-final',
+    websiteUrl: 'https://intel.twzrd.xyz',
     category: 'Services/Endpoints',
   },
   {

--- a/apps/scan/src/lib/ecosystem/list.ts
+++ b/apps/scan/src/lib/ecosystem/list.ts
@@ -294,6 +294,14 @@ export const ecosystemItems: EcosystemItem[] = [
     category: 'Client-Side Integrations',
   },
   {
+    name: 'TWZRD Agent Intel',
+    description:
+      'Solana-native trust scoring and x402 receipt layer for AI agents. Provides free preflight checks (trust score, activity flags) and paid signed V5 trust receipts — enabling AI agents to verify Solana wallet reputation before transacting. MCP endpoint at intel.twzrd.xyz.',
+    logoUrl: 'https://intel.twzrd.xyz/favicon.ico',
+    websiteUrl: 'https://github.com/twzrd-sol/wzrd-final',
+    category: 'Services/Endpoints',
+  },
+  {
     name: 'x402 Example Gallery',
     description:
       'A collection of x402 examples including Next.js integration, Go Proxy, agent use-cases, authentication flows, and more. Explore practical code samples to accelerate your x402 journey.',


### PR DESCRIPTION
TWZRD Agent Intel is a production Solana MCP server providing x402 payment and trust receipt services for AI agents. Issues cryptographically signed V5 trust receipts. Live at https://intel.twzrd.xyz with Streamable-HTTP MCP transport.

## What it does

- **Free preflight**: AI agents can query trust scores and activity flags for any Solana wallet
- **Paid V5 trust receipts**: Signed receipts issued via x402 micropayments, enabling verifiable agent-to-agent trust
- **Solana-native**: Built on Solana with Token-2022/CCM integration, not EVM-only

## Category

`Services/Endpoints` — sits alongside other x402-powered service endpoints in the ecosystem list.

## Entry added

```typescript
{
  name: 'TWZRD Agent Intel',
  description: 'Solana-native trust scoring and x402 receipt layer for AI agents...',
  logoUrl: 'https://intel.twzrd.xyz/favicon.ico',
  websiteUrl: 'https://intel.twzrd.xyz',
  category: 'Services/Endpoints',
}
```

Inserted alphabetically after Tweazy, before x402 Example Gallery.