### PR TITLE
fix: stale fallback for discover origins cache

### DIFF
--- a/apps/scan/src/lib/discover/origins.test.ts
+++ b/apps/scan/src/lib/discover/origins.test.ts
@@ -11,27 +11,17 @@ vi.mock('@/lib/cache', () => ({
   CACHE_TTL_SECONDS: 60,
 }));
 
-const mockRedis = {
-  get: vi.fn().mockResolvedValue(null),
-  setex: vi.fn().mockResolvedValue('OK'),
-};
-
 vi.mock('@/lib/redis', () => ({
-  getRedisClient: () => mockRedis,
+  getRedisClient: () => null,
 }));
 
-import {
-  fetchUsedOriginsFromAgentCash,
-  getDiscoverOrigins,
-} from './origins';
+import { fetchUsedOriginsFromAgentCash } from './origins';
 
 const originalFetch = global.fetch;
 
 describe('fetchUsedOriginsFromAgentCash', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
-    mockRedis.get.mockResolvedValue(null);
-    mockRedis.setex.mockResolvedValue('OK');
   });
 
   afterEach(() => {
@@ -134,99 +124,5 @@ describe('fetchUsedOriginsFromAgentCash', () => {
     const result = await fetchUsedOriginsFromAgentCash('x402');
 
     expect(result).toBeNull();
-  });
-});
-
-describe('getDiscoverOrigins', () => {
-  const ORIGINS = ['https://a.example.com', 'https://b.example.com'];
-  const CACHE_KEY = 'discover:origins:catalog:v1';
-  const STALE_KEY = 'discover:origins:catalog:v1:stale';
-
-  function mockAgentCashResponse(origins: string[]) {
-    global.fetch = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ origins }), {
-        status: 200,
-        headers: { 'content-type': 'application/json' },
-      })
-    ) as unknown as typeof fetch;
-  }
-
-  function mockAgentCashDown() {
-    global.fetch = vi
-      .fn()
-      .mockResolvedValue(
-        new Response('down', { status: 503 })
-      ) as unknown as typeof fetch;
-  }
-
-  beforeEach(() => {
-    mockRedis.get.mockReset().mockResolvedValue(null);
-    mockRedis.setex.mockReset().mockResolvedValue('OK');
-  });
-
-  afterEach(() => {
-    global.fetch = originalFetch;
-  });
-
-  it('returns cached result on cache hit without calling AgentCash', async () => {
-    mockRedis.get.mockResolvedValue(JSON.stringify(ORIGINS));
-    const fetchSpy = vi.fn();
-    global.fetch = fetchSpy as unknown as typeof fetch;
-
-    const result = await getDiscoverOrigins();
-
-    expect(result).toEqual(ORIGINS);
-    expect(fetchSpy).not.toHaveBeenCalled();
-  });
-
-  it('caches fresh result and writes stale fallback', async () => {
-    mockAgentCashResponse(ORIGINS);
-
-    const result = await getDiscoverOrigins();
-
-    expect(result).toEqual(ORIGINS);
-    expect(mockRedis.setex).toHaveBeenCalledWith(
-      CACHE_KEY,
-      60,
-      JSON.stringify(ORIGINS)
-    );
-    expect(mockRedis.setex).toHaveBeenCalledWith(
-      STALE_KEY,
-      86400,
-      JSON.stringify(ORIGINS)
-    );
-  });
-
-  it('does not cache empty result', async () => {
-    mockAgentCashDown();
-
-    await getDiscoverOrigins();
-
-    expect(mockRedis.setex).not.toHaveBeenCalledWith(
-      CACHE_KEY,
-      expect.anything(),
-      expect.anything()
-    );
-  });
-
-  it('returns stale fallback when AgentCash returns empty', async () => {
-    mockAgentCashDown();
-    // Primary cache miss, but stale key exists
-    mockRedis.get
-      .mockResolvedValueOnce(null) // primary cache miss
-      .mockResolvedValueOnce(JSON.stringify(ORIGINS)); // stale hit
-
-    const result = await getDiscoverOrigins();
-
-    expect(result).toEqual(ORIGINS);
-    expect(mockRedis.get).toHaveBeenCalledWith(STALE_KEY);
-  });
-
-  it('returns empty when AgentCash is down and no stale fallback', async () => {
-    mockAgentCashDown();
-
-    const result = await getDiscoverOrigins();
-
-    expect(result).toEqual([]);
   });
 });

--- a/apps/scan/src/lib/discover/origins.test.ts
+++ b/apps/scan/src/lib/discover/origins.test.ts
@@ -11,17 +11,27 @@ vi.mock('@/lib/cache', () => ({
   CACHE_TTL_SECONDS: 60,
 }));
 
+const mockRedis = {
+  get: vi.fn().mockResolvedValue(null),
+  setex: vi.fn().mockResolvedValue('OK'),
+};
+
 vi.mock('@/lib/redis', () => ({
-  getRedisClient: () => null,
+  getRedisClient: () => mockRedis,
 }));
 
-import { fetchUsedOriginsFromAgentCash } from './origins';
+import {
+  fetchUsedOriginsFromAgentCash,
+  getDiscoverOrigins,
+} from './origins';
 
 const originalFetch = global.fetch;
 
 describe('fetchUsedOriginsFromAgentCash', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    mockRedis.get.mockResolvedValue(null);
+    mockRedis.setex.mockResolvedValue('OK');
   });
 
   afterEach(() => {
@@ -124,5 +134,99 @@ describe('fetchUsedOriginsFromAgentCash', () => {
     const result = await fetchUsedOriginsFromAgentCash('x402');
 
     expect(result).toBeNull();
+  });
+});
+
+describe('getDiscoverOrigins', () => {
+  const ORIGINS = ['https://a.example.com', 'https://b.example.com'];
+  const CACHE_KEY = 'discover:origins:catalog:v1';
+  const STALE_KEY = 'discover:origins:catalog:v1:stale';
+
+  function mockAgentCashResponse(origins: string[]) {
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ origins }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    ) as unknown as typeof fetch;
+  }
+
+  function mockAgentCashDown() {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response('down', { status: 503 })
+      ) as unknown as typeof fetch;
+  }
+
+  beforeEach(() => {
+    mockRedis.get.mockReset().mockResolvedValue(null);
+    mockRedis.setex.mockReset().mockResolvedValue('OK');
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('returns cached result on cache hit without calling AgentCash', async () => {
+    mockRedis.get.mockResolvedValue(JSON.stringify(ORIGINS));
+    const fetchSpy = vi.fn();
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const result = await getDiscoverOrigins();
+
+    expect(result).toEqual(ORIGINS);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('caches fresh result and writes stale fallback', async () => {
+    mockAgentCashResponse(ORIGINS);
+
+    const result = await getDiscoverOrigins();
+
+    expect(result).toEqual(ORIGINS);
+    expect(mockRedis.setex).toHaveBeenCalledWith(
+      CACHE_KEY,
+      60,
+      JSON.stringify(ORIGINS)
+    );
+    expect(mockRedis.setex).toHaveBeenCalledWith(
+      STALE_KEY,
+      86400,
+      JSON.stringify(ORIGINS)
+    );
+  });
+
+  it('does not cache empty result', async () => {
+    mockAgentCashDown();
+
+    await getDiscoverOrigins();
+
+    expect(mockRedis.setex).not.toHaveBeenCalledWith(
+      CACHE_KEY,
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it('returns stale fallback when AgentCash returns empty', async () => {
+    mockAgentCashDown();
+    // Primary cache miss, but stale key exists
+    mockRedis.get
+      .mockResolvedValueOnce(null) // primary cache miss
+      .mockResolvedValueOnce(JSON.stringify(ORIGINS)); // stale hit
+
+    const result = await getDiscoverOrigins();
+
+    expect(result).toEqual(ORIGINS);
+    expect(mockRedis.get).toHaveBeenCalledWith(STALE_KEY);
+  });
+
+  it('returns empty when AgentCash is down and no stale fallback', async () => {
+    mockAgentCashDown();
+
+    const result = await getDiscoverOrigins();
+
+    expect(result).toEqual([]);
   });
 });

--- a/apps/scan/src/lib/discover/origins.ts
+++ b/apps/scan/src/lib/discover/origins.ts
@@ -4,6 +4,9 @@ import { getRedisClient } from '@/lib/redis';
 
 const PROTOCOL = 'x402';
 const CACHE_KEY = 'discover:origins:catalog:v1';
+/** Long-lived fallback so a transient AgentCash outage doesn't wipe the list */
+const STALE_CACHE_KEY = 'discover:origins:catalog:v1:stale';
+const STALE_TTL_SECONDS = 86400; // 24 hours
 
 /**
  * Calls AgentCash's internal used-origins endpoint. Returns the ordered list
@@ -97,11 +100,23 @@ export const getDiscoverOrigins = async (): Promise<string[]> => {
   const result = await getDiscoverOriginsUncached();
 
   if (redis) {
-    await redis
-      .setex(CACHE_KEY, CACHE_TTL_SECONDS, JSON.stringify(result))
-      .catch(() => {
+    if (result.length > 0) {
+      await Promise.all([
+        redis.setex(CACHE_KEY, CACHE_TTL_SECONDS, JSON.stringify(result)),
+        redis.setex(STALE_CACHE_KEY, STALE_TTL_SECONDS, JSON.stringify(result)),
+      ]).catch(() => {
         /* cache write is best-effort */
       });
+    } else {
+      // AgentCash returned empty — serve stale data rather than nothing
+      const stale = await redis.get(STALE_CACHE_KEY).catch(() => null);
+      if (stale) {
+        console.warn(
+          '[discover] AgentCash returned empty, using stale fallback'
+        );
+        return JSON.parse(stale) as string[];
+      }
+    }
   }
 
   return result;


### PR DESCRIPTION
## Summary
- When AgentCash is temporarily unavailable, `getDiscoverOrigins()` was caching the empty result for 30 minutes — blanking the Featured Services page on the homepage
- Now empty results are never cached, and a long-lived stale key (24h TTL) provides a fallback so the page stays populated through transient outages

## How it works
- Good AgentCash response → cached normally (30 min) + saved as stale fallback (24h)
- Empty AgentCash response → serve stale fallback instead of nothing
- Everything fails → returns `[]` (same graceful degradation as before)

## Test plan
- [x] Verify Featured Services page loads with data on production
- [x] Confirm stale key is written alongside primary cache key in Redis