### PR TITLE
fix: align cache warming page size with transactions page

### DIFF
--- a/apps/scan/src/app/(app)/(home)/transactions/constants.ts
+++ b/apps/scan/src/app/(app)/(home)/transactions/constants.ts
@@ -1,0 +1,1 @@
+export const TRANSACTIONS_PAGE_SIZE = 10;

--- a/apps/scan/src/app/(app)/(home)/transactions/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/transactions/page.tsx
@@ -16,6 +16,8 @@ import { ActivityTimeframe } from '@/types/timeframes';
 
 import { api, HydrateClient } from '@/trpc/server';
 
+import { TRANSACTIONS_PAGE_SIZE } from './constants';
+
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -28,7 +30,7 @@ export default async function TransactionsPage({
 }: PageProps<'/transactions'>) {
   const chain = await getChainForPage(await searchParams);
 
-  const pageSize = 10;
+  const pageSize = TRANSACTIONS_PAGE_SIZE;
 
   void api.public.transfers.list.prefetch({
     sorting: defaultTransfersSorting,

--- a/apps/scan/src/app/api/cron/warm-cache/route.ts
+++ b/apps/scan/src/app/api/cron/warm-cache/route.ts
@@ -7,6 +7,7 @@ import { defaultTransfersSorting } from '@/app/(app)/_contexts/sorting/transfers
 import { ActivityTimeframe } from '@/types/timeframes';
 import { facilitatorAddresses } from '@/lib/facilitators';
 import { CACHE_DURATION_MINUTES } from '@/lib/cache-constants';
+import { TRANSACTIONS_PAGE_SIZE } from '@/app/(app)/(home)/transactions/constants';
 import { Chain } from '@/types/chain';
 
 import type { NextRequest } from 'next/server';
@@ -87,7 +88,7 @@ function getHomePageTasks(
   timeframe: ActivityTimeframe,
   chain?: Chain
 ): (() => Promise<unknown>)[] {
-  const transactionsLimit = 15;
+  const transactionsLimit = TRANSACTIONS_PAGE_SIZE;
 
   return [
     // Overall Stats - current period


### PR DESCRIPTION
## Summary
- The cache warming cron used `page_size=15` while the `/transactions` page uses `page_size=10`, producing different cache keys
- Page 0 was never warmed by the cron, so it served stale data for up to 30 min while subsequent pages fetched fresh from the DB — showing newer transactions than page 1
- Extracted `TRANSACTIONS_PAGE_SIZE` constant so both the page and the cron reference the same value

## Test plan
- [x] Verify `/transactions` page 1 shows the most recent transactions
- [x] Verify cache warming logs show the same cache key as user requests for page 0
- [x] Check that paginating forward doesn't show newer data than page 1