### PR TITLE
feat: warn merchants to add contact email in openapi.json

### DIFF
--- a/apps/scan/src/app/(app)/(home)/(discover)/_components/discover-search.tsx
+++ b/apps/scan/src/app/(app)/(home)/(discover)/_components/discover-search.tsx
@@ -213,6 +213,7 @@ export const DiscoverSearchResults = () => {
           title: r.title,
           description: r.description,
           favicon: r.favicon,
+          email: null,
           createdAt: new Date(),
           updatedAt: new Date(),
         },

--- a/apps/scan/src/app/(app)/(home)/discovery/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/discovery/page.tsx
@@ -78,6 +78,58 @@ export default function DiscoveryPage() {
         </section>
 
         <section className="space-y-4">
+          <h2 className="text-xl font-semibold">Your merchant dashboard</h2>
+          <div className="space-y-2 text-sm text-muted-foreground">
+            <p>
+              Add{' '}
+              <code className="font-mono bg-muted px-1 rounded text-xs">
+                info.contact.email
+              </code>{' '}
+              to your{' '}
+              <code className="font-mono bg-muted px-1 rounded text-xs">
+                openapi.json
+              </code>{' '}
+              to unlock your free merchant dashboard on{' '}
+              <a
+                href="https://tryponcho.com"
+                className="underline hover:no-underline font-medium text-foreground"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Poncho
+              </a>
+              . Log in with the same email to access:
+            </p>
+            <ul className="list-disc pl-5 space-y-1">
+              <li>
+                <strong>Usage analytics</strong> — see how agents are using your
+                endpoints
+              </li>
+              <li>
+                <strong>Endpoint health monitoring</strong> — track uptime and
+                response quality
+              </li>
+              <li>
+                <strong>Shareable onboarding link</strong> — a one-click URL you
+                can send to anyone to try your API instantly through Poncho
+              </li>
+            </ul>
+            <p>
+              This is a standard{' '}
+              <a
+                href="https://spec.openapis.org/oas/v3.1.0#contact-object"
+                className="underline hover:no-underline font-medium text-foreground"
+                target="_blank"
+                rel="noreferrer"
+              >
+                OpenAPI field
+              </a>{' '}
+              — no custom extensions needed.
+            </p>
+          </div>
+        </section>
+
+        <section className="space-y-4">
           <h2 className="text-xl font-semibold">Get started</h2>
           <div className="grid gap-4 md:grid-cols-3">
             <NavCard

--- a/apps/scan/src/app/(app)/(home)/discovery/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/discovery/page.tsx
@@ -113,6 +113,11 @@ export default function DiscoveryPage() {
                 <strong>Shareable onboarding link</strong> — a one-click URL you
                 can send to anyone to try your API instantly through Poncho
               </li>
+              <li>
+                <strong>Custom onboarding prompts</strong> — tailor the prompts
+                agents see when they discover your API so they start using your
+                resources immediately
+              </li>
             </ul>
             <p>
               This is a standard{' '}

--- a/apps/scan/src/app/(app)/(home)/discovery/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/discovery/page.tsx
@@ -110,8 +110,8 @@ export default function DiscoveryPage() {
                 response quality
               </li>
               <li>
-                <strong>Customizeable onboarding link</strong> — a one-click URL you
-                can send to anyone to try your API instantly through Poncho
+                <strong>Customizeable onboarding link</strong> — a one-click URL
+                you can send to anyone to try your API instantly through Poncho
               </li>
             </ul>
             <p>

--- a/apps/scan/src/app/(app)/(home)/discovery/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/discovery/page.tsx
@@ -113,11 +113,6 @@ export default function DiscoveryPage() {
                 <strong>Shareable onboarding link</strong> — a one-click URL you
                 can send to anyone to try your API instantly through Poncho
               </li>
-              <li>
-                <strong>Custom onboarding prompts</strong> — tailor the prompts
-                agents see when they discover your API so they start using your
-                resources immediately
-              </li>
             </ul>
             <p>
               This is a standard{' '}

--- a/apps/scan/src/app/(app)/(home)/discovery/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/discovery/page.tsx
@@ -81,15 +81,7 @@ export default function DiscoveryPage() {
           <h2 className="text-xl font-semibold">Your merchant pages</h2>
           <div className="space-y-3 text-sm text-muted-foreground">
             <p>
-              Add{' '}
-              <code className="font-mono bg-muted px-1 rounded text-xs">
-                info.contact.email
-              </code>{' '}
-              to your{' '}
-              <code className="font-mono bg-muted px-1 rounded text-xs">
-                openapi.json
-              </code>{' '}
-              and you get two pages on{' '}
+              Every registered origin gets two pages on{' '}
               <a
                 href="https://tryponcho.com"
                 className="underline hover:no-underline font-medium text-foreground"
@@ -102,35 +94,16 @@ export default function DiscoveryPage() {
             </p>
             <ul className="list-disc pl-5 space-y-2">
               <li>
-                <strong>tryponcho.com/m/your-origin</strong> — your storefront.
-                Share this link so anyone can try your API in one click.
+                <strong>tryponcho.com/m/your-origin</strong> — your API
+                storefront. Share this link so anyone can try your API in one
+                click.
               </li>
               <li>
-                <strong>tryponcho.com/p/your-origin</strong> — your dashboard.
-                See how agents use your API and monitor endpoint health.
+                <strong>tryponcho.com/p/your-origin</strong> — your health
+                metrics. See how agents use your endpoints and monitor
+                performance.
               </li>
             </ul>
-            <p>
-              Log into{' '}
-              <a
-                href="https://tryponcho.com"
-                className="underline hover:no-underline font-medium text-foreground"
-                target="_blank"
-                rel="noreferrer"
-              >
-                tryponcho.com
-              </a>{' '}
-              with the same email to access your dashboard. This is a standard{' '}
-              <a
-                href="https://spec.openapis.org/oas/v3.1.0#contact-object"
-                className="underline hover:no-underline font-medium text-foreground"
-                target="_blank"
-                rel="noreferrer"
-              >
-                OpenAPI field
-              </a>{' '}
-              — no custom extensions needed.
-            </p>
           </div>
         </section>
 

--- a/apps/scan/src/app/(app)/(home)/discovery/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/discovery/page.tsx
@@ -78,8 +78,8 @@ export default function DiscoveryPage() {
         </section>
 
         <section id="merchant-dashboard" className="space-y-4">
-          <h2 className="text-xl font-semibold">Your merchant dashboard</h2>
-          <div className="space-y-2 text-sm text-muted-foreground">
+          <h2 className="text-xl font-semibold">Your merchant pages</h2>
+          <div className="space-y-3 text-sm text-muted-foreground">
             <p>
               Add{' '}
               <code className="font-mono bg-muted px-1 rounded text-xs">
@@ -89,7 +89,7 @@ export default function DiscoveryPage() {
               <code className="font-mono bg-muted px-1 rounded text-xs">
                 openapi.json
               </code>{' '}
-              to unlock your free merchant dashboard on{' '}
+              and you get two pages on{' '}
               <a
                 href="https://tryponcho.com"
                 className="underline hover:no-underline font-medium text-foreground"
@@ -98,24 +98,29 @@ export default function DiscoveryPage() {
               >
                 Poncho
               </a>
-              . Log in with the same email to access:
+              :
             </p>
-            <ul className="list-disc pl-5 space-y-1">
+            <ul className="list-disc pl-5 space-y-2">
               <li>
-                <strong>Usage analytics</strong> — see how agents are using your
-                endpoints
+                <strong>tryponcho.com/m/your-origin</strong> — your storefront.
+                Share this link so anyone can try your API in one click.
               </li>
               <li>
-                <strong>Endpoint health monitoring</strong> — track uptime and
-                response quality
-              </li>
-              <li>
-                <strong>Customizeable onboarding link</strong> — a one-click URL
-                you can send to anyone to try your API instantly through Poncho
+                <strong>tryponcho.com/p/your-origin</strong> — your dashboard.
+                See how agents use your API and monitor endpoint health.
               </li>
             </ul>
             <p>
-              This is a standard{' '}
+              Log into{' '}
+              <a
+                href="https://tryponcho.com"
+                className="underline hover:no-underline font-medium text-foreground"
+                target="_blank"
+                rel="noreferrer"
+              >
+                tryponcho.com
+              </a>{' '}
+              with the same email to access your dashboard. This is a standard{' '}
               <a
                 href="https://spec.openapis.org/oas/v3.1.0#contact-object"
                 className="underline hover:no-underline font-medium text-foreground"

--- a/apps/scan/src/app/(app)/(home)/discovery/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/discovery/page.tsx
@@ -110,7 +110,7 @@ export default function DiscoveryPage() {
                 response quality
               </li>
               <li>
-                <strong>Shareable onboarding link</strong> — a one-click URL you
+                <strong>Customizeable onboarding link</strong> — a one-click URL you
                 can send to anyone to try your API instantly through Poncho
               </li>
             </ul>

--- a/apps/scan/src/app/(app)/(home)/discovery/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/discovery/page.tsx
@@ -77,7 +77,7 @@ export default function DiscoveryPage() {
           </div>
         </section>
 
-        <section className="space-y-4">
+        <section id="merchant-dashboard" className="space-y-4">
           <h2 className="text-xl font-semibold">Your merchant dashboard</h2>
           <div className="space-y-2 text-sm text-muted-foreground">
             <p>

--- a/apps/scan/src/app/(app)/(home)/integration-spec/_content/markdown.ts
+++ b/apps/scan/src/app/(app)/(home)/integration-spec/_content/markdown.ts
@@ -25,6 +25,10 @@ Requirements:
 - Use OpenAPI \`security\` + \`components.securitySchemes\` for auth declaration.
 - Add high-level guidance in \`info.x-guidance\` for agent-friendly discovery.
 
+Recommended:
+
+- \`info.contact.email\` — your contact email. This unlocks your free merchant dashboard on [Poncho](https://tryponcho.com) where you can monitor endpoint health, view usage analytics, and get a shareable onboarding link that lets anyone try your API instantly. Log into tryponcho.com with the same email you include in your openapi.json to access your dashboard.
+
 ### Pricing modes in x-payment-info
 
 - Fixed: \`{ price: { mode: "fixed", currency: "USD", amount: "<amount>" } }\`
@@ -39,7 +43,10 @@ Requirements:
     "title": "My API",
     "version": "1.0.0",
     "description": "example demo server",
-    "x-guidance": "Use POST /api/search for neural web search. Accepts a JSON body with a 'query' field."
+    "x-guidance": "Use POST /api/search for neural web search. Accepts a JSON body with a 'query' field.",
+    "contact": {
+      "email": "you@example.com"
+    }
   },
   "paths": {
     "/api/search": {

--- a/apps/scan/src/app/(app)/(home)/integration-spec/_content/markdown.ts
+++ b/apps/scan/src/app/(app)/(home)/integration-spec/_content/markdown.ts
@@ -27,7 +27,7 @@ Requirements:
 
 Recommended:
 
-- \`info.contact.email\` — your contact email. This unlocks your free merchant dashboard on [Poncho](https://tryponcho.com) where you can monitor endpoint health, view usage analytics, and get a shareable onboarding link that lets anyone try your API instantly. Log into tryponcho.com with the same email you include in your openapi.json to access your dashboard.
+- \`info.contact.email\` — your contact email. This gives you two pages on [Poncho](https://tryponcho.com): \`tryponcho.com/m/your-origin\` (a storefront anyone can use to try your API in one click) and \`tryponcho.com/p/your-origin\` (a dashboard with usage analytics and endpoint health). Log into tryponcho.com with the same email to access your dashboard.
 
 ### Pricing modes in x-payment-info
 

--- a/apps/scan/src/app/(app)/(home)/integration-spec/_content/markdown.ts
+++ b/apps/scan/src/app/(app)/(home)/integration-spec/_content/markdown.ts
@@ -27,7 +27,7 @@ Requirements:
 
 Recommended:
 
-- \`info.contact.email\` — your contact email. This gives you two pages on [Poncho](https://tryponcho.com): \`tryponcho.com/m/your-origin\` (a storefront anyone can use to try your API in one click) and \`tryponcho.com/p/your-origin\` (a dashboard with usage analytics and endpoint health). Log into tryponcho.com with the same email to access your dashboard.
+- \`info.contact.email\` — your contact email. Every registered origin gets two pages on [Poncho](https://tryponcho.com): \`tryponcho.com/m/your-origin\` (your API storefront) and \`tryponcho.com/p/your-origin\` (health metrics for your endpoints).
 
 ### Pricing modes in x-payment-info
 

--- a/apps/scan/src/app/(app)/(home)/integration-spec/_content/markdown.ts
+++ b/apps/scan/src/app/(app)/(home)/integration-spec/_content/markdown.ts
@@ -27,7 +27,7 @@ Requirements:
 
 Recommended:
 
-- \`info.contact.email\` — your contact email. Every registered origin gets two pages on [Poncho](https://tryponcho.com): \`tryponcho.com/m/your-origin\` (your API storefront) and \`tryponcho.com/p/your-origin\` (health metrics for your endpoints).
+- \`info.contact.email\` — your contact email. Lets you verify ownership of your origin, allows users to contact you, and lets you customize your merchant pages on [Poncho](https://tryponcho.com).
 
 ### Pricing modes in x-payment-info
 

--- a/apps/scan/src/app/(app)/(home)/integration-spec/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/integration-spec/page.tsx
@@ -40,8 +40,7 @@ Schema guidance (important):
 
 Contact email (recommended):
 - Ask the user for their contact email and add it as info.contact.email in the openapi.json.
-- This gives the merchant two pages on Poncho: tryponcho.com/m/their-origin (a storefront anyone can use to try the API in one click) and tryponcho.com/p/their-origin (a dashboard with usage analytics and endpoint health).
-- The merchant should log into tryponcho.com with the same email to access their dashboard.
+- Every registered origin gets two pages on Poncho: tryponcho.com/m/their-origin (their API storefront) and tryponcho.com/p/their-origin (health metrics for their endpoints).
 
 OpenAPI payable operation must include ALL:
 - x-payment-info with:
@@ -210,8 +209,8 @@ export default function DiscoverySpecPage() {
               <h3 className="text-sm font-semibold">Recommended</h3>
               <ul className="list-disc pl-5 space-y-1 text-sm">
                 <li>
-                  <code>info.contact.email</code> — your contact email. Gives
-                  you two pages on{' '}
+                  <code>info.contact.email</code> — your contact email. Every
+                  registered origin gets two pages on{' '}
                   <a
                     href="https://tryponcho.com"
                     target="_blank"
@@ -220,11 +219,9 @@ export default function DiscoverySpecPage() {
                   >
                     Poncho
                   </a>
-                  : <code>tryponcho.com/m/your-origin</code> (a storefront for
-                  users to try your API in one click) and{' '}
-                  <code>tryponcho.com/p/your-origin</code> (a dashboard with
-                  usage analytics and endpoint health). Log into tryponcho.com
-                  with the same email to access your dashboard.
+                  : <code>tryponcho.com/m/your-origin</code> (your API
+                  storefront) and <code>tryponcho.com/p/your-origin</code>{' '}
+                  (health metrics for your endpoints).
                 </li>
               </ul>
               <h3 className="text-sm font-semibold">

--- a/apps/scan/src/app/(app)/(home)/integration-spec/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/integration-spec/page.tsx
@@ -39,9 +39,9 @@ Schema guidance (important):
 - Add high-level guidance in info.x-guidance for user-friendly discovery. This document should explain to an agent how to use your API at a high level.
 
 Contact email (recommended):
-- Add info.contact.email with the merchant's contact email in the openapi.json.
+- Ask the user for their contact email and add it as info.contact.email in the openapi.json.
 - This unlocks a free merchant dashboard on tryponcho.com with usage analytics, endpoint health monitoring, and a shareable onboarding link.
-- The merchant should log into tryponcho.com with the same email to access their dashboard.
+- The user should log into tryponcho.com with the same email to access their dashboard.
 
 OpenAPI payable operation must include ALL:
 - x-payment-info with:

--- a/apps/scan/src/app/(app)/(home)/integration-spec/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/integration-spec/page.tsx
@@ -38,6 +38,11 @@ Schema guidance (important):
 - TypeScript recommendation (optional): Zod v4 is a good source of truth, but any valid schema pipeline is fine.
 - Add high-level guidance in info.x-guidance for user-friendly discovery. This document should explain to an agent how to use your API at a high level.
 
+Contact email (recommended):
+- Add info.contact.email with the merchant's contact email in the openapi.json.
+- This unlocks a free merchant dashboard on tryponcho.com with usage analytics, endpoint health monitoring, and a shareable onboarding link.
+- The merchant should log into tryponcho.com with the same email to access their dashboard.
+
 OpenAPI payable operation must include ALL:
 - x-payment-info with:
   - price (structured object):
@@ -202,6 +207,24 @@ export default function DiscoverySpecPage() {
                   agent-friendly discovery.
                 </li>
               </ul>
+              <h3 className="text-sm font-semibold">Recommended</h3>
+              <ul className="list-disc pl-5 space-y-1 text-sm">
+                <li>
+                  <code>info.contact.email</code> — your contact email. Unlocks
+                  your free merchant dashboard on{' '}
+                  <a
+                    href="https://tryponcho.com"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="underline hover:no-underline font-medium text-foreground"
+                  >
+                    Poncho
+                  </a>{' '}
+                  with usage analytics, endpoint health monitoring, and a
+                  shareable onboarding link. Log into tryponcho.com with the
+                  same email to access your dashboard.
+                </li>
+              </ul>
               <h3 className="text-sm font-semibold">
                 Pricing modes in <code>x-payment-info</code>
               </h3>
@@ -231,7 +254,8 @@ export default function DiscoverySpecPage() {
     "title": "My API",
     "version": "1.0.0",
     "description": "example demo server",
-    "x-guidance": "Use POST /api/search for neural web search. Accepts a JSON body with a 'query' field."
+    "x-guidance": "Use POST /api/search for neural web search. Accepts a JSON body with a 'query' field.",
+    "contact": { "email": "you@example.com" }
   },
   "paths": {
     "/api/search": {

--- a/apps/scan/src/app/(app)/(home)/integration-spec/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/integration-spec/page.tsx
@@ -40,8 +40,8 @@ Schema guidance (important):
 
 Contact email (recommended):
 - Ask the user for their contact email and add it as info.contact.email in the openapi.json.
-- This unlocks a free merchant dashboard on tryponcho.com with usage analytics, endpoint health monitoring, and a shareable onboarding link.
-- The user should log into tryponcho.com with the same email to access their dashboard.
+- This gives the merchant two pages on Poncho: tryponcho.com/m/their-origin (a storefront anyone can use to try the API in one click) and tryponcho.com/p/their-origin (a dashboard with usage analytics and endpoint health).
+- The merchant should log into tryponcho.com with the same email to access their dashboard.
 
 OpenAPI payable operation must include ALL:
 - x-payment-info with:
@@ -210,8 +210,8 @@ export default function DiscoverySpecPage() {
               <h3 className="text-sm font-semibold">Recommended</h3>
               <ul className="list-disc pl-5 space-y-1 text-sm">
                 <li>
-                  <code>info.contact.email</code> — your contact email. Unlocks
-                  your free merchant dashboard on{' '}
+                  <code>info.contact.email</code> — your contact email. Gives
+                  you two pages on{' '}
                   <a
                     href="https://tryponcho.com"
                     target="_blank"
@@ -219,10 +219,12 @@ export default function DiscoverySpecPage() {
                     className="underline hover:no-underline font-medium text-foreground"
                   >
                     Poncho
-                  </a>{' '}
-                  with usage analytics, endpoint health monitoring, and a
-                  shareable onboarding link. Log into tryponcho.com with the
-                  same email to access your dashboard.
+                  </a>
+                  : <code>tryponcho.com/m/your-origin</code> (a storefront for
+                  users to try your API in one click) and{' '}
+                  <code>tryponcho.com/p/your-origin</code> (a dashboard with
+                  usage analytics and endpoint health). Log into tryponcho.com
+                  with the same email to access your dashboard.
                 </li>
               </ul>
               <h3 className="text-sm font-semibold">

--- a/apps/scan/src/app/(app)/(home)/integration-spec/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/integration-spec/page.tsx
@@ -40,7 +40,7 @@ Schema guidance (important):
 
 Contact email (recommended):
 - Ask the user for their contact email and add it as info.contact.email in the openapi.json.
-- Every registered origin gets two pages on Poncho: tryponcho.com/m/their-origin (their API storefront) and tryponcho.com/p/their-origin (health metrics for their endpoints).
+- This lets them verify ownership of their origin, allows users to contact them, and lets them customize their merchant pages on Poncho.
 
 OpenAPI payable operation must include ALL:
 - x-payment-info with:
@@ -209,8 +209,9 @@ export default function DiscoverySpecPage() {
               <h3 className="text-sm font-semibold">Recommended</h3>
               <ul className="list-disc pl-5 space-y-1 text-sm">
                 <li>
-                  <code>info.contact.email</code> — your contact email. Every
-                  registered origin gets two pages on{' '}
+                  <code>info.contact.email</code> — your contact email. Lets you
+                  verify ownership of your origin, allows users to contact you,
+                  and lets you customize your merchant pages on{' '}
                   <a
                     href="https://tryponcho.com"
                     target="_blank"
@@ -219,9 +220,7 @@ export default function DiscoverySpecPage() {
                   >
                     Poncho
                   </a>
-                  : <code>tryponcho.com/m/your-origin</code> (your API
-                  storefront) and <code>tryponcho.com/p/your-origin</code>{' '}
-                  (health metrics for your endpoints).
+                  .
                 </li>
               </ul>
               <h3 className="text-sm font-semibold">

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -678,7 +678,7 @@ export const RegisterResourceForm = () => {
         />
       ) : null}
 
-      {activeBulkResult?.originId ? (
+      {activeBulkResult?.originId && activeSummaryOrigin ? (
         <>
           <Link href={`/server/${activeBulkResult.originId}`}>
             <Button variant="outline" className="w-full">
@@ -688,6 +688,7 @@ export const RegisterResourceForm = () => {
           <PostRegistrationDialog
             contactEmail={contactEmail}
             originId={activeBulkResult.originId}
+            origin={activeSummaryOrigin}
           />
         </>
       ) : null}
@@ -704,109 +705,69 @@ export const RegisterResourceForm = () => {
 function PostRegistrationDialog({
   contactEmail,
   originId,
+  origin,
 }: {
   contactEmail: string | undefined;
   originId: string;
+  origin: string;
 }) {
   const [open, setOpen] = useState(true);
+
+  let hostname: string;
+  try {
+    hostname = new URL(origin).hostname;
+  } catch {
+    hostname = origin;
+  }
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogContent className="sm:max-w-md">
-        {contactEmail ? (
-          <>
-            <DialogHeader>
-              <DialogTitle>You&apos;re all set</DialogTitle>
-              <DialogDescription>
-                We detected your contact email in your openapi.json.
-              </DialogDescription>
-            </DialogHeader>
-            <div className="space-y-3 text-sm text-muted-foreground">
-              <p>
-                You&apos;re eligible for a free merchant dashboard on{' '}
-                <Link
-                  href="https://tryponcho.com"
-                  target="_blank"
-                  className="underline font-medium text-foreground"
-                >
-                  Poncho
-                </Link>{' '}
-                with:
-              </p>
-              <ul className="list-disc pl-5 space-y-1">
-                <li>Usage analytics for your endpoints</li>
-                <li>Endpoint health monitoring</li>
-                <li>A shareable link to onboard your users instantly</li>
-              </ul>
-              <p>
-                Log into{' '}
-                <Link
-                  href="https://tryponcho.com"
-                  target="_blank"
-                  className="underline font-medium text-foreground"
-                >
-                  tryponcho.com
-                </Link>{' '}
-                with the same email to access your dashboard.
-              </p>
-            </div>
-            <div className="flex gap-2 pt-2">
-              <Button asChild className="flex-1">
-                <Link href={`/server/${originId}`}>View your API page</Link>
-              </Button>
-              <Button asChild variant="outline" className="flex-1">
-                <Link href="https://tryponcho.com" target="_blank">
-                  Open Poncho
-                </Link>
-              </Button>
-            </div>
-          </>
-        ) : (
-          <>
-            <DialogHeader>
-              <DialogTitle>
-                Want usage analytics and a shareable onboarding link?
-              </DialogTitle>
-              <DialogDescription>
-                Add your contact email to unlock your free merchant dashboard.
-              </DialogDescription>
-            </DialogHeader>
-            <div className="space-y-3 text-sm text-muted-foreground">
-              <p>
-                Add{' '}
-                <code className="font-mono bg-muted px-1 rounded text-xs">
-                  info.contact.email
-                </code>{' '}
-                to your openapi.json to unlock your free merchant dashboard on{' '}
-                <Link
-                  href="https://tryponcho.com"
-                  target="_blank"
-                  className="underline font-medium text-foreground"
-                >
-                  Poncho
-                </Link>
-                :
-              </p>
-              <ul className="list-disc pl-5 space-y-1">
-                <li>See how agents use your API</li>
-                <li>Monitor endpoint health</li>
-                <li>Share a one-click onboarding link for new users</li>
-              </ul>
-              <p>
-                No extra cost. Log into tryponcho.com with the same email to
-                access your dashboard.
-              </p>
-            </div>
-            <div className="flex gap-2 pt-2">
-              <Button asChild className="flex-1">
-                <Link href={`/server/${originId}`}>View your API page</Link>
-              </Button>
-              <Button variant="outline" className="flex-1" asChild>
-                <Link href="/discovery#merchant-dashboard">Learn more</Link>
-              </Button>
-            </div>
-          </>
-        )}
+        <DialogHeader>
+          <DialogTitle>You&apos;re registered!</DialogTitle>
+          <DialogDescription>
+            {contactEmail
+              ? 'Your contact email was detected \u2014 your merchant dashboard is ready.'
+              : 'Here\u2019s what you can do next.'}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-2">
+          <Button asChild className="w-full">
+            <Link href={`/server/${originId}`}>View your API page &rarr;</Link>
+          </Button>
+          {contactEmail && (
+            <Button asChild variant="outline" className="w-full">
+              <Link
+                href={`https://tryponcho.com/p/${hostname}`}
+                target="_blank"
+              >
+                Open your merchant dashboard &rarr;
+              </Link>
+            </Button>
+          )}
+          <Button asChild variant="outline" className="w-full">
+            <Link href={`https://tryponcho.com/m/${hostname}`} target="_blank">
+              Share with your users &rarr;
+            </Link>
+          </Button>
+          {!contactEmail && (
+            <p className="text-xs text-muted-foreground text-center pt-1">
+              Add{' '}
+              <code className="font-mono bg-muted px-1 rounded text-[11px]">
+                info.contact.email
+              </code>{' '}
+              to your openapi.json to unlock your free{' '}
+              <Link
+                href="https://tryponcho.com"
+                target="_blank"
+                className="underline"
+              >
+                merchant dashboard
+              </Link>
+              .
+            </p>
+          )}
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState } from 'react';
 import {
   Check,
   ChevronDown,
+  Copy,
   Loader2,
   Minus,
   CircleHelp,
@@ -740,15 +741,28 @@ function PostRegistrationDialog({
               Test your endpoints &rarr;
             </Link>
           </Button>
-          <p className="text-xs text-muted-foreground text-center pt-1">
-            Start onboarding your users immediately at{' '}
-            <Link
-              href={`https://tryponcho.com/m/${hostname}`}
-              target="_blank"
-              className="underline"
+          <p className="text-xs text-muted-foreground text-center pt-1 flex items-center justify-center gap-1.5">
+            <span>
+              Start onboarding your users immediately at{' '}
+              <Link
+                href={`https://tryponcho.com/m/${hostname}`}
+                target="_blank"
+                className="underline"
+              >
+                tryponcho.com/m/{hostname}
+              </Link>
+            </span>
+            <button
+              type="button"
+              className="inline-flex text-muted-foreground hover:text-foreground transition-colors"
+              onClick={() =>
+                navigator.clipboard.writeText(
+                  `https://tryponcho.com/m/${hostname}`
+                )
+              }
             >
-              tryponcho.com/m/{hostname}
-            </Link>
+              <Copy className="size-3" />
+            </button>
           </p>
         </div>
       </DialogContent>

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -46,7 +46,7 @@ import type { DiscoveredResource } from '@/types/discovery';
 import Link from 'next/link';
 import { z } from 'zod';
 
-const CONTACT_EMAIL_PROMPT = `My openapi.json is missing an info.contact.email field. Add it — it's a recommended standard OpenAPI field.
+const CONTACT_EMAIL_PROMPT = `My openapi.json is missing an info.contact.email field. Add it so I can verify ownership of my origin, let users contact me, and customize my merchant pages on Poncho.
 
 In my openapi.json, add or update the top-level "info" object to include a "contact" field with my email:
 
@@ -952,11 +952,8 @@ function ProbeResult({
               <code className="font-mono bg-muted px-1 rounded text-[11px]">
                 info.contact.email
               </code>{' '}
-              to your openapi.json — recommended for your{' '}
-              <Link href="/discovery#merchant-dashboard" className="underline">
-                merchant pages
-              </Link>{' '}
-              on Poncho.
+              to your openapi.json to verify ownership and let users contact
+              you.
             </span>
           </p>
           <p className="pl-[18px] text-foreground">

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -45,6 +45,7 @@ import { resourceKey } from '@/lib/resource-key';
 import { api } from '@/trpc/client';
 import type { DiscoveredResource } from '@/types/discovery';
 import Link from 'next/link';
+import { toast } from 'sonner';
 import { z } from 'zod';
 
 const CONTACT_EMAIL_PROMPT = `My openapi.json is missing an info.contact.email field. Add it so I can verify ownership of my origin, let users contact me, and customize my merchant pages on Poncho.
@@ -741,25 +742,24 @@ function PostRegistrationDialog({
               Test your endpoints &rarr;
             </Link>
           </Button>
-          <p className="text-xs text-muted-foreground text-center pt-1 flex items-center justify-center gap-1.5">
-            <span>
-              Start onboarding your users immediately at{' '}
-              <Link
-                href={`https://tryponcho.com/m/${hostname}`}
-                target="_blank"
-                className="underline"
-              >
-                tryponcho.com/m/{hostname}
-              </Link>
-            </span>
+          <p className="text-xs text-muted-foreground text-center pt-1">
+            Start onboarding your users immediately at{' '}
+            <Link
+              href={`https://tryponcho.com/m/${hostname}`}
+              target="_blank"
+              className="underline"
+            >
+              tryponcho.com/m/{hostname}
+            </Link>
             <button
               type="button"
-              className="inline-flex text-muted-foreground hover:text-foreground transition-colors"
-              onClick={() =>
-                navigator.clipboard.writeText(
+              className="inline-flex align-middle ml-1 text-muted-foreground hover:text-foreground transition-colors"
+              onClick={() => {
+                void navigator.clipboard.writeText(
                   `https://tryponcho.com/m/${hostname}`
-                )
-              }
+                );
+                toast.success('Onboarding link copied to clipboard');
+              }}
             >
               <Copy className="size-3" />
             </button>

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -682,7 +682,7 @@ export const RegisterResourceForm = () => {
 
       {activeBulkResult?.originId && activeSummaryOrigin ? (
         <>
-          <Link href={`/server/${activeBulkResult.originId}`}>
+          <Link href={`/server/${activeBulkResult.originId}`} target="_blank">
             <Button variant="outline" className="w-full">
               View your API page &rarr;
             </Button>
@@ -730,7 +730,9 @@ function PostRegistrationDialog({
         </DialogHeader>
         <div className="flex flex-col gap-2">
           <Button asChild className="w-full">
-            <Link href={`/server/${originId}`}>View your API page &rarr;</Link>
+            <Link href={`/server/${originId}`} target="_blank">
+              View your API page &rarr;
+            </Link>
           </Button>
           <Button asChild variant="outline" className="w-full">
             <Link href={`https://tryponcho.com/p/${hostname}`} target="_blank">

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -37,6 +37,7 @@ import {
   DiscoveryPanel,
   useDiscovery,
 } from '@/app/(app)/_components/discovery';
+import { DiscoveryActions } from '@/app/(app)/_components/discovery/discovery-actions';
 import { Favicon } from '@/app/(app)/_components/favicon';
 import { normalizeUrl } from '@/lib/url';
 import { resourceKey } from '@/lib/resource-key';
@@ -44,6 +45,22 @@ import { api } from '@/trpc/client';
 import type { DiscoveredResource } from '@/types/discovery';
 import Link from 'next/link';
 import { z } from 'zod';
+
+const CONTACT_EMAIL_PROMPT = `My openapi.json is missing an info.contact.email field. Add it so I can claim my free merchant dashboard on Poncho (tryponcho.com).
+
+In my openapi.json, add or update the top-level "info" object to include a "contact" field with my email:
+
+{
+  "info": {
+    "title": "...",
+    "version": "...",
+    "contact": {
+      "email": "me@example.com"
+    }
+  }
+}
+
+Replace me@example.com with my actual email. This is part of the standard OpenAPI 3.x spec (info.contact.email). Do not remove any existing fields — just add the contact object if missing.`;
 
 interface ManualRegistrationResult {
   success: true;
@@ -451,6 +468,7 @@ export const RegisterResourceForm = () => {
                     isBatchTestLoading={isBatchTestLoading}
                     authModeMap={authModeMap}
                     invalidResourcesMap={invalidResourcesMap}
+                    contactEmail={contactEmail}
                   />
                 )}
 
@@ -546,6 +564,7 @@ export const RegisterResourceForm = () => {
                   error: getPrimaryProbeError(r),
                   status: r.statusCode,
                 }))}
+                missingContactEmail={!contactEmail}
               />
             </CollapsibleContent>
           </Collapsible>
@@ -603,40 +622,12 @@ export const RegisterResourceForm = () => {
                     error: w.message,
                   }))
                 )}
+                missingContactEmail={!contactEmail}
               />
             </CollapsibleContent>
           </Collapsible>
         );
       })()}
-
-      {/* Contact email warning — shown when discovery found but no info.contact.email */}
-      {discoveryFound &&
-        !isDiscoveryLoading &&
-        !contactEmail &&
-        !activeBulkResult && (
-          <p className="text-xs text-yellow-600 dark:text-yellow-500 flex items-start gap-1.5">
-            <TriangleAlert className="size-3 shrink-0 mt-0.5" />
-            <span>
-              Add{' '}
-              <code className="font-mono bg-muted px-1 rounded text-[11px]">
-                info.contact.email
-              </code>{' '}
-              to your openapi.json to unlock your free merchant dashboard on{' '}
-              <Link
-                href="https://tryponcho.com"
-                target="_blank"
-                className="underline"
-              >
-                Poncho
-              </Link>{' '}
-              — usage analytics, endpoint health monitoring, and a shareable
-              onboarding link for your users.{' '}
-              <Link href="/discovery" className="underline">
-                Learn more
-              </Link>
-            </span>
-          </p>
-        )}
 
       {/* Unprotected endpoints — skipped, not an error */}
       {!activeBulkResult && skippedResources.length > 0 && (
@@ -879,6 +870,7 @@ function ProbeResult({
   isBatchTestLoading = false,
   authModeMap = {},
   invalidResourcesMap = {},
+  contactEmail,
 }: {
   preview: {
     favicon: string | null;
@@ -896,6 +888,7 @@ function ProbeResult({
   isBatchTestLoading?: boolean;
   authModeMap?: Record<string, string>;
   invalidResourcesMap?: Record<string, { invalid: boolean; reason?: string }>;
+  contactEmail?: string | null;
 }) {
   const testedKeys = useMemo(
     () => new Set(testedResources.map(rk)),
@@ -1015,6 +1008,42 @@ function ProbeResult({
           Serve a <code className="font-mono">/favicon.ico</code> at your API
           root to display an icon.
         </p>
+      )}
+      {!contactEmail && (
+        <div className="text-xs text-yellow-600 dark:text-yellow-500 space-y-1.5">
+          <p className="flex items-start gap-1.5">
+            <TriangleAlert className="size-3 shrink-0 mt-0.5" />
+            <span>
+              Add{' '}
+              <code className="font-mono bg-muted px-1 rounded text-[11px]">
+                info.contact.email
+              </code>{' '}
+              to your openapi.json to unlock your free merchant dashboard on{' '}
+              <Link
+                href="https://tryponcho.com"
+                target="_blank"
+                className="underline"
+              >
+                Poncho
+              </Link>{' '}
+              — usage analytics, endpoint health monitoring, and a shareable
+              onboarding link for your users.
+            </span>
+          </p>
+          <p className="pl-[18px] text-foreground">
+            <DiscoveryActions
+              label="Have your agent add it with this prompt"
+              customPrompt={CONTACT_EMAIL_PROMPT}
+            />{' '}
+            or{' '}
+            <Link
+              href="/discovery#merchant-dashboard"
+              className="underline underline-offset-2 hover:text-foreground transition-colors"
+            >
+              learn more
+            </Link>
+          </p>
+        </div>
       )}
       {isBatchTestLoading ? (
         <div className="flex items-center gap-2 text-xs text-muted-foreground py-1">

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -149,6 +149,7 @@ export const RegisterResourceForm = () => {
     invalidResourcesMap,
     skippedResources,
     siwxResourceCount,
+    contactEmail,
   } = useDiscovery({
     url,
   });
@@ -600,6 +601,35 @@ export const RegisterResourceForm = () => {
         );
       })()}
 
+      {/* Contact email warning — shown when discovery found but no info.contact.email */}
+      {discoveryFound &&
+        !isDiscoveryLoading &&
+        !contactEmail &&
+        !activeBulkResult && (
+          <p className="text-xs text-yellow-600 dark:text-yellow-500 flex items-start gap-1.5">
+            <TriangleAlert className="size-3 shrink-0 mt-0.5" />
+            <span>
+              Add{' '}
+              <code className="font-mono bg-muted px-1 rounded text-[11px]">
+                info.contact.email
+              </code>{' '}
+              to your openapi.json to unlock your free merchant dashboard on{' '}
+              <Link
+                href="https://tryponcho.com"
+                target="_blank"
+                className="underline"
+              >
+                Poncho
+              </Link>{' '}
+              — usage analytics, endpoint health monitoring, and a shareable
+              onboarding link for your users.{' '}
+              <Link href="/discovery" className="underline">
+                Learn more
+              </Link>
+            </span>
+          </p>
+        )}
+
       {/* Unprotected endpoints — skipped, not an error */}
       {!activeBulkResult && skippedResources.length > 0 && (
         <Collapsible>
@@ -650,11 +680,57 @@ export const RegisterResourceForm = () => {
       ) : null}
 
       {activeBulkResult?.originId ? (
-        <Link href={`/server/${activeBulkResult.originId}`}>
-          <Button variant="outline" className="w-full">
-            View your API page &rarr;
-          </Button>
-        </Link>
+        <div className="space-y-2">
+          <Link href={`/server/${activeBulkResult.originId}`}>
+            <Button variant="outline" className="w-full">
+              View your API page &rarr;
+            </Button>
+          </Link>
+          {contactEmail ? (
+            <div className="rounded-md border border-green-200 dark:border-green-900 bg-green-50 dark:bg-green-950/30 p-3 text-xs space-y-1">
+              <p className="font-medium text-green-800 dark:text-green-300">
+                Contact email detected
+              </p>
+              <p className="text-green-700 dark:text-green-400">
+                You&apos;re eligible for a free merchant dashboard on{' '}
+                <Link
+                  href="https://tryponcho.com"
+                  target="_blank"
+                  className="underline"
+                >
+                  Poncho
+                </Link>{' '}
+                with usage analytics, endpoint health, and a shareable link to
+                onboard your users instantly.
+              </p>
+            </div>
+          ) : (
+            <div className="rounded-md border border-yellow-200 dark:border-yellow-900 bg-yellow-50 dark:bg-yellow-950/30 p-3 text-xs space-y-1.5">
+              <p className="font-medium text-yellow-800 dark:text-yellow-300">
+                Want usage analytics and a shareable onboarding link?
+              </p>
+              <p className="text-yellow-700 dark:text-yellow-400">
+                Add{' '}
+                <code className="font-mono bg-yellow-100 dark:bg-yellow-900/50 px-1 rounded">
+                  info.contact.email
+                </code>{' '}
+                to your openapi.json to unlock your free merchant dashboard on{' '}
+                <Link
+                  href="https://tryponcho.com"
+                  target="_blank"
+                  className="underline"
+                >
+                  Poncho
+                </Link>
+                . No extra cost — see how agents use your API and share a
+                one-click link for new users.{' '}
+                <Link href="/discovery" className="underline">
+                  Learn more
+                </Link>
+              </p>
+            </div>
+          )}
+        </div>
       ) : null}
 
       {bulkError && <p className="text-sm text-red-600">{bulkError}</p>}

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -19,6 +19,13 @@ import {
   CollapsibleTrigger,
 } from '@/components/ui/collapsible';
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -680,57 +687,17 @@ export const RegisterResourceForm = () => {
       ) : null}
 
       {activeBulkResult?.originId ? (
-        <div className="space-y-2">
+        <>
           <Link href={`/server/${activeBulkResult.originId}`}>
             <Button variant="outline" className="w-full">
               View your API page &rarr;
             </Button>
           </Link>
-          {contactEmail ? (
-            <div className="rounded-md border border-green-200 dark:border-green-900 bg-green-50 dark:bg-green-950/30 p-3 text-xs space-y-1">
-              <p className="font-medium text-green-800 dark:text-green-300">
-                Contact email detected
-              </p>
-              <p className="text-green-700 dark:text-green-400">
-                You&apos;re eligible for a free merchant dashboard on{' '}
-                <Link
-                  href="https://tryponcho.com"
-                  target="_blank"
-                  className="underline"
-                >
-                  Poncho
-                </Link>{' '}
-                with usage analytics, endpoint health, and a shareable link to
-                onboard your users instantly.
-              </p>
-            </div>
-          ) : (
-            <div className="rounded-md border border-yellow-200 dark:border-yellow-900 bg-yellow-50 dark:bg-yellow-950/30 p-3 text-xs space-y-1.5">
-              <p className="font-medium text-yellow-800 dark:text-yellow-300">
-                Want usage analytics and a shareable onboarding link?
-              </p>
-              <p className="text-yellow-700 dark:text-yellow-400">
-                Add{' '}
-                <code className="font-mono bg-yellow-100 dark:bg-yellow-900/50 px-1 rounded">
-                  info.contact.email
-                </code>{' '}
-                to your openapi.json to unlock your free merchant dashboard on{' '}
-                <Link
-                  href="https://tryponcho.com"
-                  target="_blank"
-                  className="underline"
-                >
-                  Poncho
-                </Link>
-                . No extra cost — see how agents use your API and share a
-                one-click link for new users.{' '}
-                <Link href="/discovery" className="underline">
-                  Learn more
-                </Link>
-              </p>
-            </div>
-          )}
-        </div>
+          <PostRegistrationDialog
+            contactEmail={contactEmail}
+            originId={activeBulkResult.originId}
+          />
+        </>
       ) : null}
 
       {bulkError && <p className="text-sm text-red-600">{bulkError}</p>}
@@ -741,6 +708,117 @@ export const RegisterResourceForm = () => {
     </div>
   );
 };
+
+function PostRegistrationDialog({
+  contactEmail,
+  originId,
+}: {
+  contactEmail: string | undefined;
+  originId: string;
+}) {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="sm:max-w-md">
+        {contactEmail ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>You&apos;re all set</DialogTitle>
+              <DialogDescription>
+                We detected your contact email in your openapi.json.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-3 text-sm text-muted-foreground">
+              <p>
+                You&apos;re eligible for a free merchant dashboard on{' '}
+                <Link
+                  href="https://tryponcho.com"
+                  target="_blank"
+                  className="underline font-medium text-foreground"
+                >
+                  Poncho
+                </Link>{' '}
+                with:
+              </p>
+              <ul className="list-disc pl-5 space-y-1">
+                <li>Usage analytics for your endpoints</li>
+                <li>Endpoint health monitoring</li>
+                <li>A shareable link to onboard your users instantly</li>
+              </ul>
+              <p>
+                Log into{' '}
+                <Link
+                  href="https://tryponcho.com"
+                  target="_blank"
+                  className="underline font-medium text-foreground"
+                >
+                  tryponcho.com
+                </Link>{' '}
+                with the same email to access your dashboard.
+              </p>
+            </div>
+            <div className="flex gap-2 pt-2">
+              <Button asChild className="flex-1">
+                <Link href={`/server/${originId}`}>View your API page</Link>
+              </Button>
+              <Button asChild variant="outline" className="flex-1">
+                <Link href="https://tryponcho.com" target="_blank">
+                  Open Poncho
+                </Link>
+              </Button>
+            </div>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>
+                Want usage analytics and a shareable onboarding link?
+              </DialogTitle>
+              <DialogDescription>
+                Add your contact email to unlock your free merchant dashboard.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-3 text-sm text-muted-foreground">
+              <p>
+                Add{' '}
+                <code className="font-mono bg-muted px-1 rounded text-xs">
+                  info.contact.email
+                </code>{' '}
+                to your openapi.json to unlock your free merchant dashboard on{' '}
+                <Link
+                  href="https://tryponcho.com"
+                  target="_blank"
+                  className="underline font-medium text-foreground"
+                >
+                  Poncho
+                </Link>
+                :
+              </p>
+              <ul className="list-disc pl-5 space-y-1">
+                <li>See how agents use your API</li>
+                <li>Monitor endpoint health</li>
+                <li>Share a one-click onboarding link for new users</li>
+              </ul>
+              <p>
+                No extra cost. Log into tryponcho.com with the same email to
+                access your dashboard.
+              </p>
+            </div>
+            <div className="flex gap-2 pt-2">
+              <Button asChild className="flex-1">
+                <Link href={`/server/${originId}`}>View your API page</Link>
+              </Button>
+              <Button variant="outline" className="flex-1" asChild>
+                <Link href="/discovery">Learn more</Link>
+              </Button>
+            </div>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
 
 function FailedResourceRow({
   url,

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -744,6 +744,14 @@ function PostRegistrationDialog({
               Test your endpoints &rarr;
             </Link>
           </Button>
+          <Button asChild variant="outline" className="w-full">
+            <Link
+              href="https://calendar.google.com/calendar/appointments/schedules/AcZssZ1JmDUvMb4QVktX4PscRA66DEAQCLHLJKRKvwFogirtp9JZ0s5l-Vj96Nthl3M16qDPOprzsK6U"
+              target="_blank"
+            >
+              Get help selling to agents &rarr;
+            </Link>
+          </Button>
           <p className="text-xs text-muted-foreground text-center pt-1">
             Start onboarding your users immediately at{' '}
             <Link

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -415,8 +415,9 @@ export const RegisterResourceForm = () => {
         )}
       </div>
 
-      {/* Probe result — inline, no separate card */}
-      {url.trim().length > 0 &&
+      {/* Probe result — inline, no separate card. Hidden post-registration. */}
+      {!activeBulkResult &&
+        url.trim().length > 0 &&
         (() => {
           const strippedDomain = url.replace(/^https?:\/\//, '').trim();
           const hasTld = strippedDomain.includes('.');

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -802,7 +802,7 @@ function PostRegistrationDialog({
                 <Link href={`/server/${originId}`}>View your API page</Link>
               </Button>
               <Button variant="outline" className="flex-1" asChild>
-                <Link href="/discovery">Learn more</Link>
+                <Link href="/discovery#merchant-dashboard">Learn more</Link>
               </Button>
             </div>
           </>

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -723,7 +723,10 @@ function PostRegistrationDialog({
   const [emailSubmitted, setEmailSubmitted] = useState(!!contactEmail);
 
   const updateEmailMutation = api.public.origins.updateEmail.useMutation({
-    onSuccess: () => setEmailSubmitted(true),
+    onSuccess: () => {
+      setEmailSubmitted(true);
+      window.open(CALENDAR_URL, '_blank');
+    },
   });
 
   let hostname: string;
@@ -830,9 +833,11 @@ function PostRegistrationDialog({
                 </Button>
               </form>
             ) : (
-              <Link href={CALENDAR_URL} target="_blank" className="flex-1">
-                <Button className="w-full">Schedule a call &rarr;</Button>
-              </Link>
+              contactEmail && (
+                <Link href={CALENDAR_URL} target="_blank" className="flex-1">
+                  <Button className="w-full">Schedule a call &rarr;</Button>
+                </Link>
+              )
             )}
           </ChecklistStep>
 

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -727,6 +727,9 @@ function PostRegistrationDialog({
       setEmailSubmitted(true);
       window.open(CALENDAR_URL, '_blank');
     },
+    onError: () => {
+      toast.error('Failed to save email. Please try again.');
+    },
   });
 
   let hostname: string;

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -26,6 +26,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
 import {
   Tooltip,
   TooltipContent,
@@ -690,6 +691,7 @@ export const RegisterResourceForm = () => {
           <PostRegistrationDialog
             originId={activeBulkResult.originId}
             origin={activeSummaryOrigin}
+            contactEmail={contactEmail}
           />
         </>
       ) : null}
@@ -703,14 +705,26 @@ export const RegisterResourceForm = () => {
   );
 };
 
+const CALENDAR_URL =
+  'https://calendar.google.com/calendar/appointments/schedules/AcZssZ1JmDUvMb4QVktX4PscRA66DEAQCLHLJKRKvwFogirtp9JZ0s5l-Vj96Nthl3M16qDPOprzsK6U';
+
 function PostRegistrationDialog({
   originId,
   origin,
+  contactEmail,
 }: {
   originId: string;
   origin: string;
+  contactEmail?: string;
 }) {
   const [open, setOpen] = useState(true);
+  const [clickedSteps, setClickedSteps] = useState<Set<number>>(new Set());
+  const [email, setEmail] = useState(contactEmail ?? '');
+  const [emailSubmitted, setEmailSubmitted] = useState(!!contactEmail);
+
+  const updateEmailMutation = api.public.origins.updateEmail.useMutation({
+    onSuccess: () => setEmailSubmitted(true),
+  });
 
   let hostname: string;
   try {
@@ -719,59 +733,147 @@ function PostRegistrationDialog({
     hostname = origin;
   }
 
+  const markClicked = (step: number) => {
+    setClickedSteps(prev => new Set(prev).add(step));
+  };
+
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>You&apos;re registered!</DialogTitle>
-          <DialogDescription>
-            Here&apos;s what you can do next.
-          </DialogDescription>
+          <DialogDescription>Complete your setup.</DialogDescription>
         </DialogHeader>
-        <div className="flex flex-col gap-2">
-          <Button asChild className="w-full">
-            <Link href={`/server/${originId}`} target="_blank">
-              View your API page &rarr;
-            </Link>
-          </Button>
-          <Button asChild variant="outline" className="w-full">
-            <Link href={`https://tryponcho.com/m/${hostname}`} target="_blank">
-              Test your endpoints &rarr;
-            </Link>
-          </Button>
-          <Button asChild variant="outline" className="w-full">
+        <div className="flex flex-col gap-4">
+          {/* Step 1 */}
+          <ChecklistStep number={1} completed={clickedSteps.has(1)}>
             <Link
-              href="https://calendar.google.com/calendar/appointments/schedules/AcZssZ1JmDUvMb4QVktX4PscRA66DEAQCLHLJKRKvwFogirtp9JZ0s5l-Vj96Nthl3M16qDPOprzsK6U"
+              href={`/server/${originId}`}
               target="_blank"
+              onClick={() => markClicked(1)}
+              className="flex-1"
             >
-              Get free feedback and support &rarr;
+              <Button variant="outline" size="sm" className="w-full">
+                Review your API page &rarr;
+              </Button>
             </Link>
-          </Button>
-          <p className="text-xs text-muted-foreground text-center pt-1">
-            Start onboarding your users immediately at{' '}
+          </ChecklistStep>
+
+          {/* Step 2 */}
+          <ChecklistStep number={2} completed={clickedSteps.has(2)}>
             <Link
               href={`https://tryponcho.com/m/${hostname}`}
               target="_blank"
-              className="underline"
+              onClick={() => markClicked(2)}
+              className="flex-1"
             >
-              tryponcho.com/m/{hostname}
+              <Button variant="outline" size="sm" className="w-full">
+                Test your endpoints &rarr;
+              </Button>
             </Link>
-            <button
-              type="button"
-              className="inline-flex align-middle ml-1 text-muted-foreground hover:text-foreground transition-colors"
-              onClick={() => {
-                void navigator.clipboard.writeText(
-                  `https://tryponcho.com/m/${hostname}`
-                );
-                toast.success('Onboarding link copied to clipboard');
-              }}
-            >
-              <Copy className="size-3" />
-            </button>
-          </p>
+          </ChecklistStep>
+
+          {/* Step 3 */}
+          <ChecklistStep number={3} completed={emailSubmitted}>
+            {!emailSubmitted ? (
+              <form
+                className="flex gap-2 flex-1"
+                onSubmit={e => {
+                  e.preventDefault();
+                  if (email.trim()) {
+                    updateEmailMutation.mutate({ originId, email });
+                  }
+                }}
+              >
+                <Input
+                  type="email"
+                  placeholder="you@example.com"
+                  value={email}
+                  onChange={e => setEmail(e.target.value)}
+                  className="flex-1 h-8 text-sm"
+                />
+                <Button
+                  type="submit"
+                  size="sm"
+                  disabled={!email.trim() || updateEmailMutation.isPending}
+                >
+                  {updateEmailMutation.isPending ? (
+                    <Loader2 className="size-3 animate-spin" />
+                  ) : (
+                    'Submit'
+                  )}
+                </Button>
+              </form>
+            ) : (
+              <Link href={CALENDAR_URL} target="_blank" className="flex-1">
+                <Button variant="outline" size="sm" className="w-full">
+                  Schedule a call &rarr;
+                </Button>
+              </Link>
+            )}
+          </ChecklistStep>
+
+          <div className="border-t pt-2">
+            <p className="text-xs text-muted-foreground text-center">
+              Share your merchant page:{' '}
+              <Link
+                href={`https://tryponcho.com/m/${hostname}`}
+                target="_blank"
+                className="underline"
+              >
+                tryponcho.com/m/{hostname}
+              </Link>
+              <button
+                type="button"
+                className="inline-flex align-middle ml-1 text-muted-foreground hover:text-foreground transition-colors"
+                onClick={() => {
+                  void navigator.clipboard.writeText(
+                    `https://tryponcho.com/m/${hostname}`
+                  );
+                  toast.success('Link copied to clipboard');
+                }}
+              >
+                <Copy className="size-3" />
+              </button>
+            </p>
+          </div>
         </div>
       </DialogContent>
     </Dialog>
+  );
+}
+
+function ChecklistStep({
+  number,
+  completed,
+  children,
+}: {
+  number: number;
+  completed: boolean;
+  children: React.ReactNode;
+}) {
+  const labels = [
+    'Review your API page',
+    'Test your endpoints',
+    'Get free feedback from our team',
+  ];
+
+  return (
+    <div className="flex items-start gap-3">
+      <div
+        className={`flex-shrink-0 w-6 h-6 rounded-full flex items-center justify-center text-xs font-medium transition-colors ${
+          completed
+            ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+            : 'bg-muted text-muted-foreground'
+        }`}
+      >
+        {completed ? <Check className="size-3.5" /> : number}
+      </div>
+      <div className="flex-1 space-y-1.5">
+        <p className="text-sm font-medium leading-6">{labels[number - 1]}</p>
+        {children}
+      </div>
+    </div>
   );
 }
 

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -46,7 +46,7 @@ import type { DiscoveredResource } from '@/types/discovery';
 import Link from 'next/link';
 import { z } from 'zod';
 
-const CONTACT_EMAIL_PROMPT = `My openapi.json is missing an info.contact.email field. Add it so I can claim my free merchant dashboard on Poncho (tryponcho.com).
+const CONTACT_EMAIL_PROMPT = `My openapi.json is missing an info.contact.email field. Add it — it's a recommended standard OpenAPI field.
 
 In my openapi.json, add or update the top-level "info" object to include a "contact" field with my email:
 
@@ -686,7 +686,6 @@ export const RegisterResourceForm = () => {
             </Button>
           </Link>
           <PostRegistrationDialog
-            contactEmail={contactEmail}
             originId={activeBulkResult.originId}
             origin={activeSummaryOrigin}
           />
@@ -703,11 +702,9 @@ export const RegisterResourceForm = () => {
 };
 
 function PostRegistrationDialog({
-  contactEmail,
   originId,
   origin,
 }: {
-  contactEmail: string | undefined;
   originId: string;
   origin: string;
 }) {
@@ -726,47 +723,23 @@ function PostRegistrationDialog({
         <DialogHeader>
           <DialogTitle>You&apos;re registered!</DialogTitle>
           <DialogDescription>
-            {contactEmail
-              ? 'Your contact email was detected \u2014 your merchant dashboard is ready.'
-              : 'Here\u2019s what you can do next.'}
+            Here&apos;s what you can do next.
           </DialogDescription>
         </DialogHeader>
         <div className="flex flex-col gap-2">
           <Button asChild className="w-full">
             <Link href={`/server/${originId}`}>View your API page &rarr;</Link>
           </Button>
-          {contactEmail && (
-            <Button asChild variant="outline" className="w-full">
-              <Link
-                href={`https://tryponcho.com/p/${hostname}`}
-                target="_blank"
-              >
-                Open your merchant dashboard &rarr;
-              </Link>
-            </Button>
-          )}
           <Button asChild variant="outline" className="w-full">
-            <Link href={`https://tryponcho.com/m/${hostname}`} target="_blank">
-              Share with your users &rarr;
+            <Link href={`https://tryponcho.com/p/${hostname}`} target="_blank">
+              View your health metrics &rarr;
             </Link>
           </Button>
-          {!contactEmail && (
-            <p className="text-xs text-muted-foreground text-center pt-1">
-              Add{' '}
-              <code className="font-mono bg-muted px-1 rounded text-[11px]">
-                info.contact.email
-              </code>{' '}
-              to your openapi.json to unlock your free{' '}
-              <Link
-                href="https://tryponcho.com"
-                target="_blank"
-                className="underline"
-              >
-                merchant dashboard
-              </Link>
-              .
-            </p>
-          )}
+          <Button asChild variant="outline" className="w-full">
+            <Link href={`https://tryponcho.com/m/${hostname}`} target="_blank">
+              Share your storefront &rarr;
+            </Link>
+          </Button>
         </div>
       </DialogContent>
     </Dialog>
@@ -979,15 +952,11 @@ function ProbeResult({
               <code className="font-mono bg-muted px-1 rounded text-[11px]">
                 info.contact.email
               </code>{' '}
-              to your openapi.json to get your merchant pages on{' '}
-              <Link
-                href="https://tryponcho.com"
-                target="_blank"
-                className="underline"
-              >
-                Poncho
+              to your openapi.json — recommended for your{' '}
+              <Link href="/discovery#merchant-dashboard" className="underline">
+                merchant pages
               </Link>{' '}
-              — a storefront for your users and a dashboard for you.
+              on Poncho.
             </span>
           </p>
           <p className="pl-[18px] text-foreground">

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -735,11 +735,6 @@ function PostRegistrationDialog({
             </Link>
           </Button>
           <Button asChild variant="outline" className="w-full">
-            <Link href={`https://tryponcho.com/p/${hostname}`} target="_blank">
-              Track your endpoint health &rarr;
-            </Link>
-          </Button>
-          <Button asChild variant="outline" className="w-full">
             <Link href={`https://tryponcho.com/m/${hostname}`} target="_blank">
               Test your endpoints &rarr;
             </Link>
@@ -749,7 +744,7 @@ function PostRegistrationDialog({
               href="https://calendar.google.com/calendar/appointments/schedules/AcZssZ1JmDUvMb4QVktX4PscRA66DEAQCLHLJKRKvwFogirtp9JZ0s5l-Vj96Nthl3M16qDPOprzsK6U"
               target="_blank"
             >
-              Get help selling to agents &rarr;
+              Get free feedback and support &rarr;
             </Link>
           </Button>
           <p className="text-xs text-muted-foreground text-center pt-1">

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -732,14 +732,24 @@ function PostRegistrationDialog({
           </Button>
           <Button asChild variant="outline" className="w-full">
             <Link href={`https://tryponcho.com/p/${hostname}`} target="_blank">
-              View your health metrics &rarr;
+              Track your endpoint health &rarr;
             </Link>
           </Button>
           <Button asChild variant="outline" className="w-full">
             <Link href={`https://tryponcho.com/m/${hostname}`} target="_blank">
-              Share your storefront &rarr;
+              Test your endpoints &rarr;
             </Link>
           </Button>
+          <p className="text-xs text-muted-foreground text-center pt-1">
+            Start onboarding your users immediately at{' '}
+            <Link
+              href={`https://tryponcho.com/m/${hostname}`}
+              target="_blank"
+              className="underline"
+            >
+              tryponcho.com/m/{hostname}
+            </Link>
+          </p>
         </div>
       </DialogContent>
     </Dialog>

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -979,7 +979,7 @@ function ProbeResult({
               <code className="font-mono bg-muted px-1 rounded text-[11px]">
                 info.contact.email
               </code>{' '}
-              to your openapi.json to unlock your free merchant dashboard on{' '}
+              to your openapi.json to get your merchant pages on{' '}
               <Link
                 href="https://tryponcho.com"
                 target="_blank"
@@ -987,8 +987,7 @@ function ProbeResult({
               >
                 Poncho
               </Link>{' '}
-              — usage analytics, endpoint health monitoring, and a shareable
-              onboarding link for your users.
+              — a storefront for your users and a dashboard for you.
             </span>
           </p>
           <p className="pl-[18px] text-foreground">

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -737,6 +737,14 @@ function PostRegistrationDialog({
     setClickedSteps(prev => new Set(prev).add(step));
   };
 
+  const completedFlags = [
+    clickedSteps.has(1),
+    clickedSteps.has(2),
+    emailSubmitted,
+  ];
+  const currentStep =
+    completedFlags.indexOf(false) + 1 || completedFlags.length + 1;
+
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogContent className="sm:max-w-md">
@@ -746,35 +754,48 @@ function PostRegistrationDialog({
         </DialogHeader>
         <div className="flex flex-col gap-4">
           {/* Step 1 */}
-          <ChecklistStep number={1} completed={clickedSteps.has(1)}>
+          <ChecklistStep
+            number={1}
+            completed={clickedSteps.has(1)}
+            current={currentStep === 1}
+          >
             <Link
               href={`/server/${originId}`}
               target="_blank"
               onClick={() => markClicked(1)}
               className="flex-1"
             >
-              <Button variant="outline" size="sm" className="w-full">
+              <Button variant="outline" className="w-full">
                 Review your API page &rarr;
               </Button>
             </Link>
           </ChecklistStep>
 
           {/* Step 2 */}
-          <ChecklistStep number={2} completed={clickedSteps.has(2)}>
+          <ChecklistStep
+            number={2}
+            completed={clickedSteps.has(2)}
+            current={currentStep === 2}
+          >
             <Link
               href={`https://tryponcho.com/m/${hostname}`}
               target="_blank"
               onClick={() => markClicked(2)}
               className="flex-1"
             >
-              <Button variant="outline" size="sm" className="w-full">
+              <Button variant="outline" className="w-full">
                 Test your endpoints &rarr;
               </Button>
             </Link>
           </ChecklistStep>
 
           {/* Step 3 */}
-          <ChecklistStep number={3} completed={emailSubmitted}>
+          <ChecklistStep
+            number={3}
+            label="Get free feedback from our team"
+            completed={emailSubmitted}
+            current={currentStep === 3}
+          >
             {!emailSubmitted ? (
               <form
                 className="flex gap-2 flex-1"
@@ -786,16 +807,20 @@ function PostRegistrationDialog({
                 }}
               >
                 <Input
-                  type="email"
+                  type="text"
+                  inputMode="email"
+                  autoComplete="email"
                   placeholder="you@example.com"
                   value={email}
                   onChange={e => setEmail(e.target.value)}
-                  className="flex-1 h-8 text-sm"
+                  className="flex-1"
                 />
                 <Button
                   type="submit"
-                  size="sm"
-                  disabled={!email.trim() || updateEmailMutation.isPending}
+                  disabled={
+                    !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) ||
+                    updateEmailMutation.isPending
+                  }
                 >
                   {updateEmailMutation.isPending ? (
                     <Loader2 className="size-3 animate-spin" />
@@ -806,9 +831,7 @@ function PostRegistrationDialog({
               </form>
             ) : (
               <Link href={CALENDAR_URL} target="_blank" className="flex-1">
-                <Button variant="outline" size="sm" className="w-full">
-                  Schedule a call &rarr;
-                </Button>
+                <Button className="w-full">Schedule a call &rarr;</Button>
               </Link>
             )}
           </ChecklistStep>
@@ -845,32 +868,40 @@ function PostRegistrationDialog({
 
 function ChecklistStep({
   number,
+  label,
   completed,
+  current,
   children,
 }: {
   number: number;
+  label?: string;
   completed: boolean;
+  current: boolean;
   children: React.ReactNode;
 }) {
-  const labels = [
-    'Review your API page',
-    'Test your endpoints',
-    'Get free feedback from our team',
-  ];
-
   return (
-    <div className="flex items-start gap-3">
+    <div
+      className={`flex items-start gap-3 rounded-lg px-3 py-2.5 -mx-3 transition-colors ${
+        current
+          ? 'bg-primary/5 dark:bg-primary/10'
+          : completed
+            ? ''
+            : 'opacity-40'
+      }`}
+    >
       <div
         className={`flex-shrink-0 w-6 h-6 rounded-full flex items-center justify-center text-xs font-medium transition-colors ${
           completed
-            ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
-            : 'bg-muted text-muted-foreground'
+            ? 'bg-green-500 text-white dark:bg-green-500'
+            : current
+              ? 'bg-primary text-primary-foreground'
+              : 'bg-muted text-muted-foreground'
         }`}
       >
         {completed ? <Check className="size-3.5" /> : number}
       </div>
       <div className="flex-1 space-y-1.5">
-        <p className="text-sm font-medium leading-6">{labels[number - 1]}</p>
+        {label && <p className="text-sm font-medium leading-6">{label}</p>}
         {children}
       </div>
     </div>

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-actions.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-actions.tsx
@@ -37,7 +37,7 @@ function buildConsolidatedPrompt({
 
 Your openapi.json is missing info.contact.email. Add a "contact" object with your email to the top-level "info" field:
 { "info": { "contact": { "email": "you@example.com" } } }
-This gives you two pages on tryponcho.com: /m/your-origin (a storefront for users to try your API) and /p/your-origin (a dashboard with usage analytics and endpoint health).`);
+Every registered origin gets two pages on tryponcho.com: /m/your-origin (your API storefront) and /p/your-origin (health metrics for your endpoints).`);
   }
 
   if (failedResources && failedResources.length > 0) {

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-actions.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-actions.tsx
@@ -37,7 +37,7 @@ function buildConsolidatedPrompt({
 
 Your openapi.json is missing info.contact.email. Add a "contact" object with your email to the top-level "info" field:
 { "info": { "contact": { "email": "you@example.com" } } }
-Every registered origin gets two pages on tryponcho.com: /m/your-origin (your API storefront) and /p/your-origin (health metrics for your endpoints).`);
+Adding your email lets you verify ownership, allows users to contact you, and lets you customize your merchant pages on tryponcho.com.`);
   }
 
   if (failedResources && failedResources.length > 0) {

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-actions.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-actions.tsx
@@ -37,7 +37,7 @@ function buildConsolidatedPrompt({
 
 Your openapi.json is missing info.contact.email. Add a "contact" object with your email to the top-level "info" field:
 { "info": { "contact": { "email": "you@example.com" } } }
-This unlocks your free merchant dashboard on tryponcho.com (usage analytics, endpoint health, shareable onboarding link).`);
+This gives you two pages on tryponcho.com: /m/your-origin (a storefront for users to try your API) and /p/your-origin (a dashboard with usage analytics and endpoint health).`);
   }
 
   if (failedResources && failedResources.length > 0) {

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-actions.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-actions.tsx
@@ -23,12 +23,22 @@ function buildConsolidatedPrompt({
   failedResources,
   warnings,
   missingSchemaResources,
+  missingContactEmail,
 }: {
   failedResources?: { url: string; error: string; status?: number }[];
   warnings?: { url: string; error: string; status?: number }[];
   missingSchemaResources?: string[];
+  missingContactEmail?: boolean;
 }): string {
   const sections: string[] = [];
+
+  if (missingContactEmail) {
+    sections.push(`Missing contact email:
+
+Your openapi.json is missing info.contact.email. Add a "contact" object with your email to the top-level "info" field:
+{ "info": { "contact": { "email": "you@example.com" } } }
+This unlocks your free merchant dashboard on tryponcho.com (usage analytics, endpoint health, shareable onboarding link).`);
+  }
 
   if (failedResources && failedResources.length > 0) {
     const lines = failedResources.map(r => {
@@ -86,6 +96,8 @@ export function DiscoveryActions({
   warnings,
   noDiscovery,
   missingSchemaResources,
+  missingContactEmail,
+  customPrompt,
 }: {
   iconOnly?: boolean;
   label?: string;
@@ -94,14 +106,21 @@ export function DiscoveryActions({
   noDiscovery?: boolean;
   /** URLs missing input schemas — merged into the consolidated prompt. */
   missingSchemaResources?: string[];
+  /** Whether the origin is missing info.contact.email. */
+  missingContactEmail?: boolean;
+  /** Override the generated prompt with a custom one. */
+  customPrompt?: string;
 }) {
-  const prompt = noDiscovery
-    ? SETUP_PROMPT
-    : buildConsolidatedPrompt({
-        failedResources,
-        warnings,
-        missingSchemaResources,
-      });
+  const prompt =
+    customPrompt ??
+    (noDiscovery
+      ? SETUP_PROMPT
+      : buildConsolidatedPrompt({
+          failedResources,
+          warnings,
+          missingSchemaResources,
+          missingContactEmail,
+        }));
 
   const { isCopied, copyToClipboard } = useCopyToClipboard(() => {
     toast.success('Copied prompt for agents');

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
@@ -72,12 +72,14 @@ export function DiscoveryFixHint({
   warnings,
   noDiscovery,
   missingSchemaResources,
+  missingContactEmail,
 }: {
   className?: string;
   failedResources?: { url: string; error: string; status?: number }[];
   warnings?: { url: string; error: string; status?: number }[];
   noDiscovery?: boolean;
   missingSchemaResources?: string[];
+  missingContactEmail?: boolean;
 }) {
   const label = noDiscovery
     ? 'Have your agent create an OpenAPI spec for your resource'
@@ -90,6 +92,7 @@ export function DiscoveryFixHint({
         failedResources={failedResources}
         warnings={warnings}
         missingSchemaResources={missingSchemaResources}
+        missingContactEmail={missingContactEmail}
         noDiscovery={noDiscovery}
       />{' '}
       or{' '}

--- a/apps/scan/src/app/(app)/_components/discovery/use-discovery.ts
+++ b/apps/scan/src/app/(app)/_components/discovery/use-discovery.ts
@@ -121,6 +121,9 @@ export interface UseDiscoveryReturn {
   handleRegisterAll: () => void;
   resetBulk: () => void;
 
+  // Contact email from OpenAPI info.contact.email
+  contactEmail: string | undefined;
+
   // Refresh
   refreshDiscovery: () => void;
 
@@ -337,6 +340,11 @@ export function useDiscovery({
         : undefined,
     invalidResourcesMap,
     authModeMap,
+
+    // Contact email
+    contactEmail: discoveryQuery.data?.found
+      ? discoveryQuery.data.contactEmail
+      : undefined,
 
     // Origin preview
     isPreviewLoading: previewQuery.isLoading,

--- a/apps/scan/src/app/(app)/developer/_components/dummy.ts
+++ b/apps/scan/src/app/(app)/developer/_components/dummy.ts
@@ -38,6 +38,7 @@ export function createDummyResourceOrigin(params: {
     title: params.title ?? null,
     description: params.description ?? null,
     favicon: params.favicon ?? null,
+    email: null,
     createdAt: new Date(),
     updatedAt: new Date(),
     ogImages: params.ogImages,

--- a/apps/scan/src/app/api/x402/_handlers/registry-register-origin.ts
+++ b/apps/scan/src/app/api/x402/_handlers/registry-register-origin.ts
@@ -2,6 +2,7 @@ import type { registryRegisterOriginBodySchema } from '@/app/api/x402/_lib/schem
 import { jsonResponse } from '@/app/api/x402/_lib/utils';
 import { fetchDiscoveryDocument } from '@/services/discovery';
 import { registerResourcesFromDiscovery } from '@/lib/discovery/register-origin';
+import { CONTACT_EMAIL_WARNING } from './registry-register';
 import { revalidatePath } from 'next/cache';
 
 import type { z } from 'zod';
@@ -66,5 +67,8 @@ export async function handleRegistryRegisterOrigin(
     failedDetails:
       result.failedDetails.length > 0 ? result.failedDetails : undefined,
     siwxDetails: result.siwxDetails.length > 0 ? result.siwxDetails : undefined,
+    ...(discoveryResult.contactEmail
+      ? { contactEmail: discoveryResult.contactEmail }
+      : { warning: CONTACT_EMAIL_WARNING }),
   });
 }

--- a/apps/scan/src/app/api/x402/_handlers/registry-register-origin.ts
+++ b/apps/scan/src/app/api/x402/_handlers/registry-register-origin.ts
@@ -2,7 +2,7 @@ import type { registryRegisterOriginBodySchema } from '@/app/api/x402/_lib/schem
 import { jsonResponse } from '@/app/api/x402/_lib/utils';
 import { fetchDiscoveryDocument } from '@/services/discovery';
 import { registerResourcesFromDiscovery } from '@/lib/discovery/register-origin';
-import { CONTACT_EMAIL_WARNING } from './registry-register';
+import { contactEmailFields } from './registry-register';
 import { revalidatePath } from 'next/cache';
 
 import type { z } from 'zod';
@@ -67,8 +67,6 @@ export async function handleRegistryRegisterOrigin(
     failedDetails:
       result.failedDetails.length > 0 ? result.failedDetails : undefined,
     siwxDetails: result.siwxDetails.length > 0 ? result.siwxDetails : undefined,
-    ...(discoveryResult.contactEmail
-      ? { contactEmail: discoveryResult.contactEmail }
-      : { warning: CONTACT_EMAIL_WARNING }),
+    ...contactEmailFields(discoveryResult.contactEmail),
   });
 }

--- a/apps/scan/src/app/api/x402/_handlers/registry-register-origin.ts
+++ b/apps/scan/src/app/api/x402/_handlers/registry-register-origin.ts
@@ -29,7 +29,9 @@ export async function handleRegistryRegisterOrigin(
   const result = await registerResourcesFromDiscovery(
     discoveryResult.resources,
     discoveryResult.source,
-    discoveryResult.info
+    discoveryResult.info,
+    undefined,
+    discoveryResult.contactEmail
   );
 
   try {

--- a/apps/scan/src/app/api/x402/_handlers/registry-register.ts
+++ b/apps/scan/src/app/api/x402/_handlers/registry-register.ts
@@ -6,7 +6,7 @@ import { revalidatePath } from 'next/cache';
 import type { z } from 'zod';
 
 export const CONTACT_EMAIL_WARNING =
-  'Add info.contact.email to your openapi.json to unlock your free merchant dashboard on tryponcho.com — usage analytics, endpoint health, and a shareable onboarding link.';
+  'Add info.contact.email to your openapi.json to get your merchant pages on tryponcho.com — a storefront for your users and a dashboard for you.';
 
 export async function handleRegistryRegister(
   body: z.infer<typeof registryRegisterBodySchema>

--- a/apps/scan/src/app/api/x402/_handlers/registry-register.ts
+++ b/apps/scan/src/app/api/x402/_handlers/registry-register.ts
@@ -1,13 +1,23 @@
 import type { registryRegisterBodySchema } from '@/app/api/x402/_lib/schemas';
 import { jsonResponse } from '@/app/api/x402/_lib/utils';
 import { registerEndpoint } from '@/lib/discovery/register-endpoint';
+import { fetchDiscoveryDocument } from '@/services/discovery';
 import { revalidatePath } from 'next/cache';
 import type { z } from 'zod';
+
+export const CONTACT_EMAIL_WARNING =
+  'Add info.contact.email to your openapi.json to unlock your free merchant dashboard on tryponcho.com — usage analytics, endpoint health, and a shareable onboarding link.';
 
 export async function handleRegistryRegister(
   body: z.infer<typeof registryRegisterBodySchema>
 ) {
-  const result = await registerEndpoint(body.url);
+  const origin = new URL(body.url).origin;
+  const [result, discoveryResult] = await Promise.all([
+    registerEndpoint(body.url),
+    fetchDiscoveryDocument(origin),
+  ]);
+
+  const contactEmail = discoveryResult.contactEmail;
 
   try {
     if (result.success && result.resource?.origin?.id) {
@@ -22,11 +32,17 @@ export async function handleRegistryRegister(
   }
 
   // BigInt serialization — REST-specific (TRPC uses superjson)
-  return jsonResponse(
-    JSON.parse(
-      JSON.stringify(result, (_k, v: unknown) =>
-        typeof v === 'bigint' ? Number(v) : v
-      )
+  const serialized = JSON.parse(
+    JSON.stringify(result, (_k, v: unknown) =>
+      typeof v === 'bigint' ? Number(v) : v
     )
-  );
+  ) as Record<string, unknown>;
+
+  if (contactEmail) {
+    serialized.contactEmail = contactEmail;
+  } else {
+    serialized.warning = CONTACT_EMAIL_WARNING;
+  }
+
+  return jsonResponse(serialized);
 }

--- a/apps/scan/src/app/api/x402/_handlers/registry-register.ts
+++ b/apps/scan/src/app/api/x402/_handlers/registry-register.ts
@@ -6,7 +6,7 @@ import { revalidatePath } from 'next/cache';
 import type { z } from 'zod';
 
 export const CONTACT_EMAIL_WARNING =
-  'We recommend adding info.contact.email to your openapi.json. Your origin has merchant pages on tryponcho.com — an API storefront (/m/) and health metrics (/p/).';
+  'Add info.contact.email to your openapi.json to verify ownership, let users contact you, and customize your merchant pages on tryponcho.com.';
 
 export async function handleRegistryRegister(
   body: z.infer<typeof registryRegisterBodySchema>

--- a/apps/scan/src/app/api/x402/_handlers/registry-register.ts
+++ b/apps/scan/src/app/api/x402/_handlers/registry-register.ts
@@ -5,8 +5,12 @@ import { fetchDiscoveryDocument } from '@/services/discovery';
 import { revalidatePath } from 'next/cache';
 import type { z } from 'zod';
 
-export const CONTACT_EMAIL_WARNING =
+const CONTACT_EMAIL_WARNING =
   'Add info.contact.email to your openapi.json to verify ownership, let users contact you, and customize your merchant pages on tryponcho.com.';
+
+export function contactEmailFields(contactEmail: string | undefined) {
+  return contactEmail ? { contactEmail } : { warning: CONTACT_EMAIL_WARNING };
+}
 
 export async function handleRegistryRegister(
   body: z.infer<typeof registryRegisterBodySchema>
@@ -28,13 +32,10 @@ export async function handleRegistryRegister(
   }
 
   if (!result.success) {
-    const errorBody: Record<string, unknown> = { ...result };
-    if (contactEmail) {
-      errorBody.contactEmail = contactEmail;
-    } else {
-      errorBody.warning = CONTACT_EMAIL_WARNING;
-    }
-    return jsonResponse(errorBody, 422);
+    return jsonResponse(
+      { ...result, ...contactEmailFields(contactEmail) },
+      422
+    );
   }
 
   // BigInt serialization — REST-specific (TRPC uses superjson)
@@ -44,11 +45,5 @@ export async function handleRegistryRegister(
     )
   ) as Record<string, unknown>;
 
-  if (contactEmail) {
-    serialized.contactEmail = contactEmail;
-  } else {
-    serialized.warning = CONTACT_EMAIL_WARNING;
-  }
-
-  return jsonResponse(serialized);
+  return jsonResponse({ ...serialized, ...contactEmailFields(contactEmail) });
 }

--- a/apps/scan/src/app/api/x402/_handlers/registry-register.ts
+++ b/apps/scan/src/app/api/x402/_handlers/registry-register.ts
@@ -28,7 +28,13 @@ export async function handleRegistryRegister(
   }
 
   if (!result.success) {
-    return jsonResponse(result, 422);
+    const errorBody: Record<string, unknown> = { ...result };
+    if (contactEmail) {
+      errorBody.contactEmail = contactEmail;
+    } else {
+      errorBody.warning = CONTACT_EMAIL_WARNING;
+    }
+    return jsonResponse(errorBody, 422);
   }
 
   // BigInt serialization — REST-specific (TRPC uses superjson)

--- a/apps/scan/src/app/api/x402/_handlers/registry-register.ts
+++ b/apps/scan/src/app/api/x402/_handlers/registry-register.ts
@@ -6,7 +6,7 @@ import { revalidatePath } from 'next/cache';
 import type { z } from 'zod';
 
 export const CONTACT_EMAIL_WARNING =
-  'Add info.contact.email to your openapi.json to get your merchant pages on tryponcho.com — a storefront for your users and a dashboard for you.';
+  'We recommend adding info.contact.email to your openapi.json. Your origin has merchant pages on tryponcho.com — an API storefront (/m/) and health metrics (/p/).';
 
 export async function handleRegistryRegister(
   body: z.infer<typeof registryRegisterBodySchema>

--- a/apps/scan/src/lib/discovery/register-origin.ts
+++ b/apps/scan/src/lib/discovery/register-origin.ts
@@ -104,7 +104,8 @@ export async function registerResourcesFromDiscovery(
   originInfo?: { title: string; description?: string },
   /** Server-side probe session ID. URLs with a cached probe result in Redis
    *  skip re-probing — avoids rate limiting on registration. */
-  probeSessionId?: string
+  probeSessionId?: string,
+  contactEmail?: string
 ): Promise<RegisterOriginResult> {
   const uniqueOrigins = [
     ...new Set(resources.map(resource => getOriginFromUrl(resource.url))),
@@ -408,6 +409,7 @@ export async function registerResourcesFromDiscovery(
           title: title ?? undefined,
           description: description ?? undefined,
           favicon: favicon ?? undefined,
+          email: contactEmail ?? undefined,
           ogImages:
             og?.ogImage?.flatMap(image => {
               try {

--- a/apps/scan/src/services/db/resources/origin.ts
+++ b/apps/scan/src/services/db/resources/origin.ts
@@ -165,10 +165,10 @@ export const listOrigins = async (input: z.infer<typeof listOriginsSchema>) => {
     where: {
       resources: { some: resourceFilter },
     },
-    omit: { email: true },
     orderBy: { createdAt: 'desc' },
   });
-  return origins;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  return origins.map(({ email, ...rest }) => rest);
 };
 
 export const listOriginsWithResourcesSchema = z.object({
@@ -203,7 +203,6 @@ export const listOriginsWithResources = async (
       ...(originIds ? { id: { in: originIds } } : {}),
       resources: { some: paidOrSiwxResource },
     },
-    omit: { email: true },
     include: {
       resources: {
         where: paidOrSiwxResource,
@@ -230,35 +229,38 @@ export const listOriginsWithResources = async (
       },
     },
   });
-  return origins
-    .map(origin => ({
-      ...origin,
-      resources: origin.resources.map(resource => {
-        // SIWX (free) resources have no 402 response — they're identity-gated,
-        // not paid. Treat them as successful with empty payment data.
-        if (isSiwxResource(resource)) {
+  return (
+    origins
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      .map(({ email, ...origin }) => ({
+        ...origin,
+        resources: origin.resources.map(resource => {
+          // SIWX (free) resources have no 402 response — they're identity-gated,
+          // not paid. Treat them as successful with empty payment data.
+          if (isSiwxResource(resource)) {
+            return {
+              ...resource,
+              success: true as const,
+              data: {} as ParsedX402Response,
+            };
+          }
+          const response = parseX402Response(resource.response?.response);
+          if (!response.success) {
+            console.error(
+              `[listOriginsWithResources] parseX402Response failed for resource ${resource.id} (${resource.resource}):`,
+              JSON.stringify(response.errors),
+              'raw response:',
+              JSON.stringify(resource.response?.response)
+            );
+          }
           return {
             ...resource,
-            success: true as const,
-            data: {} as ParsedX402Response,
+            ...response,
           };
-        }
-        const response = parseX402Response(resource.response?.response);
-        if (!response.success) {
-          console.error(
-            `[listOriginsWithResources] parseX402Response failed for resource ${resource.id} (${resource.resource}):`,
-            JSON.stringify(response.errors),
-            'raw response:',
-            JSON.stringify(resource.response?.response)
-          );
-        }
-        return {
-          ...resource,
-          ...response,
-        };
-      }),
-    }))
-    .filter(origin => origin.resources.length > 0);
+        }),
+      }))
+      .filter(origin => origin.resources.length > 0)
+  );
 };
 
 export const searchOriginsSchema = z.object({
@@ -271,7 +273,7 @@ export const searchOrigins = async (
 ) => {
   const { search, limit } = searchOriginsSchema.parse(input);
   const acceptsWhere = getDisplayableAcceptsWhere({});
-  return await scanDb.resourceOrigin.findMany({
+  const results = await scanDb.resourceOrigin.findMany({
     where: {
       origin: {
         contains: search,
@@ -286,7 +288,6 @@ export const searchOrigins = async (
         },
       },
     },
-    omit: { email: true },
     include: {
       resources: {
         where: {
@@ -307,12 +308,13 @@ export const searchOrigins = async (
     },
     take: limit,
   });
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  return results.map(({ email, ...rest }) => rest);
 };
 
 export const getOrigin = async (id: string) => {
   const origin = await scanDb.resourceOrigin.findUnique({
     where: { id },
-    omit: { email: true },
     include: {
       ogImages: true,
       resources: {
@@ -325,7 +327,8 @@ export const getOrigin = async (id: string) => {
 
   if (!origin) return null;
 
-  const { resources, ...originData } = origin;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { resources, email, ...originData } = origin;
 
   return {
     ...originData,

--- a/apps/scan/src/services/db/resources/origin.ts
+++ b/apps/scan/src/services/db/resources/origin.ts
@@ -64,6 +64,7 @@ const originSchema = z.object({
   title: z.string().optional(),
   description: z.string().optional(),
   favicon: z.url().optional(),
+  email: z.string().email().optional(),
   ogImages: z.array(ogImageSchema),
 });
 
@@ -78,12 +79,14 @@ export const upsertOrigin = async (
         title: origin.title,
         description: origin.description,
         favicon: origin.favicon,
+        ...(origin.email && { email: origin.email }),
       },
       create: {
         origin: origin.origin,
         title: origin.title,
         description: origin.description,
         favicon: origin.favicon,
+        email: origin.email,
       },
     });
 

--- a/apps/scan/src/services/db/resources/origin.ts
+++ b/apps/scan/src/services/db/resources/origin.ts
@@ -165,6 +165,7 @@ export const listOrigins = async (input: z.infer<typeof listOriginsSchema>) => {
     where: {
       resources: { some: resourceFilter },
     },
+    omit: { email: true },
     orderBy: { createdAt: 'desc' },
   });
   return origins;
@@ -202,6 +203,7 @@ export const listOriginsWithResources = async (
       ...(originIds ? { id: { in: originIds } } : {}),
       resources: { some: paidOrSiwxResource },
     },
+    omit: { email: true },
     include: {
       resources: {
         where: paidOrSiwxResource,
@@ -284,6 +286,7 @@ export const searchOrigins = async (
         },
       },
     },
+    omit: { email: true },
     include: {
       resources: {
         where: {
@@ -309,6 +312,7 @@ export const searchOrigins = async (
 export const getOrigin = async (id: string) => {
   const origin = await scanDb.resourceOrigin.findUnique({
     where: { id },
+    omit: { email: true },
     include: {
       ogImages: true,
       resources: {

--- a/apps/scan/src/services/db/resources/origin.ts
+++ b/apps/scan/src/services/db/resources/origin.ts
@@ -167,8 +167,7 @@ export const listOrigins = async (input: z.infer<typeof listOriginsSchema>) => {
     },
     orderBy: { createdAt: 'desc' },
   });
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  return origins.map(({ email, ...rest }) => rest);
+  return origins;
 };
 
 export const listOriginsWithResourcesSchema = z.object({
@@ -229,38 +228,35 @@ export const listOriginsWithResources = async (
       },
     },
   });
-  return (
-    origins
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      .map(({ email, ...origin }) => ({
-        ...origin,
-        resources: origin.resources.map(resource => {
-          // SIWX (free) resources have no 402 response — they're identity-gated,
-          // not paid. Treat them as successful with empty payment data.
-          if (isSiwxResource(resource)) {
-            return {
-              ...resource,
-              success: true as const,
-              data: {} as ParsedX402Response,
-            };
-          }
-          const response = parseX402Response(resource.response?.response);
-          if (!response.success) {
-            console.error(
-              `[listOriginsWithResources] parseX402Response failed for resource ${resource.id} (${resource.resource}):`,
-              JSON.stringify(response.errors),
-              'raw response:',
-              JSON.stringify(resource.response?.response)
-            );
-          }
+  return origins
+    .map(origin => ({
+      ...origin,
+      resources: origin.resources.map(resource => {
+        // SIWX (free) resources have no 402 response — they're identity-gated,
+        // not paid. Treat them as successful with empty payment data.
+        if (isSiwxResource(resource)) {
           return {
             ...resource,
-            ...response,
+            success: true as const,
+            data: {} as ParsedX402Response,
           };
-        }),
-      }))
-      .filter(origin => origin.resources.length > 0)
-  );
+        }
+        const response = parseX402Response(resource.response?.response);
+        if (!response.success) {
+          console.error(
+            `[listOriginsWithResources] parseX402Response failed for resource ${resource.id} (${resource.resource}):`,
+            JSON.stringify(response.errors),
+            'raw response:',
+            JSON.stringify(resource.response?.response)
+          );
+        }
+        return {
+          ...resource,
+          ...response,
+        };
+      }),
+    }))
+    .filter(origin => origin.resources.length > 0);
 };
 
 export const searchOriginsSchema = z.object({
@@ -273,7 +269,7 @@ export const searchOrigins = async (
 ) => {
   const { search, limit } = searchOriginsSchema.parse(input);
   const acceptsWhere = getDisplayableAcceptsWhere({});
-  const results = await scanDb.resourceOrigin.findMany({
+  return await scanDb.resourceOrigin.findMany({
     where: {
       origin: {
         contains: search,
@@ -308,8 +304,6 @@ export const searchOrigins = async (
     },
     take: limit,
   });
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  return results.map(({ email, ...rest }) => rest);
 };
 
 export const getOrigin = async (id: string) => {
@@ -327,8 +321,7 @@ export const getOrigin = async (id: string) => {
 
   if (!origin) return null;
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { resources, email, ...originData } = origin;
+  const { resources, ...originData } = origin;
 
   return {
     ...originData,

--- a/apps/scan/src/services/discovery/fetch-discovery.ts
+++ b/apps/scan/src/services/discovery/fetch-discovery.ts
@@ -116,6 +116,9 @@ export async function fetchDiscoveryDocument(
     source: mapSourceToDiscoverySource(discovered.source),
     resources,
     ...(discovered.info ? { info: discovered.info } : {}),
+    ...(discovered.info?.contactEmail
+      ? { contactEmail: discovered.info.contactEmail }
+      : {}),
     ownershipProofs: discovered.ownershipProofs ?? [],
   };
 }

--- a/apps/scan/src/trpc/routers/public/origins.ts
+++ b/apps/scan/src/trpc/routers/public/origins.ts
@@ -13,6 +13,26 @@ import {
 import { scanDb } from '@x402scan/scan-db';
 import { TRPCError } from '@trpc/server';
 
+// Per-origin rate limit: 5 requests per 60 seconds
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX = 5;
+const requestLog = new Map<string, number[]>();
+
+function checkRateLimit(originId: string): void {
+  const now = Date.now();
+  const timestamps = requestLog.get(originId) ?? [];
+  const recent = timestamps.filter(t => now - t < RATE_LIMIT_WINDOW_MS);
+  if (recent.length >= RATE_LIMIT_MAX) {
+    requestLog.set(originId, recent);
+    throw new TRPCError({
+      code: 'TOO_MANY_REQUESTS',
+      message: 'Too many requests',
+    });
+  }
+  recent.push(now);
+  requestLog.set(originId, recent);
+}
+
 export const originsRouter = createTRPCRouter({
   get: publicProcedure.input(z.uuid()).query(async ({ input }) => {
     return await getOrigin(input);
@@ -41,6 +61,7 @@ export const originsRouter = createTRPCRouter({
   updateEmail: publicProcedure
     .input(z.object({ originId: z.string().uuid(), email: z.string().email() }))
     .mutation(async ({ input }) => {
+      checkRateLimit(input.originId);
       const origin = await scanDb.resourceOrigin.findUnique({
         where: { id: input.originId },
         select: { id: true },

--- a/apps/scan/src/trpc/routers/public/origins.ts
+++ b/apps/scan/src/trpc/routers/public/origins.ts
@@ -10,6 +10,7 @@ import {
   searchOrigins,
   searchOriginsSchema,
 } from '@/services/db/resources/origin';
+import { scanDb } from '@x402scan/scan-db';
 
 export const originsRouter = createTRPCRouter({
   get: publicProcedure.input(z.uuid()).query(async ({ input }) => {
@@ -35,5 +36,14 @@ export const originsRouter = createTRPCRouter({
     .input(searchOriginsSchema)
     .query(async ({ input }) => {
       return await searchOrigins(input);
+    }),
+  updateEmail: publicProcedure
+    .input(z.object({ originId: z.string().uuid(), email: z.string().email() }))
+    .mutation(async ({ input }) => {
+      await scanDb.resourceOrigin.update({
+        where: { id: input.originId },
+        data: { email: input.email },
+      });
+      return { success: true };
     }),
 });

--- a/apps/scan/src/trpc/routers/public/origins.ts
+++ b/apps/scan/src/trpc/routers/public/origins.ts
@@ -11,6 +11,7 @@ import {
   searchOriginsSchema,
 } from '@/services/db/resources/origin';
 import { scanDb } from '@x402scan/scan-db';
+import { TRPCError } from '@trpc/server';
 
 export const originsRouter = createTRPCRouter({
   get: publicProcedure.input(z.uuid()).query(async ({ input }) => {
@@ -40,6 +41,16 @@ export const originsRouter = createTRPCRouter({
   updateEmail: publicProcedure
     .input(z.object({ originId: z.string().uuid(), email: z.string().email() }))
     .mutation(async ({ input }) => {
+      const origin = await scanDb.resourceOrigin.findUnique({
+        where: { id: input.originId },
+        select: { id: true },
+      });
+      if (!origin) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Origin not found',
+        });
+      }
       await scanDb.resourceOrigin.update({
         where: { id: input.originId },
         data: { email: input.email },

--- a/apps/scan/src/trpc/routers/public/resources.ts
+++ b/apps/scan/src/trpc/routers/public/resources.ts
@@ -243,6 +243,7 @@ export const resourcesRouter = createTRPCRouter({
         resourceCount: discoveryResult.resources.length,
         resources: discoveryResult.resources,
         ownershipProofs: discoveryResult.ownershipProofs,
+        contactEmail: discoveryResult.contactEmail,
       };
     }),
 

--- a/apps/scan/src/trpc/routers/public/resources.ts
+++ b/apps/scan/src/trpc/routers/public/resources.ts
@@ -186,7 +186,8 @@ export const resourcesRouter = createTRPCRouter({
         discoveryResult.resources,
         discoveryResult.source,
         discoveryResult.info,
-        input.probeSessionId
+        input.probeSessionId,
+        discoveryResult.contactEmail
       );
 
       if (result.registered === 0 && result.siwx === 0) {

--- a/apps/scan/src/types/discovery.ts
+++ b/apps/scan/src/types/discovery.ts
@@ -53,6 +53,8 @@ export interface X402DiscoveryResult {
    * the origin's homepage isn't HTML (e.g. APIs that serve JSON at /).
    */
   info?: { title: string; description?: string; version?: string };
+  /** Contact email extracted from info.contact.email in the OpenAPI spec. */
+  contactEmail?: string;
   /** Optional instructions for AI agents consuming this API */
   instructions?: string;
   /**

--- a/packages/internal/databases/scan/prisma/migrations/20260611000000_add_email_to_resource_origin/migration.sql
+++ b/packages/internal/databases/scan/prisma/migrations/20260611000000_add_email_to_resource_origin/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "ResourceOrigin" ADD COLUMN "email" TEXT;

--- a/packages/internal/databases/scan/prisma/schema.prisma
+++ b/packages/internal/databases/scan/prisma/schema.prisma
@@ -166,6 +166,7 @@ model ResourceOrigin {
   title       String?
   description String?
   favicon     String?
+  email       String?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/packages/internal/databases/scan/src/client.ts
+++ b/packages/internal/databases/scan/src/client.ts
@@ -19,6 +19,10 @@ if (process.env.NODE_ENV !== 'production')
   globalForPrisma.scanDbAdapter = scanDbAdapter;
 
 export const scanDb =
-  globalForPrisma.scanDb || new PrismaClient({ adapter: scanDbAdapter });
+  globalForPrisma.scanDb ||
+  new PrismaClient({
+    adapter: scanDbAdapter,
+    omit: { resourceOrigin: { email: true } },
+  });
 
 if (process.env.NODE_ENV !== 'production') globalForPrisma.scanDb = scanDb;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1016,8 +1016,6 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
-  packages/internal/databases/scan/generated/client: {}
-
   packages/internal/databases/transfers:
     dependencies:
       '@neondatabase/serverless':
@@ -1063,8 +1061,6 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
-
-  packages/internal/databases/transfers/generated/client: {}
 
   packages/internal/neverthrow:
     dependencies:


### PR DESCRIPTION
## Summary

- **Onboarding checklist dialog** — post-registration dialog redesigned as a numbered 3-step checklist with completion tracking:
  1. Review your API page (checkmark on click)
  2. Test your endpoints (checkmark on click)
  3. Get free feedback from our team — inline email input, or "Schedule a call" if email already in openapi.json
- **Email persistence** — new `email` column on `ResourceOrigin` (Prisma migration). Populated during registration from `info.contact.email`, or manually via the dialog.
- **`updateEmail` tRPC mutation** — public endpoint for the dialog to save merchant email (with NOT_FOUND guard)
- **`contactEmailFields()` helper** — DRYs the conditional spread in both registration handlers
- Yellow warning during discovery when `info.contact.email` is missing, with copy-prompt CTA
- Discovery hub: "Your merchant pages" section describing `/m/` and `/p/` pages
- Discovery docs, agent prompts, and examples updated with the recommended field
- All post-registration links open in new tabs
- Copyable merchant page link at bottom of dialog

## Why

Merchants register and disappear — 80% are pseudonymous. The checklist guides them through setup, captures their email for follow-up, and offers a free consultation. Email is persisted to the origin for future contact and page customization.
