### PR TITLE
fix: use --primary color for share button

### DIFF
--- a/apps/scan/src/app/(app)/@breadcrumbs/server/[id]/layout.tsx
+++ b/apps/scan/src/app/(app)/@breadcrumbs/server/[id]/layout.tsx
@@ -4,7 +4,7 @@ import { Breadcrumb } from '../../_components/breadcrumb';
 
 import { Separator } from '../../_components/separator';
 import { api } from '@/trpc/server';
-import { cleanExternalText } from '@/lib/utils';
+import { cleanExternalText, truncateAtDelimiter } from '@/lib/utils';
 import { notFound } from 'next/navigation';
 
 export default async function OriginLayout({
@@ -31,7 +31,7 @@ export default async function OriginLayout({
         image={origin.favicon}
         name={
           origin.title
-            ? cleanExternalText(origin.title)
+            ? truncateAtDelimiter(cleanExternalText(origin.title))
             : new URL(origin.origin).hostname
         }
         Fallback={Wallet}

--- a/apps/scan/src/app/(app)/server/[id]/(overview)/_components/share-modal.tsx
+++ b/apps/scan/src/app/(app)/server/[id]/(overview)/_components/share-modal.tsx
@@ -274,7 +274,7 @@ export const ShareModal: React.FC<Props> = ({
   return (
     <Dialog onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
-        <button className="shrink-0 inline-flex items-center gap-1 px-2.5 py-1.5 rounded-md bg-[#0052ff] hover:bg-[#0045dd] text-white text-xs font-medium cursor-pointer">
+        <button className="shrink-0 inline-flex items-center gap-1 px-2.5 py-1.5 rounded-md bg-primary hover:bg-primary/90 text-primary-foreground text-xs font-medium cursor-pointer">
           <Share2 className="size-3" />
           Share
         </button>


### PR DESCRIPTION
## Summary
- Replaces hardcoded `bg-[#0052ff]` / `hover:bg-[#0045dd]` with `bg-primary` / `hover:bg-primary/90` on the Share button in origin pages
- Truncates origin titles at delimiters (` – `, ` - `, ` | `, etc.) in the breadcrumb nav, matching the existing pattern in the header and featured columns

## Test plan
- [ ] Visit an origin page with a long title containing delimiters (e.g. "BlockRun – YOPO...") and verify the breadcrumb shows only the first segment
- [ ] Verify the Share button matches the `--primary` theme color
- [ ] Check both light and dark modes