### PR TITLE
Switch Base transfer sync from CDP to BitQuery (Events endpoint)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1203,6 +1203,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
 
 packages:
 

--- a/sync/transfers/package.json
+++ b/sync/transfers/package.json
@@ -14,7 +14,9 @@
     "lint:fix": "eslint . --fix",
     "knip": "pnpm -w knip --workspace ./sync/transfers",
     "format": "pnpm -w format:dir ./sync/transfers",
-    "format:check": "pnpm -w format:check:dir ./sync/transfers"
+    "format:check": "pnpm -w format:check:dir ./sync/transfers",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@coinbase/cdp-sdk": "^1.38.4",
@@ -34,6 +36,7 @@
     "@types/node": "catalog:",
     "eslint": "catalog:",
     "trigger.dev": "catalog:trigger",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/sync/transfers/trigger/chains/evm/base/bitquery/config.ts
+++ b/sync/transfers/trigger/chains/evm/base/bitquery/config.ts
@@ -1,22 +1,22 @@
+import { FACILITATORS_BY_CHAIN } from '@/trigger/lib/facilitators';
 import { ONE_MINUTE_IN_SECONDS } from '@/trigger/lib/constants';
 import type { SyncConfig } from '@/trigger/types';
-import { PaginationStrategy, QueryProvider } from '@/trigger/types';
+import { Network, PaginationStrategy, QueryProvider } from '@/trigger/types';
 import { buildQuery, transformResponse } from './query';
-import { FACILITATORS_BY_CHAIN } from '@/trigger/lib/facilitators';
-import { Network } from '@/trigger/types';
 
-export const baseCdpConfig: SyncConfig = {
+export const baseBitqueryConfig: SyncConfig = {
   cron: '*/5 * * * *',
   maxDurationInSeconds: ONE_MINUTE_IN_SECONDS * 15,
   chain: 'base',
-  provider: QueryProvider.CDP,
-  apiUrl: 'api.cdp.coinbase.com',
+  provider: QueryProvider.BITQUERY,
+  apiUrl: 'https://streaming.bitquery.io/graphql',
   paginationStrategy: PaginationStrategy.OFFSET,
-  limit: 10_000, // NOTE(shafu): 100k is the CDP limit
+  limit: 25_000,
   facilitators: FACILITATORS_BY_CHAIN(Network.BASE),
   buildQuery,
   transformResponse,
-  enabled: false,
+  enabled: true,
   machine: 'medium-1x',
   splitSyncByFacilitator: true,
+  resumeFromProviders: [QueryProvider.CDP, QueryProvider.BITQUERY],
 };

--- a/sync/transfers/trigger/chains/evm/base/bitquery/query.test.ts
+++ b/sync/transfers/trigger/chains/evm/base/bitquery/query.test.ts
@@ -193,6 +193,7 @@ describe('transformResponse', () => {
     );
 
     expect(result).toHaveLength(0);
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('Skipping event with missing args')
     );

--- a/sync/transfers/trigger/chains/evm/base/bitquery/query.test.ts
+++ b/sync/transfers/trigger/chains/evm/base/bitquery/query.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@trigger.dev/sdk/v3', () => ({
+  logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { buildQuery, transformResponse } from './query';
+import type {
+  EvmBitQueryEventRow,
+  SyncConfig,
+  Facilitator,
+  FacilitatorConfig,
+} from '@/trigger/types';
+import { QueryProvider, PaginationStrategy } from '@/trigger/types';
+import { logger } from '@trigger.dev/sdk/v3';
+
+const mockConfig: SyncConfig = {
+  chain: 'base',
+  provider: QueryProvider.BITQUERY,
+  apiUrl: 'https://streaming.bitquery.io/graphql',
+  paginationStrategy: PaginationStrategy.OFFSET,
+  cron: '*/5 * * * *',
+  maxDurationInSeconds: 900,
+  facilitators: [],
+  limit: 25_000,
+  enabled: true,
+  machine: 'medium-1x',
+  buildQuery,
+  transformResponse,
+};
+
+const mockFacilitator: Facilitator = {
+  id: 'coinbase',
+  addresses: {},
+};
+
+const mockFacilitatorConfig: FacilitatorConfig = {
+  address: '0xFacilitatorAddress',
+  token: {
+    address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+    decimals: 6,
+    symbol: 'USDC',
+  },
+  syncStartDate: new Date('2025-01-01'),
+  enabled: true,
+};
+
+describe('buildQuery', () => {
+  it('uses Events endpoint, not Transfers', () => {
+    const query = buildQuery(
+      mockConfig,
+      mockFacilitatorConfig,
+      new Date('2026-06-05T12:00:00Z'),
+      new Date('2026-06-05T12:05:00Z')
+    );
+
+    expect(query).toContain('Events(');
+    expect(query).not.toContain('Transfers(');
+  });
+
+  it('filters by Transfer signature hash', () => {
+    const query = buildQuery(
+      mockConfig,
+      mockFacilitatorConfig,
+      new Date('2026-06-05T12:00:00Z'),
+      new Date('2026-06-05T12:05:00Z')
+    );
+
+    // Transfer(address,address,uint256) topic without 0x prefix
+    expect(query).toContain(
+      'ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
+    );
+  });
+
+  it('filters by token address and facilitator', () => {
+    const query = buildQuery(
+      mockConfig,
+      mockFacilitatorConfig,
+      new Date('2026-06-05T12:00:00Z'),
+      new Date('2026-06-05T12:05:00Z')
+    );
+
+    expect(query).toContain(mockFacilitatorConfig.token.address.toLowerCase());
+    expect(query).toContain(mockFacilitatorConfig.address.toLowerCase());
+  });
+
+  it('orders by Log_EnterIndex for stable ordering', () => {
+    const query = buildQuery(
+      mockConfig,
+      mockFacilitatorConfig,
+      new Date('2026-06-05T12:00:00Z'),
+      new Date('2026-06-05T12:05:00Z')
+    );
+
+    expect(query).toContain('Log_EnterIndex');
+  });
+});
+
+describe('transformResponse', () => {
+  function makeEvent(
+    overrides: Partial<EvmBitQueryEventRow> = {}
+  ): EvmBitQueryEventRow {
+    return {
+      Block: { Time: '2026-06-05T12:00:00Z', Number: '12345' },
+      Transaction: {
+        Hash: '0xabc123',
+        From: '0xFacilitatorAddress',
+        Index: 0,
+      },
+      LogHeader: {
+        Address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+        Index: 5,
+        Removed: false,
+      },
+      Log: {
+        EnterIndex: 206,
+        Index: 31,
+        LogAfterCallIndex: 0,
+        SmartContract: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+      },
+      Arguments: [
+        { Name: 'from', Value: { address: '0xSenderAddress' } },
+        { Name: 'to', Value: { address: '0xRecipientAddress' } },
+        { Name: 'value', Value: { bigInteger: '1000000' } },
+      ],
+      ...overrides,
+    };
+  }
+
+  it('maps valid events to TransferEventData', () => {
+    const data = { EVM: { Events: [makeEvent()] } };
+
+    const result = transformResponse(
+      data,
+      mockConfig,
+      mockFacilitator,
+      mockFacilitatorConfig
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      address: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+      transaction_from: '0xfacilitatoraddress',
+      sender: '0xsenderaddress',
+      recipient: '0xrecipientaddress',
+      amount: 1000000,
+      block_timestamp: new Date('2026-06-05T12:00:00Z'),
+      tx_hash: '0xabc123',
+      log_index: 206, // Uses Log.EnterIndex, NOT Log.Index
+      chain: 'base',
+      provider: 'bitquery',
+      decimals: 6,
+      facilitator_id: 'coinbase',
+    });
+  });
+
+  it('uses Log.EnterIndex as log_index (not Log.Index)', () => {
+    const event = makeEvent({
+      Log: {
+        EnterIndex: 206, // BitQuery's stable index
+        Index: 31, // Does NOT match CDP's receipt logIndex
+        LogAfterCallIndex: 0,
+        SmartContract: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+      },
+    });
+    const data = { EVM: { Events: [event] } };
+
+    const result = transformResponse(
+      data,
+      mockConfig,
+      mockFacilitator,
+      mockFacilitatorConfig
+    );
+
+    // log_index should be EnterIndex (206), not Index (31)
+    expect(result[0]!.log_index).toBe(206);
+  });
+
+  it('skips events with missing from argument instead of throwing', () => {
+    const event = makeEvent({
+      Arguments: [
+        { Name: 'to', Value: { address: '0xRecipient' } },
+        { Name: 'value', Value: { bigInteger: '1000000' } },
+      ],
+    });
+    const data = { EVM: { Events: [event] } };
+
+    const result = transformResponse(
+      data,
+      mockConfig,
+      mockFacilitator,
+      mockFacilitatorConfig
+    );
+
+    expect(result).toHaveLength(0);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Skipping event with missing args')
+    );
+  });
+
+  it('skips events with missing value argument instead of throwing', () => {
+    const event = makeEvent({
+      Arguments: [
+        { Name: 'from', Value: { address: '0xSender' } },
+        { Name: 'to', Value: { address: '0xRecipient' } },
+      ],
+    });
+    const data = { EVM: { Events: [event] } };
+
+    const result = transformResponse(
+      data,
+      mockConfig,
+      mockFacilitator,
+      mockFacilitatorConfig
+    );
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('lowercases all addresses', () => {
+    const data = { EVM: { Events: [makeEvent()] } };
+
+    const result = transformResponse(
+      data,
+      mockConfig,
+      mockFacilitator,
+      mockFacilitatorConfig
+    );
+
+    expect(result[0]!.address).toBe(result[0]!.address.toLowerCase());
+    expect(result[0]!.sender).toBe(result[0]!.sender.toLowerCase());
+    expect(result[0]!.recipient).toBe(result[0]!.recipient.toLowerCase());
+    expect(result[0]!.tx_hash).toBe(result[0]!.tx_hash.toLowerCase());
+  });
+});

--- a/sync/transfers/trigger/chains/evm/base/bitquery/query.ts
+++ b/sync/transfers/trigger/chains/evm/base/bitquery/query.ts
@@ -1,0 +1,142 @@
+import { logger } from '@trigger.dev/sdk/v3';
+import { TRANSFER_TOPIC } from '@/trigger/lib/constants';
+import type {
+  EvmBitQueryEventRow,
+  Facilitator,
+  FacilitatorConfig,
+  SyncConfig,
+  TransferEventData,
+} from '@/trigger/types';
+
+const TRANSFER_TOPIC_WITHOUT_PREFIX = TRANSFER_TOPIC.replace(/^0x/, '');
+
+export function buildQuery(
+  config: SyncConfig,
+  facilitatorConfig: FacilitatorConfig,
+  since: Date,
+  now: Date,
+  offset = 0
+): string {
+  return `
+    {
+      EVM(dataset: combined, network: base) {
+        Events(
+          limit: { count: ${config.limit}, offset: ${offset} }
+          where: {
+            LogHeader: {
+              Address: {
+                is: "${facilitatorConfig.token.address.toLowerCase()}"
+              }
+              Removed: false
+            }
+            Log: {
+              Signature: {
+                SignatureHash: {
+                  is: "${TRANSFER_TOPIC_WITHOUT_PREFIX}"
+                }
+              }
+            }
+            Transaction: {
+              From: {
+                is: "${facilitatorConfig.address.toLowerCase()}"
+              }
+            }
+            Block: {
+              Time: {
+                since: "${since.toISOString()}"
+                till: "${now.toISOString()}"
+              }
+            }
+          }
+          orderBy: {
+            ascending: [
+              Block_Number,
+              Transaction_Index,
+              Log_EnterIndex
+            ]
+          }
+        ) {
+          Block {
+            Time
+            Number
+          }
+          Transaction {
+            Hash
+            From
+            Index
+          }
+          LogHeader {
+            Address
+            Index
+            Removed
+          }
+          Log {
+            EnterIndex
+            Index
+            LogAfterCallIndex
+            SmartContract
+          }
+          Arguments {
+            Name
+            Value {
+              ... on EVM_ABI_Address_Value_Arg {
+                address
+              }
+              ... on EVM_ABI_BigInt_Value_Arg {
+                bigInteger
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+}
+
+export function transformResponse(
+  data: unknown,
+  config: SyncConfig,
+  facilitator: Facilitator,
+  facilitatorConfig: FacilitatorConfig
+): TransferEventData[] {
+  const events = (data as { EVM: { Events: EvmBitQueryEventRow[] } }).EVM
+    .Events;
+
+  return events.flatMap(event => {
+    const sender = getArgument(event, 'from', 'address');
+    const recipient = getArgument(event, 'to', 'address');
+    const amount = getArgument(event, 'value', 'bigInteger');
+
+    if (!sender || !recipient || !amount) {
+      logger.warn(
+        `[base] Skipping event with missing args: ${event.Transaction.Hash} (from=${sender}, to=${recipient}, value=${amount})`
+      );
+      return [];
+    }
+
+    return [
+      {
+        address: event.LogHeader.Address.toLowerCase(),
+        transaction_from: event.Transaction.From.toLowerCase(),
+        sender: sender.toLowerCase(),
+        recipient: recipient.toLowerCase(),
+        amount: Number(amount),
+        block_timestamp: new Date(event.Block.Time),
+        tx_hash: event.Transaction.Hash.toLowerCase(),
+        log_index: event.Log.EnterIndex,
+        chain: config.chain,
+        provider: config.provider,
+        decimals: facilitatorConfig.token.decimals,
+        facilitator_id: facilitator.id,
+      },
+    ];
+  });
+}
+
+function getArgument(
+  event: EvmBitQueryEventRow,
+  name: string,
+  field: 'address' | 'bigInteger'
+): string | undefined {
+  return event.Arguments.find(arg => arg.Name === name)?.Value[field];
+}

--- a/sync/transfers/trigger/chains/evm/base/bitquery/sync.ts
+++ b/sync/transfers/trigger/chains/evm/base/bitquery/sync.ts
@@ -1,0 +1,5 @@
+import { createChainSyncTask } from '../../../../sync';
+import { baseBitqueryConfig } from './config';
+
+export const baseBitquerySyncTransfers =
+  createChainSyncTask(baseBitqueryConfig);

--- a/sync/transfers/trigger/fetch/bitquery/fetch.ts
+++ b/sync/transfers/trigger/fetch/bitquery/fetch.ts
@@ -14,7 +14,8 @@ export async function fetchWithOffsetPagination(
   facilitator: Facilitator,
   facilitatorConfig: FacilitatorConfig,
   since: Date,
-  now: Date
+  now: Date,
+  onBatchFetched?: (batch: TransferEventData[]) => Promise<void>
 ): Promise<TransferEventData[]> {
   const allTransfers = [];
   let offset = 0;
@@ -38,6 +39,10 @@ export async function fetchWithOffsetPagination(
     );
 
     allTransfers.push(...transfers);
+
+    if (onBatchFetched && transfers.length > 0) {
+      await onBatchFetched(transfers);
+    }
 
     if (transfers.length < config.limit) {
       hasMore = false;

--- a/sync/transfers/trigger/fetch/fetch.ts
+++ b/sync/transfers/trigger/fetch/fetch.ts
@@ -137,12 +137,9 @@ async function fetchWithOffset(
       facilitator,
       facilitatorConfig,
       since,
-      now
+      now,
+      onBatchFetched
     );
-
-    if (onBatchFetched && results.length > 0) {
-      await onBatchFetched(results);
-    }
 
     return { totalFetched: results.length };
   }

--- a/sync/transfers/trigger/sync.test.ts
+++ b/sync/transfers/trigger/sync.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock external dependencies before importing the module under test
+vi.mock('@/db/services', () => ({
+  createManyTransferEvents: vi.fn(),
+  getTransferEvents: vi.fn(),
+}));
+
+vi.mock('@trigger.dev/sdk/v3', () => ({
+  logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  schedules: { task: vi.fn() },
+}));
+
+vi.mock('./fetch/fetch', () => ({
+  fetchTransfers: vi.fn(),
+}));
+
+import { getTransferEvents } from '@/db/services';
+import {
+  getMostRecentTransferForResume,
+  normalizeTransactionFrom,
+} from './sync';
+import type { SyncConfig } from './types';
+import { QueryProvider, PaginationStrategy } from './types';
+
+const getTransferEventsMock = vi.mocked(getTransferEvents);
+
+const baseSyncConfig: SyncConfig = {
+  chain: 'base',
+  provider: QueryProvider.BITQUERY,
+  paginationStrategy: PaginationStrategy.OFFSET,
+  cron: '*/5 * * * *',
+  maxDurationInSeconds: 900,
+  facilitators: [],
+  limit: 25_000,
+  enabled: true,
+  machine: 'medium-1x',
+  buildQuery: () => '',
+  transformResponse: () => [],
+};
+
+describe('normalizeTransactionFrom', () => {
+  it('lowercases EVM addresses', () => {
+    expect(normalizeTransactionFrom('base', '0xAbCdEf1234567890')).toBe(
+      '0xabcdef1234567890'
+    );
+  });
+
+  it('preserves Solana addresses as-is', () => {
+    expect(normalizeTransactionFrom('solana', 'SoLaNaAdDrEsS123')).toBe(
+      'SoLaNaAdDrEsS123'
+    );
+  });
+});
+
+describe('getMostRecentTransferForResume', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the latest transfer across multiple providers', async () => {
+    const cdpTransfer = {
+      block_timestamp: new Date('2026-06-05T17:45:31Z'),
+      id: 'cdp-1',
+    };
+    const bitqueryTransfer = {
+      block_timestamp: new Date('2026-06-05T18:28:27Z'),
+      id: 'bq-1',
+    };
+
+    getTransferEventsMock
+      .mockResolvedValueOnce([cdpTransfer] as never)
+      .mockResolvedValueOnce([bitqueryTransfer] as never);
+
+    const result = await getMostRecentTransferForResume(
+      {
+        ...baseSyncConfig,
+        resumeFromProviders: [QueryProvider.CDP, QueryProvider.BITQUERY],
+      },
+      '0xfacilitator',
+      [QueryProvider.CDP, QueryProvider.BITQUERY]
+    );
+
+    expect(result?.block_timestamp).toEqual(new Date('2026-06-05T18:28:27Z'));
+  });
+
+  it('queries each provider separately', async () => {
+    getTransferEventsMock.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+    await getMostRecentTransferForResume(baseSyncConfig, '0xfacilitator', [
+      QueryProvider.CDP,
+      QueryProvider.BITQUERY,
+    ]);
+
+    expect(getTransferEventsMock).toHaveBeenCalledTimes(2);
+    expect(getTransferEventsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ provider: QueryProvider.CDP }),
+      })
+    );
+    expect(getTransferEventsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ provider: QueryProvider.BITQUERY }),
+      })
+    );
+  });
+
+  it('returns undefined when no transfers exist from any provider', async () => {
+    getTransferEventsMock.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+    const result = await getMostRecentTransferForResume(
+      baseSyncConfig,
+      '0xfacilitator',
+      [QueryProvider.CDP, QueryProvider.BITQUERY]
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns the single provider result when only one has data', async () => {
+    const cdpTransfer = {
+      block_timestamp: new Date('2026-06-05T17:45:31Z'),
+    };
+
+    getTransferEventsMock
+      .mockResolvedValueOnce([cdpTransfer] as never)
+      .mockResolvedValueOnce([]);
+
+    const result = await getMostRecentTransferForResume(
+      baseSyncConfig,
+      '0xfacilitator',
+      [QueryProvider.CDP, QueryProvider.BITQUERY]
+    );
+
+    expect(result?.block_timestamp).toEqual(new Date('2026-06-05T17:45:31Z'));
+  });
+});
+
+describe('resume cursor advances forward (no overlap)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('starts from T+1s after latest transfer, not T-overlap', async () => {
+    // This test proves the bug fix: without resumeOverlapMs, the cursor
+    // advances forward by 1 second, not backwards by 60 seconds.
+    const latestTimestamp = new Date('2026-06-05T17:45:31Z');
+    const cdpTransfer = { block_timestamp: latestTimestamp };
+
+    getTransferEventsMock.mockResolvedValueOnce([cdpTransfer] as never);
+
+    const result = await getMostRecentTransferForResume(
+      baseSyncConfig,
+      '0xfacilitator',
+      [QueryProvider.CDP]
+    );
+
+    // syncFacilitator computes: since = result.block_timestamp + 1000ms
+    const since = new Date(result!.block_timestamp.getTime() + 1000);
+    expect(since).toEqual(new Date('2026-06-05T17:45:32Z'));
+
+    // The old buggy code would have done: since = result.block_timestamp - 60000ms
+    const buggyOverlapSince = new Date(
+      result!.block_timestamp.getTime() - 60000
+    );
+    expect(buggyOverlapSince).toEqual(new Date('2026-06-05T17:44:31Z'));
+
+    // Cursor moves FORWARD, not backward
+    expect(since.getTime()).toBeGreaterThan(latestTimestamp.getTime());
+    expect(buggyOverlapSince.getTime()).toBeLessThan(latestTimestamp.getTime());
+  });
+});

--- a/sync/transfers/trigger/sync.test.ts
+++ b/sync/transfers/trigger/sync.test.ts
@@ -94,13 +94,17 @@ describe('getMostRecentTransferForResume', () => {
 
     expect(getTransferEventsMock).toHaveBeenCalledTimes(2);
     expect(getTransferEventsMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({ provider: QueryProvider.CDP }),
+      expect.objectContaining<Record<string, unknown>>({
+        where: expect.objectContaining<Record<string, unknown>>({
+          provider: QueryProvider.CDP,
+        }),
       })
     );
     expect(getTransferEventsMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({ provider: QueryProvider.BITQUERY }),
+      expect.objectContaining<Record<string, unknown>>({
+        where: expect.objectContaining<Record<string, unknown>>({
+          provider: QueryProvider.BITQUERY,
+        }),
       })
     );
   });

--- a/sync/transfers/trigger/sync.ts
+++ b/sync/transfers/trigger/sync.ts
@@ -5,6 +5,41 @@ import { fetchTransfers } from './fetch/fetch';
 
 import type { Facilitator, SyncConfig } from './types';
 
+type ResumeTransfer = Awaited<ReturnType<typeof getTransferEvents>>[number];
+
+export function normalizeTransactionFrom(
+  chain: string,
+  address: string
+): string {
+  return chain === Network.SOLANA.toString() ? address : address.toLowerCase();
+}
+
+export async function getMostRecentTransferForResume(
+  syncConfig: SyncConfig,
+  transactionFrom: string,
+  resumeFromProviders: string[]
+): Promise<ResumeTransfer | undefined> {
+  const results = await Promise.all(
+    resumeFromProviders.map(provider =>
+      getTransferEvents({
+        orderBy: { block_timestamp: 'desc' },
+        take: 1,
+        where: {
+          chain: syncConfig.chain,
+          transaction_from: transactionFrom,
+          provider,
+        },
+      })
+    )
+  );
+
+  return results
+    .flat()
+    .sort(
+      (a, b) => b.block_timestamp.getTime() - a.block_timestamp.getTime()
+    )[0];
+}
+
 async function syncFacilitator(
   syncConfig: SyncConfig,
   facilitator: Facilitator,
@@ -24,26 +59,27 @@ async function syncFacilitator(
       `[${syncConfig.chain}] Getting most recent transfer for ${facilitator.id}:${facilitatorConfig.address}`
     );
 
-    const mostRecentTransfer = await getTransferEvents({
-      orderBy: { block_timestamp: 'desc' },
-      take: 1,
-      where: {
-        chain: syncConfig.chain,
-        transaction_from:
-          syncConfig.chain === Network.SOLANA.toString()
-            ? facilitatorConfig.address
-            : facilitatorConfig.address.toLowerCase(),
-        provider: syncConfig.provider,
-      },
-    });
+    const resumeFromProviders = syncConfig.resumeFromProviders ?? [
+      syncConfig.provider,
+    ];
+    const transactionFrom = normalizeTransactionFrom(
+      syncConfig.chain,
+      facilitatorConfig.address
+    );
+
+    const mostRecentTransfer = await getMostRecentTransferForResume(
+      syncConfig,
+      transactionFrom,
+      resumeFromProviders
+    );
 
     logger.log(
-      `[${syncConfig.chain}] Most recent transfer: ${mostRecentTransfer[0]?.block_timestamp?.toISOString()}`
+      `[${syncConfig.chain}] Most recent transfer from ${resumeFromProviders.join(',')}: ${mostRecentTransfer?.block_timestamp?.toISOString()}`
     );
 
     // Start from 1 second after the most recent transfer to avoid re-fetching it
-    const since = mostRecentTransfer[0]?.block_timestamp
-      ? new Date(mostRecentTransfer[0].block_timestamp.getTime() + 1000)
+    const since = mostRecentTransfer?.block_timestamp
+      ? new Date(mostRecentTransfer.block_timestamp.getTime() + 1000)
       : facilitatorConfig.syncStartDate;
 
     logger.log(

--- a/sync/transfers/trigger/types.ts
+++ b/sync/transfers/trigger/types.ts
@@ -80,6 +80,7 @@ export type SyncConfig = QueryConfig & {
   enabled: boolean;
   machine: 'small-1x' | 'medium-1x' | 'large-2x';
   splitSyncByFacilitator?: boolean;
+  resumeFromProviders?: QueryProvider[];
 };
 
 export interface EvmChainConfig {
@@ -125,6 +126,36 @@ export interface BitQueryTransferRow {
   amount: string;
   currency: { address: string };
   transaction: { feePayer: string; signature: string };
+}
+
+export interface EvmBitQueryEventRow {
+  Block: {
+    Time: string;
+    Number: string;
+  };
+  Transaction: {
+    Hash: string;
+    From: string;
+    Index: number;
+  };
+  LogHeader: {
+    Address: string;
+    Index: number;
+    Removed: boolean;
+  };
+  Log: {
+    EnterIndex: number;
+    Index: number;
+    LogAfterCallIndex: number;
+    SmartContract: string;
+  };
+  Arguments: {
+    Name: string;
+    Value: {
+      address?: string;
+      bigInteger?: string;
+    };
+  }[];
 }
 
 export interface BitQueryTransferRowStream {

--- a/sync/transfers/vitest.config.ts
+++ b/sync/transfers/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, '.'),
+      facilitators: resolve(
+        __dirname,
+        '../../packages/external/facilitators/src'
+      ),
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Re-attempts the Base CDP → BitQuery migration, fixing three issues from previous attempts (#954, #961, #962, all reverted):

- **No `resumeOverlapMs`** — cursor advances forward (`T + 1s`), not backward into CDP territory. Prevents the infinite duplicate loop from #954.
- **Events endpoint** — queries ERC20 Transfer event logs by signature hash, avoiding the `Transfers` endpoint bug where Coinbase rows have the facilitator address in `Currency.SmartContract` (caused zero results in #961).
- **Log index mismatch is safe** — BitQuery `Log.EnterIndex` ≠ CDP receipt `logIndex`, but with zero time overlap between providers, no collision or double-counting is possible.
- **Warn-and-skip on missing args** — if an event is missing `from`/`to`/`value`, it's logged and skipped instead of crashing the sync job.

## Root cause (why previous attempts failed)

### #954: Stuck cursor (all duplicates)
`resumeOverlapMs: 60000` made the cursor go **backwards** 60s from the latest transfer. CDP already had all data in that window. The unique constraint `(tx_hash, log_index, chain, block_timestamp)` doesn't include `provider`, so BitQuery inserts collided with CDP rows. `skipDuplicates` silently dropped them → 0 saved → cursor never advanced → infinite loop.

**Fix:** Remove `resumeOverlapMs`. Default behavior is `T + 1s` forward. `resumeFromProviders: [CDP, BITQUERY]` finds the latest transfer from either provider so BitQuery picks up where CDP left off.

### #961: Transfers endpoint returns zero rows
BitQuery's `Transfers` endpoint returns the **facilitator address** in `Transfer.Currency.SmartContract` for current Coinbase transactions, not the USDC address. The filter `Currency.SmartContract = USDC` matched nothing.

**Fix:** Use the `Events` endpoint instead. Filter by ERC20 Transfer signature hash (`0xddf252ad...`) on `LogHeader.Address = USDC`. Shafu validated this in #962: 701/701 rows matched CDP in a 10-minute window.

### #962: Log index mismatch
BitQuery's `Log.EnterIndex` ≠ CDP's canonical receipt `logIndex` (e.g., CDP=31, BitQuery=206). With time overlap, this creates **double rows** (different `log_index` = different unique constraint key = two entries for the same transfer).

**Fix:** The no-overlap handoff (`T + 1s`) makes this a non-issue. Each provider's data occupies a distinct time range — no collision possible. `Log.EnterIndex` is self-consistent within BitQuery for dedup.

## Key design decisions

| Decision | Rationale |
|----------|-----------|
| `resumeFromProviders: [CDP, BITQUERY]` | BitQuery picks up from CDP's last transfer timestamp |
| No `resumeOverlapMs` | Overlap caused stuck cursor — all fetched data were duplicates |
| Events endpoint, not Transfers | Transfers endpoint returns wrong `Currency.SmartContract` for Coinbase facilitator |
| `Log.EnterIndex` as `log_index` | BitQuery's stable event index; doesn't match CDP but no overlap means no collision |
| `flatMap` + warn instead of `throw` | Missing args skip the event with a Trigger.dev warning, not crash the job |

## Tests (16 passing)

**Resume logic** (`sync.test.ts`):
- Cross-provider resume returns latest transfer from any provider
- Queries each provider separately (parallel)
- Falls back to `syncStartDate` when no transfers exist
- Cursor advances forward (`T + 1s`), not backward (`T - 60s`)

**Query + transform** (`query.test.ts`):
- Uses Events endpoint (not Transfers)
- Filters by Transfer signature hash
- Uses `Log.EnterIndex` as `log_index`
- Skips events with missing args (doesn't throw)
- Lowercases all addresses

## Post-merge checklist

After Trigger.dev deploys:
- [ ] Monitor first BitQuery run in Trigger.dev logs — confirm transfers are being saved (not all duplicates)
- [ ] Check `TransferEvent` table for new `provider: 'bitquery'` rows with recent timestamps
- [ ] Verify no double-counting: no two rows with same `tx_hash` but different `log_index`/`provider` for the same `block_timestamp`