### PR TITLE
fix: clean up orphaned origin rows after failed bulk registration

### DIFF
--- a/apps/scan/src/lib/discovery/register-origin.ts
+++ b/apps/scan/src/lib/discovery/register-origin.ts
@@ -9,7 +9,6 @@ import {
 } from '@/services/db/resources/origin';
 import { notifyNewServer } from '@/lib/discord-notifications';
 import { getOriginFromUrl, normalizeResourceUrl } from '@/lib/url';
-import { scanDb } from '@x402scan/scan-db';
 import { scrapeOriginData } from '@/services/scraper';
 
 import type {
@@ -115,20 +114,6 @@ export async function registerResourcesFromDiscovery(
       uniqueOrigins.map(
         async origin => [origin, await getOriginResourceCount(origin)] as const
       )
-    )
-  );
-
-  // Pre-create origin rows outside transactions to prevent P2002 races.
-  // When multiple resources from the same origin register concurrently,
-  // each transaction's resourceOrigin.upsert() can race on INSERT.
-  // Top-level upserts use native INSERT ON CONFLICT, which is safe.
-  await Promise.all(
-    uniqueOrigins.map(origin =>
-      scanDb.resourceOrigin.upsert({
-        where: { origin },
-        create: { origin },
-        update: {},
-      })
     )
   );
 
@@ -383,6 +368,19 @@ export async function registerResourcesFromDiscovery(
     }
   }
 
+  // Only scrape metadata for origins that have resources (either newly
+  // registered in this batch or pre-existing). Origins where every resource
+  // failed have no origin row — scraping would cause upsertOrigin to create
+  // one, re-introducing the orphan problem.
+  const originsWithResources = new Set(
+    [...successfulResults, ...siwxResults].map(r => getOriginFromUrl(r.url))
+  );
+  const originsToScrape = uniqueOrigins.filter(
+    origin =>
+      originsWithResources.has(origin) ||
+      (originResourceCounts.get(origin) ?? 0) > 0
+  );
+
   // Scrape and upsert origin metadata once per unique origin (deduped).
   // Individual registerResource/registerSiwxResource calls skip this
   // (skipMetadataScrape: true) so the scrape+upsert happens exactly once
@@ -392,7 +390,7 @@ export async function registerResourcesFromDiscovery(
   // was unreliable (the deferred scrape+upsert could be killed before
   // completing, leaving stale ICO URLs in the DB).
   await Promise.all(
-    uniqueOrigins.map(async origin => {
+    originsToScrape.map(async origin => {
       try {
         const { og, metadata, favicon } = await scrapeOriginData(origin);
         const title =

--- a/apps/scan/src/lib/resources.ts
+++ b/apps/scan/src/lib/resources.ts
@@ -1,6 +1,7 @@
 import { scrapeOriginData } from '@/services/scraper';
 import { upsertResource } from '@/services/db/resources/resource';
 import {
+  ensureOriginExists,
   getOriginResourceCount,
   upsertOrigin,
 } from '@/services/db/resources/origin';
@@ -185,11 +186,7 @@ export async function registerSiwxResource(
 
   try {
     const resource = await scanDb.$transaction(async tx => {
-      await tx.resourceOrigin.upsert({
-        where: { origin },
-        create: { origin },
-        update: {},
-      });
+      await ensureOriginExists(tx, origin);
 
       const siwxMetadata = {
         authMode: 'siwx' as const,

--- a/apps/scan/src/services/db/resources/origin.ts
+++ b/apps/scan/src/services/db/resources/origin.ts
@@ -67,6 +67,22 @@ const originSchema = z.object({
   ogImages: z.array(ogImageSchema),
 });
 
+/**
+ * Atomic origin ensure-exists. Uses raw INSERT ON CONFLICT so it's immune to
+ * the SELECT→INSERT P2002 race that Prisma's upsert suffers inside concurrent
+ * transactions.
+ */
+export async function ensureOriginExists(
+  tx: Prisma.TransactionClient,
+  origin: string
+) {
+  await tx.$executeRaw`
+    INSERT INTO "ResourceOrigin" ("id", "origin", "createdAt", "updatedAt")
+    VALUES (gen_random_uuid(), ${origin}, now(), now())
+    ON CONFLICT ("origin") DO NOTHING
+  `;
+}
+
 export const upsertOrigin = async (
   originInput: z.input<typeof originSchema>
 ) => {

--- a/apps/scan/src/services/db/resources/resource.ts
+++ b/apps/scan/src/services/db/resources/resource.ts
@@ -9,6 +9,7 @@ import { supportedChainSchema } from '@/lib/schemas';
 import { SUPPORTED_CHAINS } from '@/types/chain';
 
 import { upsertResourceSchema } from './resource-schema';
+import { ensureOriginExists } from './origin';
 
 import type { PaginatedQueryParams } from '@/lib/pagination';
 import type { AcceptsNetwork, Prisma } from '@x402scan/scan-db';
@@ -42,13 +43,7 @@ export const upsertResource = async (
   const originStr = getOriginFromUrl(baseResource.resource);
 
   return await scanDb.$transaction(async tx => {
-    // Ensure the origin exists inside the transaction to avoid
-    // concurrent connectOrCreate race conditions (P2002).
-    await tx.resourceOrigin.upsert({
-      where: { origin: originStr },
-      create: { origin: originStr },
-      update: {},
-    });
+    await ensureOriginExists(tx, originStr);
 
     // Merge new metadata with existing to avoid clobbering fields set by
     // a different registration path (e.g. paid sets pricingMode, siwx sets


### PR DESCRIPTION
## Summary

`registerResourcesFromDiscovery` pre-creates `ResourceOrigin` rows outside transactions to prevent P2002 races during concurrent resource registration. If all resources fail, the empty origin persists — 229 orphans accumulated in prod.

**Root cause**: Prisma's `upsert` inside a transaction does SELECT → INSERT, which races when concurrent transactions both see "no row" and both INSERT. The workaround was pre-creating origins outside the transaction, but that decouples origin creation from resource creation.

**Fix**: Replace Prisma's in-transaction `upsert` with raw `INSERT ON CONFLICT DO NOTHING` — a single atomic Postgres statement that eliminates the P2002 race. This means:
- Origins are only created inside the same transaction that creates a resource — orphans are impossible by construction
- The pre-creation block is deleted entirely
- No cleanup code needed
- `ensureOriginExists()` helper in `services/db/resources/origin.ts` centralizes the pattern

Also filters metadata scraping to skip fully-failed origins, preventing `upsertOrigin()` from re-creating orphans through the metadata enrichment path.

## Test plan

Tested against a Neon branch database (forked from prod, 3030 origins, 229 orphans):

- [x] Atomic INSERT creates origin row correctly
- [x] Second INSERT is no-op (same ID preserved, ON CONFLICT DO NOTHING)
- [x] 6 concurrent transactions on same origin — all succeed, 0 P2002 errors, exactly 1 origin row
- [x] No orphan created when resources fail (orphan count unchanged: 229 → 229)
- [x] Existing origins with resources are untouched (DO NOTHING preserves them)
- [x] Type checks pass, CI green