### PR TITLE
fix: use after() for origin metadata upserts + add missing object-fit to favicons

### DIFF
--- a/apps/scan/src/app/(app)/@breadcrumbs/_components/breadcrumb.tsx
+++ b/apps/scan/src/app/(app)/@breadcrumbs/_components/breadcrumb.tsx
@@ -47,7 +47,7 @@ export const Breadcrumb = <T extends string>({
             )}
           >
             {image ? (
-              <AvatarImage src={image} className="size-full object-cover" />
+              <AvatarImage src={image} className="size-full" />
             ) : (
               <AvatarImage />
             )}

--- a/apps/scan/src/app/(app)/@breadcrumbs/_components/breadcrumb.tsx
+++ b/apps/scan/src/app/(app)/@breadcrumbs/_components/breadcrumb.tsx
@@ -47,7 +47,7 @@ export const Breadcrumb = <T extends string>({
             )}
           >
             {image ? (
-              <AvatarImage src={image} className="size-full" />
+              <AvatarImage src={image} className="size-full object-cover" />
             ) : (
               <AvatarImage />
             )}

--- a/apps/scan/src/app/(app)/_components/origins.tsx
+++ b/apps/scan/src/app/(app)/_components/origins.tsx
@@ -122,14 +122,9 @@ export const Origin: React.FC<OriginProps> = ({
 }) => {
   return (
     <OriginsContainer
-      Icon={({ className }) =>
-        origin.favicon ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img src={origin.favicon} alt="Favicon" className={className} />
-        ) : (
-          <Globe className={className} />
-        )
-      }
+      Icon={({ className }) => (
+        <Favicon url={origin.favicon} className={className} />
+      )}
       title={new URL(origin.origin).hostname}
       address={
         <Addresses

--- a/apps/scan/src/lib/discovery/register-origin.ts
+++ b/apps/scan/src/lib/discovery/register-origin.ts
@@ -3,10 +3,15 @@ import { getCachedProbeResult } from './probe-cache';
 import { getRegistrationErrorMessage } from './utils';
 import { registerResource, registerSiwxResource } from '@/lib/resources';
 import { deprecateStaleResources } from '@/services/db/resources/resource';
-import { getOriginResourceCount } from '@/services/db/resources/origin';
+import {
+  getOriginResourceCount,
+  upsertOrigin,
+} from '@/services/db/resources/origin';
 import { notifyNewServer } from '@/lib/discord-notifications';
 import { getOriginFromUrl, normalizeResourceUrl } from '@/lib/url';
 import { scanDb } from '@x402scan/scan-db';
+import { scrapeOriginData } from '@/services/scraper';
+import { after } from 'next/server';
 
 import type {
   AuditWarning,
@@ -139,6 +144,7 @@ export async function registerResourcesFromDiscovery(
       originMetadataFallback: originInfo,
       pricingMode,
       price,
+      skipMetadataScrape: true,
     });
     return siwxResult.success
       ? {
@@ -233,6 +239,7 @@ export async function registerResourcesFromDiscovery(
       pricingMode: resource.pricingMode,
       price: resource.price,
       method: resource.method,
+      skipMetadataScrape: true,
     });
 
     if (result.success) return result;
@@ -375,6 +382,60 @@ export async function registerResourcesFromDiscovery(
       });
       notifiedOrigins.add(origin);
     }
+  }
+
+  // Scrape and upsert origin metadata once per unique origin (deduped).
+  // Individual registerResource/registerSiwxResource calls skip this
+  // (skipMetadataScrape: true) so the scrape+upsert happens exactly once
+  // per origin, not once per resource.
+  const metadataTask = async () => {
+    await Promise.all(
+      uniqueOrigins.map(async origin => {
+        try {
+          const { og, metadata, favicon } = await scrapeOriginData(origin);
+          const title =
+            metadata?.title ?? og?.ogTitle ?? originInfo?.title ?? null;
+          const description =
+            metadata?.description ??
+            og?.ogDescription ??
+            originInfo?.description ??
+            null;
+
+          await upsertOrigin({
+            origin,
+            title: title ?? undefined,
+            description: description ?? undefined,
+            favicon: favicon ?? undefined,
+            ogImages:
+              og?.ogImage?.flatMap(image => {
+                try {
+                  return [
+                    {
+                      url: new URL(image.url, origin).toString(),
+                      height: image.height,
+                      width: image.width,
+                      title: og.ogTitle,
+                      description: og.ogDescription,
+                    },
+                  ];
+                } catch {
+                  return [];
+                }
+              }) ?? [],
+          });
+        } catch (err) {
+          console.error(
+            `[registerResourcesFromDiscovery] Metadata upsert failed for ${origin}:`,
+            err
+          );
+        }
+      })
+    );
+  };
+  try {
+    after(metadataTask);
+  } catch {
+    void metadataTask();
   }
 
   return {

--- a/apps/scan/src/lib/resources.ts
+++ b/apps/scan/src/lib/resources.ts
@@ -32,6 +32,7 @@ import type { AcceptsNetwork } from '@x402scan/scan-db';
 import { convertOpenApiSchemaToV1 } from '@/lib/openapi-to-v1';
 import { deduplicateWarnings } from '@/lib/discovery/utils';
 import { notifyNewServer } from '@/lib/discord-notifications';
+import { after } from 'next/server';
 
 /**
  * Pure validation — no DB writes, no side effects. Used by both
@@ -238,7 +239,8 @@ export async function registerSiwxResource(
 
     // Scrape and upsert origin metadata (non-blocking — resource is already
     // persisted, so a scrape failure shouldn't fail the registration).
-    void (async () => {
+    // Uses after() so the upsert survives Vercel's function lifecycle.
+    after(async () => {
       try {
         const { og, metadata, favicon } = await scrapeOriginData(origin);
         const title =
@@ -280,7 +282,7 @@ export async function registerSiwxResource(
           err
         );
       }
-    })();
+    });
 
     return {
       success: true as const,
@@ -526,36 +528,41 @@ export const registerResource = async (
   // scraped metadata (title, favicon, OG images). When multiple resources
   // from the same origin register concurrently, this can race (P2002) —
   // safe to swallow since another concurrent call will succeed.
-  void upsertOrigin({
-    origin,
-    title: title ?? undefined,
-    description: description ?? undefined,
-    favicon: favicon ?? undefined,
-    ogImages:
-      og?.ogImage?.flatMap(image => {
-        try {
-          return [
-            {
-              url: new URL(image.url, origin).toString(),
-              height: image.height,
-              width: image.width,
-              title: og.ogTitle,
-              description: og.ogDescription,
-            },
-          ];
-        } catch {
-          return [];
-        }
-      }) ?? [],
-  }).catch(err => {
-    // P2002: another concurrent call already upserted this origin — safe to ignore.
-    // Log anything else so metadata failures aren't silent.
-    const isP2002 =
-      err instanceof Error &&
-      'code' in err &&
-      (err as { code: string }).code === 'P2002';
-    if (!isP2002) {
-      console.error('[registerResource] Origin metadata upsert failed:', err);
+  // Uses after() so the upsert survives Vercel's function lifecycle.
+  after(async () => {
+    try {
+      await upsertOrigin({
+        origin,
+        title: title ?? undefined,
+        description: description ?? undefined,
+        favicon: favicon ?? undefined,
+        ogImages:
+          og?.ogImage?.flatMap(image => {
+            try {
+              return [
+                {
+                  url: new URL(image.url, origin).toString(),
+                  height: image.height,
+                  width: image.width,
+                  title: og.ogTitle,
+                  description: og.ogDescription,
+                },
+              ];
+            } catch {
+              return [];
+            }
+          }) ?? [],
+      });
+    } catch (err) {
+      // P2002: another concurrent call already upserted this origin — safe to ignore.
+      // Log anything else so metadata failures aren't silent.
+      const isP2002 =
+        err instanceof Error &&
+        'code' in err &&
+        (err as { code: string }).code === 'P2002';
+      if (!isP2002) {
+        console.error('[registerResource] Origin metadata upsert failed:', err);
+      }
     }
   });
 
@@ -574,7 +581,7 @@ export const registerResource = async (
   }
 
   // Attempt ownership verification (non-blocking)
-  void (async () => {
+  after(async () => {
     try {
       const discoveryResult = await fetchDiscoveryDocument(origin);
       if (
@@ -595,7 +602,7 @@ export const registerResource = async (
         error
       );
     }
-  })();
+  });
 
   return {
     success: true as const,

--- a/apps/scan/src/lib/resources.ts
+++ b/apps/scan/src/lib/resources.ts
@@ -240,7 +240,7 @@ export async function registerSiwxResource(
     // Scrape and upsert origin metadata (non-blocking — resource is already
     // persisted, so a scrape failure shouldn't fail the registration).
     // Uses after() so the upsert survives Vercel's function lifecycle.
-    after(async () => {
+    const siwxMetadataTask = async () => {
       try {
         const { og, metadata, favicon } = await scrapeOriginData(origin);
         const title =
@@ -282,7 +282,12 @@ export async function registerSiwxResource(
           err
         );
       }
-    });
+    };
+    try {
+      after(siwxMetadataTask);
+    } catch {
+      void siwxMetadataTask();
+    }
 
     return {
       success: true as const,
@@ -529,7 +534,7 @@ export const registerResource = async (
   // from the same origin register concurrently, this can race (P2002) —
   // safe to swallow since another concurrent call will succeed.
   // Uses after() so the upsert survives Vercel's function lifecycle.
-  after(async () => {
+  const originMetadataTask = async () => {
     try {
       await upsertOrigin({
         origin,
@@ -564,7 +569,12 @@ export const registerResource = async (
         console.error('[registerResource] Origin metadata upsert failed:', err);
       }
     }
-  });
+  };
+  try {
+    after(originMetadataTask);
+  } catch {
+    void originMetadataTask();
+  }
 
   await upsertResourceResponse(
     resource.resource.id,
@@ -581,7 +591,7 @@ export const registerResource = async (
   }
 
   // Attempt ownership verification (non-blocking)
-  after(async () => {
+  const ownershipTask = async () => {
     try {
       const discoveryResult = await fetchDiscoveryDocument(origin);
       if (
@@ -602,7 +612,12 @@ export const registerResource = async (
         error
       );
     }
-  });
+  };
+  try {
+    after(ownershipTask);
+  } catch {
+    void ownershipTask();
+  }
 
   return {
     success: true as const,

--- a/apps/scan/src/lib/resources.ts
+++ b/apps/scan/src/lib/resources.ts
@@ -164,6 +164,8 @@ export async function registerSiwxResource(
     originMetadataFallback?: { title?: string; description?: string };
     pricingMode?: string;
     price?: string;
+    /** Skip metadata scrape+upsert — caller handles it (e.g. batch registration). */
+    skipMetadataScrape?: boolean;
   } = {}
 ) {
   const urlObj = new URL(url);
@@ -239,54 +241,56 @@ export async function registerSiwxResource(
 
     // Scrape and upsert origin metadata (non-blocking — resource is already
     // persisted, so a scrape failure shouldn't fail the registration).
-    // Uses after() so the upsert survives Vercel's function lifecycle.
-    const siwxMetadataTask = async () => {
-      try {
-        const { og, metadata, favicon } = await scrapeOriginData(origin);
-        const title =
-          metadata?.title ??
-          og?.ogTitle ??
-          options.originMetadataFallback?.title ??
-          null;
-        const description =
-          metadata?.description ??
-          og?.ogDescription ??
-          options.originMetadataFallback?.description ??
-          null;
+    // Skipped in batch registration where the caller deduplicates per origin.
+    if (!options.skipMetadataScrape) {
+      const siwxMetadataTask = async () => {
+        try {
+          const { og, metadata, favicon } = await scrapeOriginData(origin);
+          const title =
+            metadata?.title ??
+            og?.ogTitle ??
+            options.originMetadataFallback?.title ??
+            null;
+          const description =
+            metadata?.description ??
+            og?.ogDescription ??
+            options.originMetadataFallback?.description ??
+            null;
 
-        await upsertOrigin({
-          origin,
-          title: title ?? undefined,
-          description: description ?? undefined,
-          favicon: favicon ?? undefined,
-          ogImages:
-            og?.ogImage?.flatMap(image => {
-              try {
-                return [
-                  {
-                    url: new URL(image.url, origin).toString(),
-                    height: image.height,
-                    width: image.width,
-                    title: og.ogTitle,
-                    description: og.ogDescription,
-                  },
-                ];
-              } catch {
-                return [];
-              }
-            }) ?? [],
-        });
-      } catch (err) {
-        console.error(
-          '[registerSiwxResource] Metadata scrape failed (non-blocking):',
-          err
-        );
+          await upsertOrigin({
+            origin,
+            title: title ?? undefined,
+            description: description ?? undefined,
+            favicon: favicon ?? undefined,
+            ogImages:
+              og?.ogImage?.flatMap(image => {
+                try {
+                  return [
+                    {
+                      url: new URL(image.url, origin).toString(),
+                      height: image.height,
+                      width: image.width,
+                      title: og.ogTitle,
+                      description: og.ogDescription,
+                    },
+                  ];
+                } catch {
+                  return [];
+                }
+              }) ?? [],
+          });
+        } catch (err) {
+          console.error(
+            '[registerSiwxResource] Metadata scrape failed (non-blocking):',
+            err
+          );
+        }
+      };
+      try {
+        after(siwxMetadataTask);
+      } catch {
+        void siwxMetadataTask();
       }
-    };
-    try {
-      after(siwxMetadataTask);
-    } catch {
-      void siwxMetadataTask();
     }
 
     return {
@@ -350,6 +354,8 @@ export const registerResource = async (
     /** HTTP method from discovery — preferred over advisory.method which
      *  is always POST (x402 payment protocol). */
     method?: string;
+    /** Skip metadata scrape+upsert — caller handles it (e.g. batch registration). */
+    skipMetadataScrape?: boolean;
   } = {}
 ) => {
   const validation = validateResource(url, advisory);
@@ -515,65 +521,72 @@ export const registerResource = async (
     };
   }
 
-  const { og, metadata, favicon } = await scrapeOriginData(origin);
+  // Scrape origin metadata (title, favicon, OG images) and upsert.
+  // Skipped in batch registration where the caller deduplicates per origin.
+  let title: string | null = options.originMetadataFallback?.title ?? null;
+  let description: string | null =
+    options.originMetadataFallback?.description ?? null;
+  let favicon: string | null = null;
+  let og: Awaited<ReturnType<typeof scrapeOriginData>>['og'] = null;
 
-  const title =
-    metadata?.title ??
-    og?.ogTitle ??
-    options.originMetadataFallback?.title ??
-    null;
-  const description =
-    metadata?.description ??
-    og?.ogDescription ??
-    options.originMetadataFallback?.description ??
-    null;
+  if (!options.skipMetadataScrape) {
+    const scraped = await scrapeOriginData(origin);
+    og = scraped.og;
+    favicon = scraped.favicon;
 
-  // Origin metadata upsert — non-blocking. The origin row itself is already
-  // created inside upsertResource's transaction. This just enriches it with
-  // scraped metadata (title, favicon, OG images). When multiple resources
-  // from the same origin register concurrently, this can race (P2002) —
-  // safe to swallow since another concurrent call will succeed.
-  // Uses after() so the upsert survives Vercel's function lifecycle.
-  const originMetadataTask = async () => {
-    try {
-      await upsertOrigin({
-        origin,
-        title: title ?? undefined,
-        description: description ?? undefined,
-        favicon: favicon ?? undefined,
-        ogImages:
-          og?.ogImage?.flatMap(image => {
-            try {
-              return [
-                {
-                  url: new URL(image.url, origin).toString(),
-                  height: image.height,
-                  width: image.width,
-                  title: og.ogTitle,
-                  description: og.ogDescription,
-                },
-              ];
-            } catch {
-              return [];
-            }
-          }) ?? [],
-      });
-    } catch (err) {
-      // P2002: another concurrent call already upserted this origin — safe to ignore.
-      // Log anything else so metadata failures aren't silent.
-      const isP2002 =
-        err instanceof Error &&
-        'code' in err &&
-        (err as { code: string }).code === 'P2002';
-      if (!isP2002) {
-        console.error('[registerResource] Origin metadata upsert failed:', err);
+    title = scraped.metadata?.title ?? og?.ogTitle ?? title;
+    description =
+      scraped.metadata?.description ?? og?.ogDescription ?? description;
+
+    // Origin metadata upsert — non-blocking. The origin row itself is already
+    // created inside upsertResource's transaction. This just enriches it with
+    // scraped metadata (title, favicon, OG images). When multiple resources
+    // from the same origin register concurrently, this can race (P2002) —
+    // safe to swallow since another concurrent call will succeed.
+    const originMetadataTask = async () => {
+      try {
+        await upsertOrigin({
+          origin,
+          title: title ?? undefined,
+          description: description ?? undefined,
+          favicon: favicon ?? undefined,
+          ogImages:
+            og?.ogImage?.flatMap(image => {
+              try {
+                return [
+                  {
+                    url: new URL(image.url, origin).toString(),
+                    height: image.height,
+                    width: image.width,
+                    title: og?.ogTitle,
+                    description: og?.ogDescription,
+                  },
+                ];
+              } catch {
+                return [];
+              }
+            }) ?? [],
+        });
+      } catch (err) {
+        // P2002: another concurrent call already upserted this origin — safe to ignore.
+        // Log anything else so metadata failures aren't silent.
+        const isP2002 =
+          err instanceof Error &&
+          'code' in err &&
+          (err as { code: string }).code === 'P2002';
+        if (!isP2002) {
+          console.error(
+            '[registerResource] Origin metadata upsert failed:',
+            err
+          );
+        }
       }
+    };
+    try {
+      after(originMetadataTask);
+    } catch {
+      void originMetadataTask();
     }
-  };
-  try {
-    after(originMetadataTask);
-  } catch {
-    void originMetadataTask();
   }
 
   await upsertResourceResponse(


### PR DESCRIPTION
## Summary

**Root cause**: `void upsertOrigin(...)` fire-and-forget calls were getting killed by Vercel after the HTTP response was sent. The scraper correctly found SVG favicon URLs, but the DB upsert never completed — origins kept stale ICO URLs from initial registration (which contained horizontally stretched cube icons).

**Fix** (3 changes):

1. **`void` → `after()` with try/catch fallback** — ensures metadata upserts survive Vercel's function lifecycle, matching the existing pattern in `discord-notifications.ts`

2. **Deduplicate metadata scrape per origin** — batch registration (`registerResourcesFromDiscovery`) was triggering N independent scrapes + N upserts for the same origin (one per resource). Now passes `skipMetadataScrape: true` to individual calls and does a single scrape+upsert per unique origin after all resources are registered. Reduces external HTTP calls and DB writes from O(resources) to O(origins).

3. **Replace raw `<img>` with `Favicon` component** — `origins.tsx` used a raw `<img>` without `object-fit` while sibling components in the same file used the `Favicon` component. Consolidated for consistency.
