### PR TITLE
fix: await metadata upserts to persist favicon URLs

### DIFF
--- a/apps/scan/src/app/api/proxy-image/route.ts
+++ b/apps/scan/src/app/api/proxy-image/route.ts
@@ -28,7 +28,10 @@ export async function GET(req: NextRequest) {
     if (res.url && res.url !== url) {
       const finalHost = new URL(res.url).hostname;
       if (blockedPatterns.test(finalHost)) {
-        return NextResponse.json({ error: 'Blocked redirect target' }, { status: 403 });
+        return NextResponse.json(
+          { error: 'Blocked redirect target' },
+          { status: 403 }
+        );
       }
     }
 

--- a/apps/scan/src/lib/discovery/register-origin.ts
+++ b/apps/scan/src/lib/discovery/register-origin.ts
@@ -11,7 +11,6 @@ import { notifyNewServer } from '@/lib/discord-notifications';
 import { getOriginFromUrl, normalizeResourceUrl } from '@/lib/url';
 import { scanDb } from '@x402scan/scan-db';
 import { scrapeOriginData } from '@/services/scraper';
-import { after } from 'next/server';
 
 import type {
   AuditWarning,
@@ -388,55 +387,52 @@ export async function registerResourcesFromDiscovery(
   // Individual registerResource/registerSiwxResource calls skip this
   // (skipMetadataScrape: true) so the scrape+upsert happens exactly once
   // per origin, not once per resource.
-  const metadataTask = async () => {
-    await Promise.all(
-      uniqueOrigins.map(async origin => {
-        try {
-          const { og, metadata, favicon } = await scrapeOriginData(origin);
-          const title =
-            metadata?.title ?? og?.ogTitle ?? originInfo?.title ?? null;
-          const description =
-            metadata?.description ??
-            og?.ogDescription ??
-            originInfo?.description ??
-            null;
+  // Awaited directly — favicon URLs are essential for rendering and must
+  // be persisted before the response is sent. The previous after() approach
+  // was unreliable (the deferred scrape+upsert could be killed before
+  // completing, leaving stale ICO URLs in the DB).
+  await Promise.all(
+    uniqueOrigins.map(async origin => {
+      try {
+        const { og, metadata, favicon } = await scrapeOriginData(origin);
+        const title =
+          metadata?.title ?? og?.ogTitle ?? originInfo?.title ?? null;
+        const description =
+          metadata?.description ??
+          og?.ogDescription ??
+          originInfo?.description ??
+          null;
 
-          await upsertOrigin({
-            origin,
-            title: title ?? undefined,
-            description: description ?? undefined,
-            favicon: favicon ?? undefined,
-            ogImages:
-              og?.ogImage?.flatMap(image => {
-                try {
-                  return [
-                    {
-                      url: new URL(image.url, origin).toString(),
-                      height: image.height,
-                      width: image.width,
-                      title: og.ogTitle,
-                      description: og.ogDescription,
-                    },
-                  ];
-                } catch {
-                  return [];
-                }
-              }) ?? [],
-          });
-        } catch (err) {
-          console.error(
-            `[registerResourcesFromDiscovery] Metadata upsert failed for ${origin}:`,
-            err
-          );
-        }
-      })
-    );
-  };
-  try {
-    after(metadataTask);
-  } catch {
-    void metadataTask();
-  }
+        await upsertOrigin({
+          origin,
+          title: title ?? undefined,
+          description: description ?? undefined,
+          favicon: favicon ?? undefined,
+          ogImages:
+            og?.ogImage?.flatMap(image => {
+              try {
+                return [
+                  {
+                    url: new URL(image.url, origin).toString(),
+                    height: image.height,
+                    width: image.width,
+                    title: og.ogTitle,
+                    description: og.ogDescription,
+                  },
+                ];
+              } catch {
+                return [];
+              }
+            }) ?? [],
+        });
+      } catch (err) {
+        console.error(
+          `[registerResourcesFromDiscovery] Metadata upsert failed for ${origin}:`,
+          err
+        );
+      }
+    })
+  );
 
   return {
     registered: successfulResults.length,

--- a/apps/scan/src/lib/resources.ts
+++ b/apps/scan/src/lib/resources.ts
@@ -239,57 +239,50 @@ export async function registerSiwxResource(
       });
     });
 
-    // Scrape and upsert origin metadata (non-blocking — resource is already
-    // persisted, so a scrape failure shouldn't fail the registration).
+    // Scrape and upsert origin metadata. Resource is already persisted, so
+    // a scrape failure won't fail the registration.
     // Skipped in batch registration where the caller deduplicates per origin.
     if (!options.skipMetadataScrape) {
-      const siwxMetadataTask = async () => {
-        try {
-          const { og, metadata, favicon } = await scrapeOriginData(origin);
-          const title =
-            metadata?.title ??
-            og?.ogTitle ??
-            options.originMetadataFallback?.title ??
-            null;
-          const description =
-            metadata?.description ??
-            og?.ogDescription ??
-            options.originMetadataFallback?.description ??
-            null;
-
-          await upsertOrigin({
-            origin,
-            title: title ?? undefined,
-            description: description ?? undefined,
-            favicon: favicon ?? undefined,
-            ogImages:
-              og?.ogImage?.flatMap(image => {
-                try {
-                  return [
-                    {
-                      url: new URL(image.url, origin).toString(),
-                      height: image.height,
-                      width: image.width,
-                      title: og.ogTitle,
-                      description: og.ogDescription,
-                    },
-                  ];
-                } catch {
-                  return [];
-                }
-              }) ?? [],
-          });
-        } catch (err) {
-          console.error(
-            '[registerSiwxResource] Metadata scrape failed (non-blocking):',
-            err
-          );
-        }
-      };
       try {
-        after(siwxMetadataTask);
-      } catch {
-        void siwxMetadataTask();
+        const { og, metadata, favicon } = await scrapeOriginData(origin);
+        const title =
+          metadata?.title ??
+          og?.ogTitle ??
+          options.originMetadataFallback?.title ??
+          null;
+        const description =
+          metadata?.description ??
+          og?.ogDescription ??
+          options.originMetadataFallback?.description ??
+          null;
+
+        await upsertOrigin({
+          origin,
+          title: title ?? undefined,
+          description: description ?? undefined,
+          favicon: favicon ?? undefined,
+          ogImages:
+            og?.ogImage?.flatMap(image => {
+              try {
+                return [
+                  {
+                    url: new URL(image.url, origin).toString(),
+                    height: image.height,
+                    width: image.width,
+                    title: og.ogTitle,
+                    description: og.ogDescription,
+                  },
+                ];
+              } catch {
+                return [];
+              }
+            }) ?? [],
+        });
+      } catch (err) {
+        console.error(
+          '[registerSiwxResource] Metadata scrape failed (non-blocking):',
+          err
+        );
       }
     }
 
@@ -538,54 +531,45 @@ export const registerResource = async (
     description =
       scraped.metadata?.description ?? og?.ogDescription ?? description;
 
-    // Origin metadata upsert — non-blocking. The origin row itself is already
-    // created inside upsertResource's transaction. This just enriches it with
-    // scraped metadata (title, favicon, OG images). When multiple resources
-    // from the same origin register concurrently, this can race (P2002) —
-    // safe to swallow since another concurrent call will succeed.
-    const originMetadataTask = async () => {
-      try {
-        await upsertOrigin({
-          origin,
-          title: title ?? undefined,
-          description: description ?? undefined,
-          favicon: favicon ?? undefined,
-          ogImages:
-            og?.ogImage?.flatMap(image => {
-              try {
-                return [
-                  {
-                    url: new URL(image.url, origin).toString(),
-                    height: image.height,
-                    width: image.width,
-                    title: og?.ogTitle,
-                    description: og?.ogDescription,
-                  },
-                ];
-              } catch {
-                return [];
-              }
-            }) ?? [],
-        });
-      } catch (err) {
-        // P2002: another concurrent call already upserted this origin — safe to ignore.
-        // Log anything else so metadata failures aren't silent.
-        const isP2002 =
-          err instanceof Error &&
-          'code' in err &&
-          (err as { code: string }).code === 'P2002';
-        if (!isP2002) {
-          console.error(
-            '[registerResource] Origin metadata upsert failed:',
-            err
-          );
-        }
-      }
-    };
+    // Origin metadata upsert — awaited to ensure favicon URLs are persisted.
+    // The origin row itself is already created inside upsertResource's
+    // transaction. This enriches it with scraped metadata (title, favicon,
+    // OG images). When multiple resources from the same origin register
+    // concurrently, this can race (P2002) — safe to swallow since another
+    // concurrent call will succeed.
     try {
-      after(originMetadataTask);
-    } catch {
-      void originMetadataTask();
+      await upsertOrigin({
+        origin,
+        title: title ?? undefined,
+        description: description ?? undefined,
+        favicon: favicon ?? undefined,
+        ogImages:
+          og?.ogImage?.flatMap(image => {
+            try {
+              return [
+                {
+                  url: new URL(image.url, origin).toString(),
+                  height: image.height,
+                  width: image.width,
+                  title: og?.ogTitle,
+                  description: og?.ogDescription,
+                },
+              ];
+            } catch {
+              return [];
+            }
+          }) ?? [],
+      });
+    } catch (err) {
+      // P2002: another concurrent call already upserted this origin — safe to ignore.
+      // Log anything else so metadata failures aren't silent.
+      const isP2002 =
+        err instanceof Error &&
+        'code' in err &&
+        (err as { code: string }).code === 'P2002';
+      if (!isP2002) {
+        console.error('[registerResource] Origin metadata upsert failed:', err);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

PR #966's `after()` approach was still unreliable — the deferred scrape+upsert callbacks were being killed before completing on Vercel, leaving stale ICO URLs in the DB.

**Root cause** (verified against production):
- StableEnrich's DB row still had the ICO URL (`/favicon.ico`) despite re-registration
- The ICO contains a horizontally distorted cube — the non-square SVG viewBox (`67.72 x 77.82`) was squished into a `256x256` square
- The scraper correctly finds the SVG (priority 1) but `after()` never persisted the upsert
- The CSS (`object-contain`) works correctly — confirmed with a standalone test page. The problem was the image data, not the rendering.

**Fix**: `await` the metadata scrape+upsert directly in all three registration paths (`registerResourcesFromDiscovery`, `registerResource`, `registerSiwxResource`) instead of deferring via `after()`. Ownership verification and Discord notifications stay in `after()` — they're not rendering-critical.

**After deploying**: re-register the affected origins to get the SVG favicon URLs saved.

## Test plan
- [x] `pnpm format && pnpm lint && pnpm check` passes
- [ ] Deploy to preview, re-register StableEnrich, verify DB now has `/favicon.svg` via API query
- [ ] Confirm the favicon on the server detail page is no longer stretched