### PR TITLE
Fix Base Bitquery transfer event query

### DIFF
--- a/sync/transfers/trigger/chains/evm/base/bitquery/query.ts
+++ b/sync/transfers/trigger/chains/evm/base/bitquery/query.ts
@@ -1,10 +1,13 @@
+import { TRANSFER_TOPIC } from '@/trigger/lib/constants';
 import type {
-  EvmBitQueryTransferRow,
+  EvmBitQueryEventRow,
   Facilitator,
   FacilitatorConfig,
   SyncConfig,
   TransferEventData,
 } from '@/trigger/types';
+
+const TRANSFER_TOPIC_WITHOUT_PREFIX = TRANSFER_TOPIC.replace(/^0x/, '');
 
 export function buildQuery(
   config: SyncConfig,
@@ -16,14 +19,19 @@ export function buildQuery(
   return `
     {
       EVM(dataset: combined, network: base) {
-        Transfers(
+        Events(
           limit: { count: ${config.limit}, offset: ${offset} }
           where: {
-            Transfer: {
-              Success: true
-              Currency: {
-                SmartContract: {
-                  is: "${facilitatorConfig.token.address}"
+            LogHeader: {
+              Address: {
+                is: "${facilitatorConfig.token.address.toLowerCase()}"
+              }
+              Removed: false
+            }
+            Log: {
+              Signature: {
+                SignatureHash: {
+                  is: "${TRANSFER_TOPIC_WITHOUT_PREFIX}"
                 }
               }
             }
@@ -43,10 +51,7 @@ export function buildQuery(
             ascending: [
               Block_Number,
               Transaction_Index,
-              Call_Index,
-              Log_Index,
-              Transfer_Index,
-              Transfer_Type
+              Log_EnterIndex
             ]
           }
         ) {
@@ -59,25 +64,27 @@ export function buildQuery(
             From
             Index
           }
-          Transfer {
-            Amount
-            Sender
-            Receiver
+          LogHeader {
+            Address
             Index
-            Type
-            Success
-            Currency {
-              SmartContract
-              Decimals
-              Symbol
-              Name
-            }
+            Removed
           }
           Log {
+            EnterIndex
             Index
+            LogAfterCallIndex
+            SmartContract
           }
-          Call {
-            Index
+          Arguments {
+            Name
+            Value {
+              ... on EVM_ABI_Address_Value_Arg {
+                address
+              }
+              ... on EVM_ABI_BigInt_Value_Arg {
+                bigInteger
+              }
+            }
           }
         }
       }
@@ -91,30 +98,53 @@ export function transformResponse(
   facilitator: Facilitator,
   facilitatorConfig: FacilitatorConfig
 ): TransferEventData[] {
-  const transfers = (data as { EVM: { Transfers: EvmBitQueryTransferRow[] } })
-    .EVM.Transfers;
-  const multiplier = 10 ** facilitatorConfig.token.decimals;
+  const events = (data as { EVM: { Events: EvmBitQueryEventRow[] } }).EVM
+    .Events;
 
-  return transfers.map(transfer => {
-    if (transfer.Log?.Index === undefined || transfer.Log.Index === null) {
-      throw new Error(
-        `Bitquery transfer is missing Log.Index for ${transfer.Transaction.Hash}`
-      );
-    }
+  return events.map(event => {
+    const sender = getAddressArgument(event, 'from');
+    const recipient = getAddressArgument(event, 'to');
+    const amount = getBigIntArgument(event, 'value');
 
     return {
-      address: transfer.Transfer.Currency.SmartContract.toLowerCase(),
-      transaction_from: transfer.Transaction.From.toLowerCase(),
-      sender: transfer.Transfer.Sender.toLowerCase(),
-      recipient: transfer.Transfer.Receiver.toLowerCase(),
-      amount: Math.round(parseFloat(transfer.Transfer.Amount) * multiplier),
-      block_timestamp: new Date(transfer.Block.Time),
-      tx_hash: transfer.Transaction.Hash.toLowerCase(),
-      log_index: transfer.Log.Index,
+      address: event.LogHeader.Address.toLowerCase(),
+      transaction_from: event.Transaction.From.toLowerCase(),
+      sender: sender.toLowerCase(),
+      recipient: recipient.toLowerCase(),
+      amount: Number(amount),
+      block_timestamp: new Date(event.Block.Time),
+      tx_hash: event.Transaction.Hash.toLowerCase(),
+      log_index: event.Log.EnterIndex,
       chain: config.chain,
       provider: config.provider,
       decimals: facilitatorConfig.token.decimals,
       facilitator_id: facilitator.id,
     };
   });
+}
+
+function getAddressArgument(event: EvmBitQueryEventRow, name: string): string {
+  const value = event.Arguments.find(argument => argument.Name === name)?.Value
+    .address;
+
+  if (!value) {
+    throw new Error(
+      `Bitquery event is missing ${name} address for ${event.Transaction.Hash}`
+    );
+  }
+
+  return value;
+}
+
+function getBigIntArgument(event: EvmBitQueryEventRow, name: string): string {
+  const value = event.Arguments.find(argument => argument.Name === name)?.Value
+    .bigInteger;
+
+  if (!value) {
+    throw new Error(
+      `Bitquery event is missing ${name} amount for ${event.Transaction.Hash}`
+    );
+  }
+
+  return value;
 }

--- a/sync/transfers/trigger/types.ts
+++ b/sync/transfers/trigger/types.ts
@@ -150,6 +150,36 @@ export interface BitQueryTransferRowStream {
   };
 }
 
+export interface EvmBitQueryEventRow {
+  Block: {
+    Time: string;
+    Number: string;
+  };
+  Transaction: {
+    Hash: string;
+    From: string;
+    Index: string;
+  };
+  LogHeader: {
+    Address: string;
+    Index: string;
+    Removed: boolean;
+  };
+  Log: {
+    EnterIndex: number;
+    Index: number;
+    LogAfterCallIndex: number;
+    SmartContract: string;
+  };
+  Arguments: {
+    Name: string;
+    Value: {
+      address?: string;
+      bigInteger?: string;
+    };
+  }[];
+}
+
 export interface EvmBitQueryTransferRow {
   Transfer: {
     Amount: string;
@@ -173,11 +203,5 @@ export interface EvmBitQueryTransferRow {
     Hash: string;
     From: string;
     Index: number;
-  };
-  Log?: {
-    Index: number | null;
-  };
-  Call?: {
-    Index: number | null;
   };
 }


### PR DESCRIPTION
## Summary

- switch Base Bitquery from the `Transfers` cube to the `Events` cube to match CDP's ERC20 log-event query
- filter server-side by USDC `LogHeader.Address`, ERC20 `Transfer` signature, facilitator `Transaction.From`, and block time
- transform decoded `from`, `to`, and `value` event arguments into the existing `TransferEventData` shape
- use `Log.EnterIndex` as Bitquery's stable event index because Bitquery does not expose CDP/RPC canonical receipt `logIndex` in the Events fields we tested

## Why

The previous Base Bitquery query filtered on `Transfer.Currency.SmartContract = USDC`. For current Coinbase transfers, Bitquery returns the facilitator address in `Transfer.Currency.SmartContract` and the USDC address in the log fields, so the production query returned zero rows.

## Validation

- `pnpm --filter @x402scan/sync-transfers types:check`
- `pnpm --filter @x402scan/sync-transfers lint`

Read-only CDP DB vs Bitquery Events comparisons for Coinbase Base:

- 5-minute window: `2026-06-07T12:30:29.000Z` to `2026-06-07T12:35:29.000Z`
  - CDP rows: 473
  - transformed Bitquery rows: 473
  - missing in Bitquery: 0
  - extra in Bitquery: 0
  - mismatches excluding `provider` and `log_index`: 0

- 10-minute window: `2026-06-07T12:25:29.000Z` to `2026-06-07T12:35:29.000Z`
  - CDP rows: 701
  - transformed Bitquery rows: 701
  - missing in Bitquery: 0
  - extra in Bitquery: 0
  - mismatches excluding `provider` and `log_index`: 0

## Log index note

The payment fields match CDP after transform: token address, transaction_from, sender, recipient, amount, timestamp, tx hash, chain, decimals, and facilitator_id.

`log_index` does not match CDP/RPC canonical receipt logIndex. Example from the 5-minute comparison: CDP `log_index = 31`, Bitquery `Log.EnterIndex = 206`. Bitquery `Log.Index` and `LogHeader.Index` also did not match canonical receipt logIndex in manual checks. This means CDP/Bitquery overlap can create duplicates, so the no-overlap handoff remains important.
