### PR TITLE
fix: exclude deprecated resources from accepts address mapping

### DIFF
--- a/apps/scan/src/services/db/resources/accepts.ts
+++ b/apps/scan/src/services/db/resources/accepts.ts
@@ -24,28 +24,25 @@ export const getAcceptsAddresses = async (input: GetAcceptsAddressesInput) => {
     },
     where: {
       network: chain as AcceptsNetwork,
-      ...(tags || originUrls
-        ? {
-            resourceRel: {
-              ...(tags
-                ? {
-                    tags: {
-                      some: {
-                        tag: { name: { in: tags } },
-                      },
-                    },
-                  }
-                : {}),
-              ...(originUrls
-                ? {
-                    origin: {
-                      origin: { in: originUrls },
-                    },
-                  }
-                : {}),
-            },
-          }
-        : {}),
+      resourceRel: {
+        deprecatedAt: null,
+        ...(tags
+          ? {
+              tags: {
+                some: {
+                  tag: { name: { in: tags } },
+                },
+              },
+            }
+          : {}),
+        ...(originUrls
+          ? {
+              origin: {
+                origin: { in: originUrls },
+              },
+            }
+          : {}),
+      },
     },
   });
 


### PR DESCRIPTION
## Summary

- Filters `deprecatedAt: null` on `resourceRel` in `getAcceptsAddresses` so deprecated resources never contribute to the payTo → origin mapping
- Fixes ghost "+1" origin counts on Featured Services (e.g., StableMerch showing "+1" from stablemerch.dev's deprecated records sharing stableemail.dev's payTo)
- Fixes inflated transaction stats (StableMerch showing 7.86k txs instead of ~7 — it was inheriting stableemail's stats through the shared deprecated payTo)

## Root cause

`getAcceptsAddresses` only applied the `resourceRel` filter when `tags` or `originUrls` were provided. Without either, no `resourceRel` filter was set at all, so deprecated resources' accepts records were included. The fix always sets `resourceRel: { deprecatedAt: null, ... }` regardless of other filters.

## Test plan

- [x] Preview deploy: Featured Services no longer shows "+1" on StableMerch
- [x] Preview deploy: StableMerch tx count matches actual stats (~7 txs, $115 volume)
- [ ] Spot-check other origins — no active origins disappeared