### PR TITLE
Switch Base transfer sync to Bitquery

### DIFF
--- a/packages/internal/databases/transfers/prisma/migrations/20260609180000_transfer_sync_state/migration.sql
+++ b/packages/internal/databases/transfers/prisma/migrations/20260609180000_transfer_sync_state/migration.sql
@@ -1,0 +1,20 @@
+CREATE TABLE "TransferSyncState" (
+    "id" TEXT NOT NULL,
+    "chain" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "facilitator_id" TEXT NOT NULL,
+    "transaction_from" TEXT NOT NULL,
+    "token_address" TEXT NOT NULL,
+    "cursor_timestamp" TIMESTAMP(3) NOT NULL,
+    "last_started_at" TIMESTAMP(3),
+    "last_completed_at" TIMESTAMP(3),
+    "last_error" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "TransferSyncState_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "TransferSyncState_chain_provider_facilitator_id_transaction_key" ON "TransferSyncState"("chain", "provider", "facilitator_id", "transaction_from", "token_address");
+
+CREATE INDEX "TransferSyncState_chain_provider_cursor_timestamp_idx" ON "TransferSyncState"("chain", "provider", "cursor_timestamp");

--- a/packages/internal/databases/transfers/prisma/schema.prisma
+++ b/packages/internal/databases/transfers/prisma/schema.prisma
@@ -39,3 +39,22 @@ model TransferEvent {
   @@index([sender, block_timestamp])
   @@index([chain, transaction_from, provider, block_timestamp(sort: Desc)])
 }
+
+model TransferSyncState {
+  id                String    @default(uuid())
+  chain             String
+  provider          String
+  facilitator_id    String
+  transaction_from  String
+  token_address     String
+  cursor_timestamp  DateTime
+  last_started_at   DateTime?
+  last_completed_at DateTime?
+  last_error        String?
+  created_at        DateTime  @default(now())
+  updated_at        DateTime  @updatedAt
+
+  @@id([id])
+  @@unique([chain, provider, facilitator_id, transaction_from, token_address])
+  @@index([chain, provider, cursor_timestamp])
+}

--- a/sync/transfers/db/services.ts
+++ b/sync/transfers/db/services.ts
@@ -161,3 +161,77 @@ export async function deleteManyTransferEvents(
     where,
   });
 }
+
+export interface TransferSyncStateKey {
+  chain: string;
+  provider: string;
+  facilitator_id: string;
+  transaction_from: string;
+  token_address: string;
+}
+
+function syncStateWhere(key: TransferSyncStateKey) {
+  return {
+    chain_provider_facilitator_id_transaction_from_token_address: key,
+  };
+}
+
+export async function getTransferSyncState(key: TransferSyncStateKey) {
+  return await transfersDb.transferSyncState.findUnique({
+    where: syncStateWhere(key),
+  });
+}
+
+export async function createTransferSyncState(
+  key: TransferSyncStateKey,
+  cursorTimestamp: Date
+) {
+  return await transfersDb.transferSyncState.upsert({
+    where: syncStateWhere(key),
+    create: {
+      ...key,
+      cursor_timestamp: cursorTimestamp,
+    },
+    update: {},
+  });
+}
+
+export async function markTransferSyncStateStarted(
+  key: TransferSyncStateKey,
+  startedAt: Date
+) {
+  return await transfersDb.transferSyncState.update({
+    where: syncStateWhere(key),
+    data: {
+      last_started_at: startedAt,
+      last_error: null,
+    },
+  });
+}
+
+export async function advanceTransferSyncState(
+  key: TransferSyncStateKey,
+  cursorTimestamp: Date,
+  completedAt: Date
+) {
+  return await transfersDb.transferSyncState.update({
+    where: syncStateWhere(key),
+    data: {
+      cursor_timestamp: cursorTimestamp,
+      last_completed_at: completedAt,
+      last_error: null,
+    },
+  });
+}
+
+export async function recordTransferSyncStateError(
+  key: TransferSyncStateKey,
+  error: string
+) {
+  return await transfersDb.transferSyncState.update({
+    where: syncStateWhere(key),
+    data: {
+      last_error: error,
+    },
+  });
+}

--- a/sync/transfers/trigger/chains/evm/base/bitquery/config.ts
+++ b/sync/transfers/trigger/chains/evm/base/bitquery/config.ts
@@ -1,0 +1,27 @@
+import { FACILITATORS_BY_CHAIN } from '@/trigger/lib/facilitators';
+import { ONE_MINUTE_IN_SECONDS } from '@/trigger/lib/constants';
+import type { SyncConfig } from '@/trigger/types';
+import { Network, PaginationStrategy, QueryProvider } from '@/trigger/types';
+import { buildQuery, transformResponse } from './query';
+
+const ONE_HOUR_IN_MS = 60 * 60 * 1000;
+const DEFAULT_CUTOVER_AT = '2026-06-09T18:00:00.000Z'; // switch from CDP to Bitquery
+
+export const baseBitqueryConfig: SyncConfig = {
+  cron: '*/5 * * * *',
+  maxDurationInSeconds: ONE_MINUTE_IN_SECONDS * 15,
+  chain: 'base',
+  provider: QueryProvider.BITQUERY,
+  apiUrl: 'https://streaming.bitquery.io/graphql',
+  paginationStrategy: PaginationStrategy.TIME_WINDOW,
+  timeWindowInMs: ONE_HOUR_IN_MS,
+  limit: 25_000,
+  facilitators: FACILITATORS_BY_CHAIN(Network.BASE),
+  buildQuery,
+  transformResponse,
+  enabled: true,
+  machine: 'medium-1x',
+  splitSyncByFacilitator: true,
+  useSyncState: true,
+  syncStateCutoverAt: new Date(DEFAULT_CUTOVER_AT),
+};

--- a/sync/transfers/trigger/chains/evm/base/bitquery/query.ts
+++ b/sync/transfers/trigger/chains/evm/base/bitquery/query.ts
@@ -1,0 +1,152 @@
+import { TRANSFER_TOPIC } from '@/trigger/lib/constants';
+import { logger } from '@trigger.dev/sdk/v3';
+import type {
+  EvmBitQueryEventRow,
+  Facilitator,
+  FacilitatorConfig,
+  SyncConfig,
+  TransferEventData,
+} from '@/trigger/types';
+
+const TRANSFER_TOPIC_WITHOUT_PREFIX = TRANSFER_TOPIC.replace(/^0x/, '');
+
+export function buildQuery(
+  config: SyncConfig,
+  facilitatorConfig: FacilitatorConfig,
+  since: Date,
+  now: Date
+): string {
+  // Bitquery treats both `since` and `till` as inclusive. The sync cursor is
+  // the next window start, so subtract 1ms from the upper bound to make windows
+  // behave like [since, now) and avoid refetching boundary events.
+  const exclusiveTill = new Date(Math.max(since.getTime(), now.getTime() - 1));
+
+  return `
+    {
+      EVM(dataset: combined, network: base) {
+        Events(
+          limit: { count: ${config.limit} }
+          where: {
+            LogHeader: {
+              Address: {
+                is: "${facilitatorConfig.token.address.toLowerCase()}"
+              }
+              Removed: false
+            }
+            Log: {
+              Signature: {
+                SignatureHash: {
+                  is: "${TRANSFER_TOPIC_WITHOUT_PREFIX}"
+                }
+              }
+            }
+            Transaction: {
+              From: {
+                is: "${facilitatorConfig.address.toLowerCase()}"
+              }
+            }
+            Block: {
+              Time: {
+                since: "${since.toISOString()}"
+                till: "${exclusiveTill.toISOString()}"
+              }
+            }
+          }
+          orderBy: {
+            ascending: [
+              Block_Number,
+              Transaction_Index,
+              Log_EnterIndex
+            ]
+          }
+        ) {
+          Block {
+            Time
+            Number
+          }
+          Transaction {
+            Hash
+            From
+            Index
+          }
+          LogHeader {
+            Address
+            Index
+            Removed
+          }
+          Log {
+            EnterIndex
+            Index
+            LogAfterCallIndex
+            SmartContract
+          }
+          Arguments {
+            Name
+            Value {
+              ... on EVM_ABI_Address_Value_Arg {
+                address
+              }
+              ... on EVM_ABI_BigInt_Value_Arg {
+                bigInteger
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+}
+
+export function transformResponse(
+  data: unknown,
+  config: SyncConfig,
+  facilitator: Facilitator,
+  facilitatorConfig: FacilitatorConfig
+): TransferEventData[] {
+  const events = (data as { EVM: { Events: EvmBitQueryEventRow[] } }).EVM
+    .Events;
+
+  return events.flatMap(event => {
+    const sender = getAddressArgument(event, 'from');
+    const recipient = getAddressArgument(event, 'to');
+    const amount = getBigIntArgument(event, 'value');
+
+    if (!sender || !recipient || !amount) {
+      logger.warn(
+        `[${config.chain}] Skipping Bitquery event with missing args for ${event.Transaction.Hash}`
+      );
+      return [];
+    }
+
+    return {
+      address: event.LogHeader.Address.toLowerCase(),
+      transaction_from: event.Transaction.From.toLowerCase(),
+      sender: sender.toLowerCase(),
+      recipient: recipient.toLowerCase(),
+      amount: Number(amount),
+      block_timestamp: new Date(event.Block.Time),
+      tx_hash: event.Transaction.Hash.toLowerCase(),
+      log_index: event.Log.EnterIndex,
+      chain: config.chain,
+      provider: config.provider,
+      decimals: facilitatorConfig.token.decimals,
+      facilitator_id: facilitator.id,
+    };
+  });
+}
+
+function getAddressArgument(
+  event: EvmBitQueryEventRow,
+  name: string
+): string | undefined {
+  return event.Arguments.find(argument => argument.Name === name)?.Value
+    .address;
+}
+
+function getBigIntArgument(
+  event: EvmBitQueryEventRow,
+  name: string
+): string | undefined {
+  return event.Arguments.find(argument => argument.Name === name)?.Value
+    .bigInteger;
+}

--- a/sync/transfers/trigger/chains/evm/base/bitquery/sync.ts
+++ b/sync/transfers/trigger/chains/evm/base/bitquery/sync.ts
@@ -1,0 +1,5 @@
+import { createChainSyncTask } from '../../../../sync';
+import { baseBitqueryConfig } from './config';
+
+export const baseBitquerySyncTransfers =
+  createChainSyncTask(baseBitqueryConfig);

--- a/sync/transfers/trigger/chains/evm/base/cdp/config.ts
+++ b/sync/transfers/trigger/chains/evm/base/cdp/config.ts
@@ -16,7 +16,7 @@ export const baseCdpConfig: SyncConfig = {
   facilitators: FACILITATORS_BY_CHAIN(Network.BASE),
   buildQuery,
   transformResponse,
-  enabled: true,
+  enabled: false,
   machine: 'medium-1x',
   splitSyncByFacilitator: true,
 };

--- a/sync/transfers/trigger/fetch/fetch.ts
+++ b/sync/transfers/trigger/fetch/fetch.ts
@@ -16,7 +16,12 @@ export async function fetchTransfers(
   facilitatorConfig: FacilitatorConfig,
   since: Date,
   now: Date,
-  onBatchFetched?: (batch: TransferEventData[]) => Promise<void>
+  onBatchFetched?: (batch: TransferEventData[]) => Promise<void>,
+  onWindowFetched?: (
+    windowStart: Date,
+    windowEnd: Date,
+    resultCount: number
+  ) => Promise<void>
 ): Promise<{ totalFetched: number }> {
   const strategy = config.paginationStrategy;
 
@@ -27,7 +32,8 @@ export async function fetchTransfers(
       facilitatorConfig,
       since,
       now,
-      onBatchFetched
+      onBatchFetched,
+      onWindowFetched
     );
   }
 
@@ -51,7 +57,12 @@ async function fetchWithWindow(
   facilitatorConfig: FacilitatorConfig,
   since: Date,
   now: Date,
-  onBatchFetched?: (batch: TransferEventData[]) => Promise<void>
+  onBatchFetched?: (batch: TransferEventData[]) => Promise<void>,
+  onWindowFetched?: (
+    windowStart: Date,
+    windowEnd: Date,
+    resultCount: number
+  ) => Promise<void>
 ): Promise<{ totalFetched: number }> {
   const provider = config.provider;
   let currentStart = new Date(since);
@@ -109,6 +120,10 @@ async function fetchWithWindow(
 
     if (onBatchFetched && results.length > 0) {
       await onBatchFetched(results);
+    }
+
+    if (onWindowFetched) {
+      await onWindowFetched(currentStart, currentEnd, results.length);
     }
 
     if (results.length >= config.limit) {

--- a/sync/transfers/trigger/sync.ts
+++ b/sync/transfers/trigger/sync.ts
@@ -1,9 +1,100 @@
-import { createManyTransferEvents, getTransferEvents } from '@/db/services';
+import {
+  advanceTransferSyncState,
+  createManyTransferEvents,
+  createTransferSyncState,
+  getTransferEvents,
+  getTransferSyncState,
+  markTransferSyncStateStarted,
+  recordTransferSyncStateError,
+  type TransferSyncStateKey,
+} from '@/db/services';
 import { logger, schedules } from '@trigger.dev/sdk/v3';
-import { Network } from './types';
+import { Network, QueryProvider } from './types';
 import { fetchTransfers } from './fetch/fetch';
 
-import type { Facilitator, SyncConfig } from './types';
+import type { Facilitator, FacilitatorConfig, SyncConfig } from './types';
+
+function normalizeAddress(chain: string, address: string): string {
+  return chain === Network.SOLANA.toString() ? address : address.toLowerCase();
+}
+
+function getSyncStateKey(
+  syncConfig: SyncConfig,
+  facilitator: Facilitator,
+  transactionFrom: string,
+  tokenAddress: string
+): TransferSyncStateKey {
+  return {
+    chain: syncConfig.chain,
+    provider: syncConfig.provider,
+    facilitator_id: facilitator.id,
+    transaction_from: transactionFrom,
+    token_address: normalizeAddress(syncConfig.chain, tokenAddress),
+  };
+}
+
+async function getBootstrapCursor(
+  syncConfig: SyncConfig,
+  facilitatorConfig: FacilitatorConfig,
+  transactionFrom: string
+) {
+  const mostRecentCdpTransfer = await getTransferEvents({
+    orderBy: { block_timestamp: 'desc' },
+    take: 1,
+    where: {
+      address: normalizeAddress(
+        syncConfig.chain,
+        facilitatorConfig.token.address
+      ),
+      chain: syncConfig.chain,
+      transaction_from: transactionFrom,
+      provider: QueryProvider.CDP,
+    },
+  });
+
+  const candidates = [
+    facilitatorConfig.syncStartDate,
+    syncConfig.syncStateCutoverAt,
+    mostRecentCdpTransfer[0]?.block_timestamp
+      ? new Date(mostRecentCdpTransfer[0].block_timestamp.getTime() + 1000)
+      : undefined,
+  ].filter((date): date is Date => date !== undefined);
+
+  return new Date(Math.max(...candidates.map(date => date.getTime())));
+}
+
+async function getOrCreateTransferSyncState(
+  syncConfig: SyncConfig,
+  facilitator: Facilitator,
+  facilitatorConfig: FacilitatorConfig,
+  transactionFrom: string
+) {
+  const key = getSyncStateKey(
+    syncConfig,
+    facilitator,
+    transactionFrom,
+    facilitatorConfig.token.address
+  );
+  const existing = await getTransferSyncState(key);
+
+  if (existing) {
+    return { key, state: existing };
+  }
+
+  const cursorTimestamp = await getBootstrapCursor(
+    syncConfig,
+    facilitatorConfig,
+    transactionFrom
+  );
+
+  logger.log(
+    `[${syncConfig.chain}] Bootstrapping sync state for ${facilitator.id}:${facilitatorConfig.address} at ${cursorTimestamp.toISOString()}`
+  );
+
+  const state = await createTransferSyncState(key, cursorTimestamp);
+
+  return { key, state };
+}
 
 async function syncFacilitator(
   syncConfig: SyncConfig,
@@ -24,15 +115,75 @@ async function syncFacilitator(
       `[${syncConfig.chain}] Getting most recent transfer for ${facilitator.id}:${facilitatorConfig.address}`
     );
 
+    const transactionFrom = normalizeAddress(
+      syncConfig.chain,
+      facilitatorConfig.address
+    );
+
+    if (syncConfig.useSyncState) {
+      const { key, state } = await getOrCreateTransferSyncState(
+        syncConfig,
+        facilitator,
+        facilitatorConfig,
+        transactionFrom
+      );
+      const since = state.cursor_timestamp;
+
+      logger.log(
+        `[${syncConfig.chain}] Syncing ${facilitator.id}:${facilitatorConfig.address} from sync state ${since.toISOString()} to ${now.toISOString()}`
+      );
+
+      await markTransferSyncStateStarted(key, now);
+
+      if (since >= now) {
+        logger.log(
+          `[${syncConfig.chain}] Sync state is current for ${facilitator.id}:${facilitatorConfig.address}`
+        );
+        await advanceTransferSyncState(key, since, new Date());
+        continue;
+      }
+
+      let totalSaved = 0;
+
+      try {
+        const { totalFetched } = await fetchTransfers(
+          syncConfig,
+          facilitator,
+          facilitatorConfig,
+          since,
+          now,
+          async batch => {
+            const syncResult = await createManyTransferEvents(batch);
+            totalSaved += syncResult.count;
+            logger.log(
+              `[${syncConfig.chain}] Saved ${syncResult.count} transfers (${batch.length} fetched, ${batch.length - syncResult.count} duplicates)`
+            );
+          },
+          async (_windowStart, windowEnd, resultCount) => {
+            await advanceTransferSyncState(key, windowEnd, new Date());
+            logger.log(
+              `[${syncConfig.chain}] Advanced sync state to ${windowEnd.toISOString()} after ${resultCount} fetched transfers`
+            );
+          }
+        );
+
+        logger.log(
+          `[${syncConfig.chain}] Completed ${facilitator.id}: ${totalFetched} fetched, ${totalSaved} saved`
+        );
+      } catch (error) {
+        await recordTransferSyncStateError(key, String(error));
+        throw error;
+      }
+
+      continue;
+    }
+
     const mostRecentTransfer = await getTransferEvents({
       orderBy: { block_timestamp: 'desc' },
       take: 1,
       where: {
         chain: syncConfig.chain,
-        transaction_from:
-          syncConfig.chain === Network.SOLANA.toString()
-            ? facilitatorConfig.address
-            : facilitatorConfig.address.toLowerCase(),
+        transaction_from: transactionFrom,
         provider: syncConfig.provider,
       },
     });

--- a/sync/transfers/trigger/types.ts
+++ b/sync/transfers/trigger/types.ts
@@ -80,6 +80,8 @@ export type SyncConfig = QueryConfig & {
   enabled: boolean;
   machine: 'small-1x' | 'medium-1x' | 'large-2x';
   splitSyncByFacilitator?: boolean;
+  useSyncState?: boolean;
+  syncStateCutoverAt?: Date;
 };
 
 export interface EvmChainConfig {
@@ -146,4 +148,34 @@ export interface BitQueryTransferRowStream {
     Hash: string;
     From: string;
   };
+}
+
+export interface EvmBitQueryEventRow {
+  Block: {
+    Time: string;
+    Number: number;
+  };
+  Transaction: {
+    Hash: string;
+    From: string;
+    Index: number;
+  };
+  LogHeader: {
+    Address: string;
+    Index: number | null;
+    Removed: boolean;
+  };
+  Log: {
+    EnterIndex: number;
+    Index: number | null;
+    LogAfterCallIndex: number | null;
+    SmartContract: string;
+  };
+  Arguments: {
+    Name: string;
+    Value: {
+      address?: string;
+      bigInteger?: string;
+    };
+  }[];
 }


### PR DESCRIPTION
## Summary
- add `TransferSyncState` to track provider sync cursors independently from transfer rows
- switch Base transfers from CDP to Bitquery Events with one-hour sync-state windows
- bootstrap Base Bitquery cursors from `max(cutoverAt, latest CDP transfer + 1s, syncStartDate)` so stale facilitators do not backfill old empty history
- keep Solana behavior unchanged

## Migration
- migration creates only a new empty `TransferSyncState` table and indexes
- applied manually to test and prod transfer DBs before this PR was opened
