### PR TITLE
UI polish: CTA, colors, spacing, skip action

### DIFF
--- a/apps/scan/public/wallet-poncho.svg
+++ b/apps/scan/public/wallet-poncho.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" width="1000" height="1000"><metadata><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/"><rdf:Description><dc:creator>RealFaviconGenerator</dc:creator><dc:source>https://realfavicongenerator.net</dc:source></rdf:Description></rdf:RDF></metadata><g clip-path="url(#SvgjsClipPath1111)"><rect width="1000" height="1000" fill="#262624"></rect><g transform="matrix(2.681992337164751,0,0,2.681992337164751,196.89463601532566,150)"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="Layer_1" data-name="Layer 1" viewBox="0 0 226.03 261" width="226.03" height="261"><defs>
+    <style>
+      .cls-1 {
+        fill: none;
+      }
+
+      .cls-2 {
+        clip-path: url(#clippath);
+      }
+
+      .cls-3 {
+        fill: #7f0404;
+      }
+
+      .cls-4 {
+        fill: #DFE2D9;
+      }
+
+      .cls-5 {
+        fill: #a50404;
+      }
+
+      .cls-6 {
+        fill: #cd0202;
+        opacity: .9;
+      }
+    </style>
+    <clipPath id="clippath">
+      <rect class="cls-1" x="-2246.03" y="-677" width="2000" height="3017"></rect>
+    </clipPath>
+  <clipPath id="SvgjsClipPath1111"><rect width="1000" height="1000" x="0" y="0" rx="350" ry="350"></rect></clipPath></defs><polygon class="cls-6" points="59.23 99.45 59.23 161.55 113.02 192.61 113.02 130.5 59.23 99.45"></polygon><polygon class="cls-5" points="113.02 68.39 113.02 68.39 59.23 99.45 113.02 130.5 166.8 99.45 113.02 68.39"></polygon><polygon class="cls-3" points="166.8 99.45 113.02 130.5 113.02 192.61 113.02 192.61 166.8 161.55 166.8 99.45"></polygon><g>
+    <path class="cls-4" d="m113.02,196.41l-57.08-32.95v-65.91l57.08-32.95,57.08,32.95v65.91l-57.08,32.95Zm-52.53-35.58l52.53,30.33,52.53-30.33v-60.66l-52.53-30.33-52.53,30.33v60.66Z"></path>
+    <path class="cls-4" d="m113.02,261L0,195.75V65.25L113.02,0l113.02,65.25v130.5l-113.02,65.25ZM6.82,191.81l106.2,61.31,106.2-61.31v-122.62L113.02,7.88,6.82,69.19v122.62Z"></path>
+    <rect class="cls-4" x="111.88" y="3.94" width="2.27" height="63.28"></rect>
+    <rect class="cls-4" x="-.83" y="176.82" width="63.28" height="2.27" transform="translate(-84.84 39.24) rotate(-29.99)"></rect>
+    <rect class="cls-4" x="194.08" y="146.32" width="2.27" height="63.28" transform="translate(-56.51 258.05) rotate(-60)"></rect>
+    <rect class="cls-4" x="111.88" y="130.5" width="2.27" height="126.56"></rect>
+    <rect class="cls-4" x="104.54" y="97.72" width="126.56" height="2.27" transform="translate(-26.95 97.14) rotate(-29.99)"></rect>
+    <rect class="cls-4" x="57.08" y="35.58" width="2.27" height="126.56" transform="translate(-56.51 99.84) rotate(-60)"></rect>
+  </g><g class="cls-2">
+    <image width="1856" height="2464" transform="translate(-2534.13 -861.53) scale(1.37)" xlink:href="srags_Computer_terminal_high_tech_interface_to_labor_coordinati_2bd089c7-4038-4d4f-a649-cfed17d9f3eb.png"></image>
+  </g></svg></g></g></svg>

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -538,7 +538,7 @@ export const RegisterResourceForm = () => {
                 {failedResources.length === 1 ? '' : 's'} with errors
               </button>
             </CollapsibleTrigger>
-            <CollapsibleContent className="pt-2 space-y-3">
+            <CollapsibleContent className="pt-2 space-y-2">
               <p className="text-xs text-muted-foreground">
                 <strong>
                   {failedResources.length} endpoint
@@ -592,7 +592,7 @@ export const RegisterResourceForm = () => {
                 (Not blocking)
               </button>
             </CollapsibleTrigger>
-            <CollapsibleContent className="pt-2 space-y-3">
+            <CollapsibleContent className="pt-2 space-y-2">
               <p className="text-xs text-muted-foreground">
                 These endpoints will still be registered, but have issues that
                 may affect agent compatibility.
@@ -837,6 +837,14 @@ function PostRegistrationDialog({
                       'Submit'
                     )}
                   </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    className="text-muted-foreground"
+                    onClick={() => setOpen(false)}
+                  >
+                    Skip
+                  </Button>
                 </form>
               ) : (
                 contactEmail && (
@@ -847,7 +855,7 @@ function PostRegistrationDialog({
               )}
             </ChecklistStep>
 
-            <div className="border-t pt-2">
+            <div className="border-t pt-3 -mx-6 px-6">
               <p className="text-xs text-muted-foreground text-center">
                 Share your merchant page:{' '}
                 <Link
@@ -893,7 +901,7 @@ function ChecklistStep({
 }) {
   return (
     <div
-      className={`flex items-start gap-3 rounded-lg px-3 py-2.5 -mx-3 transition-colors ${
+      className={`flex ${label ? 'items-start' : 'items-center'} gap-3 rounded-lg px-3 py-2.5 -mx-3 transition-colors ${
         current
           ? 'bg-primary/5 dark:bg-primary/10'
           : completed
@@ -1169,7 +1177,7 @@ function ProbeResult({
                   ) : invalidKeys.has(k) ? (
                     <X className="size-3 text-red-500 shrink-0" />
                   ) : siwxKeys.has(k) ? (
-                    <Check className="size-3 text-blue-500 shrink-0" />
+                    <Check className="size-3 text-primary shrink-0" />
                   ) : warningKeys.has(k) ? (
                     <TriangleAlert className="size-3 text-yellow-500 shrink-0" />
                   ) : testedKeys.has(k) ? (

--- a/apps/scan/src/app/(app)/(home)/resources/register/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { Send, Mail } from 'lucide-react';
+import { Send, Mail, CalendarDays } from 'lucide-react';
 import { Body } from '@/app/_components/layout/page-utils';
 import { RegisterResourceForm } from './_components/form';
 import { DiscoveryActions } from './_components/discovery-actions';
@@ -50,6 +50,14 @@ export default function RegisterResourcePage() {
                 className="hover:text-foreground transition-colors"
               >
                 <Mail className="size-3.5" />
+              </a>
+              <a
+                href="https://calendar.google.com/calendar/appointments/schedules/AcZssZ1JmDUvMb4QVktX4PscRA66DEAQCLHLJKRKvwFogirtp9JZ0s5l-Vj96Nthl3M16qDPOprzsK6U"
+                target="_blank"
+                rel="noreferrer"
+                className="hover:text-foreground transition-colors"
+              >
+                <CalendarDays className="size-3.5" />
               </a>
             </ExpandableLink>
           </div>

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
@@ -1280,7 +1280,7 @@ function RegisterModeResourceList({
                       className={cn(
                         'text-xs px-1.5 py-0.5 rounded',
                         resourceSource === 'entered'
-                          ? 'bg-blue-500/10 text-blue-600'
+                          ? 'bg-primary/10 text-primary'
                           : 'bg-muted text-muted-foreground'
                       )}
                     >

--- a/apps/scan/src/app/(app)/_components/resources/resource-card.tsx
+++ b/apps/scan/src/app/(app)/_components/resources/resource-card.tsx
@@ -63,7 +63,13 @@ export const ResourceCard: React.FC<Props> = ({
       {!isFlat && (
         <div className="absolute left-0 top-[calc(2rem+5px)] w-4 h-px bg-border" />
       )}
-      <Card className={cn(className, 'overflow-hidden')}>
+      <Card
+        className={cn(
+          className,
+          'overflow-hidden',
+          !isFlat && 'border-0 shadow-none'
+        )}
+      >
         <CardHeader className="bg-muted w-full flex flex-row items-center justify-between space-y-0 px-4 py-2 gap-4">
           <Header
             resource={resource}

--- a/apps/scan/src/app/(app)/admin/end-users/_components/columns.tsx
+++ b/apps/scan/src/app/(app)/admin/end-users/_components/columns.tsx
@@ -17,7 +17,7 @@ const AuthMethodBadge = ({
 }) => {
   if (method.type === 'email') {
     return (
-      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-blue-500/10 text-blue-600 text-xs">
+      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-primary/10 text-primary text-xs">
         Email: {method.email}
       </span>
     );

--- a/apps/scan/src/app/(app)/admin/resource-search/_components/table/columns.tsx
+++ b/apps/scan/src/app/(app)/admin/resource-search/_components/table/columns.tsx
@@ -55,7 +55,7 @@ export const createColumns = (): ExtendedColumnDef<FilteredSearchResult>[] => [
         matchPercentage === 100
           ? 'bg-green-500/10 text-green-500 border-green-500/20'
           : matchPercentage >= 60
-            ? 'bg-blue-500/10 text-blue-500 border-blue-500/20'
+            ? 'bg-primary/10 text-primary border-primary/20'
             : matchPercentage >= 40
               ? 'bg-yellow-500/10 text-yellow-500 border-yellow-500/20'
               : 'bg-red-500/10 text-red-500 border-red-500/20';
@@ -191,7 +191,7 @@ export const createColumns = (): ExtendedColumnDef<FilteredSearchResult>[] => [
 
       return (
         <div className="flex items-center gap-2">
-          <TrendingUp className="h-3.5 w-3.5 text-blue-500" />
+          <TrendingUp className="h-3.5 w-3.5 text-primary" />
           <span className="text-sm font-medium">
             {formatNumber(analytics.totalCalls)} calls
           </span>

--- a/apps/scan/src/app/(app)/developer/_components/ngrok-alert.tsx
+++ b/apps/scan/src/app/(app)/developer/_components/ngrok-alert.tsx
@@ -30,29 +30,29 @@ export function NgrokAlert({ port }: NgrokAlertProps) {
   };
 
   return (
-    <div className="rounded-lg border border-blue-200 bg-blue-50 dark:bg-blue-950/20 dark:border-blue-900 p-4 relative">
+    <div className="rounded-lg border border-primary/20 bg-primary/5 dark:bg-primary/10 p-4 relative">
       <button
         onClick={() => setDismissed(true)}
-        className="absolute top-2 right-2 text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-200"
+        className="absolute top-2 right-2 text-primary hover:text-primary/70"
         aria-label="Dismiss"
       >
         <X className="size-4" />
       </button>
 
       <div className="flex gap-3">
-        <Info className="size-5 text-blue-600 dark:text-blue-400 shrink-0 mt-0.5" />
+        <Info className="size-5 text-primary shrink-0 mt-0.5" />
         <div className="flex-1 pr-6">
-          <h3 className="font-semibold text-sm mb-2 text-blue-900 dark:text-blue-100">
+          <h3 className="font-semibold text-sm mb-2">
             Need to test a local endpoint?
           </h3>
-          <div className="text-sm space-y-3 text-blue-800 dark:text-blue-200">
+          <div className="text-sm space-y-3 text-muted-foreground">
             <p>
               x402scan runs in production and can&apos;t reach localhost URLs.
               Use <strong>ngrok</strong> to create a public tunnel to your local
               server.
             </p>
 
-            <div className="bg-blue-100 dark:bg-blue-900/40 rounded-md p-3 font-mono text-xs flex items-center justify-between gap-2">
+            <div className="bg-primary/10 rounded-md p-3 font-mono text-xs flex items-center justify-between gap-2">
               <code className="flex-1">{ngrokCommand}</code>
               <Button
                 variant="ghost"
@@ -70,11 +70,7 @@ export function NgrokAlert({ port }: NgrokAlertProps) {
 
             <Collapsible>
               <CollapsibleTrigger asChild>
-                <Button
-                  variant="link"
-                  size="sm"
-                  className="h-auto p-0 text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-200"
-                >
+                <Button variant="link" size="sm" className="h-auto p-0">
                   Show detailed instructions →
                 </Button>
               </CollapsibleTrigger>
@@ -82,7 +78,7 @@ export function NgrokAlert({ port }: NgrokAlertProps) {
                 <ol className="list-decimal list-inside space-y-1.5 text-xs">
                   <li>
                     Install ngrok:{' '}
-                    <code className="bg-blue-100 dark:bg-blue-900/40 px-1 py-0.5 rounded">
+                    <code className="bg-primary/10 px-1 py-0.5 rounded">
                       brew install ngrok
                     </code>{' '}
                     or{' '}
@@ -102,7 +98,7 @@ export function NgrokAlert({ port }: NgrokAlertProps) {
                   </li>
                   <li>
                     Copy the <strong>HTTPS</strong> URL from ngrok output (e.g.,{' '}
-                    <code className="bg-blue-100 dark:bg-blue-900/40 px-1 py-0.5 rounded">
+                    <code className="bg-primary/10 px-1 py-0.5 rounded">
                       https://abc123.ngrok.io
                     </code>
                     )

--- a/apps/scan/src/app/(app)/server/[id]/(overview)/_components/header/agentcash-cta.tsx
+++ b/apps/scan/src/app/(app)/server/[id]/(overview)/_components/header/agentcash-cta.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useCallback, useRef, useEffect } from 'react';
-import { ChevronDown, Check, Copy } from 'lucide-react';
+import { ChevronDown, Check, Copy, ExternalLink } from 'lucide-react';
 
 import type { RouterOutputs } from '@/trpc/client';
 import { Button } from '@/components/ui/button';
@@ -22,13 +22,15 @@ interface Props {
   origin: NonNullable<RouterOutputs['public']['origins']['get']>;
 }
 
-type WalletId = 'agentcash' | 'awal' | 'circle' | 'paysh';
+type WalletId = 'agentcash' | 'poncho' | 'awal' | 'circle' | 'paysh';
 
 interface WalletOption {
   id: WalletId;
   label: string;
   icon: string;
   getCommand: (origin: string, hostname: string) => string;
+  /** When set, the action button navigates to this URL instead of copying */
+  getUrl?: (origin: string, hostname: string) => string;
 }
 
 const wallets: WalletOption[] = [
@@ -37,6 +39,13 @@ const wallets: WalletOption[] = [
     label: 'AgentCash',
     icon: '/wallet-agentcash.svg',
     getCommand: origin => `npx agentcash try ${origin}`,
+  },
+  {
+    id: 'poncho',
+    label: 'Poncho',
+    icon: '/wallet-poncho.svg',
+    getCommand: (_, hostname) => `https://tryponcho.com/m/${hostname}`,
+    getUrl: (_, hostname) => `https://tryponcho.com/m/${hostname}`,
   },
   {
     id: 'awal',
@@ -66,6 +75,7 @@ export const AgentCashCTA: React.FC<Props> = ({ origin }) => {
   const hostname = new URL(origin.origin).hostname.replace(/^www\./, '');
   const wallet = wallets.find(w => w.id === selectedWallet)!;
   const command = wallet.getCommand(origin.origin, hostname);
+  const walletUrl = wallet.getUrl?.(origin.origin, hostname);
 
   useEffect(() => {
     return () => {
@@ -80,17 +90,25 @@ export const AgentCashCTA: React.FC<Props> = ({ origin }) => {
     timerRef.current = setTimeout(() => setShowCopied(false), 2500);
   }, [command]);
 
+  const handleAction = useCallback(() => {
+    if (walletUrl) {
+      window.open(walletUrl, '_blank', 'noopener,noreferrer');
+    } else {
+      void handleCopy();
+    }
+  }, [walletUrl, handleCopy]);
+
   return (
-    <div className="flex items-center gap-2 w-fit bg-muted/50 rounded-lg px-3 py-2.5 text-sm">
-      <span className="text-sm font-semibold shrink-0 text-muted-foreground">
-        Try with
-      </span>
+    <div className="flex items-center gap-2 w-fit text-sm">
       <DropdownMenu>
-        <DropdownMenuTrigger className="inline-flex items-center gap-1.5 text-sm font-semibold text-muted-foreground hover:opacity-80 cursor-pointer focus:outline-none shrink-0">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src={wallet.icon} alt="" className="size-4 rounded-sm" />
-          {wallet.label}
-          <ChevronDown className="size-3" />
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" className="gap-1.5 text-sm shrink-0">
+            Try with
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={wallet.icon} alt="" className="size-4 rounded-sm" />
+            {wallet.label}
+            <ChevronDown className="size-3" />
+          </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start">
           {wallets.map(w => (
@@ -106,35 +124,33 @@ export const AgentCashCTA: React.FC<Props> = ({ origin }) => {
           ))}
         </DropdownMenuContent>
       </DropdownMenu>
-      <div className="relative shrink-0">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant="outline"
-              className="shrink-0 size-fit p-2"
-              size="icon"
-              onClick={() => void handleCopy()}
-            >
-              {showCopied ? (
-                <Check className="size-3" />
-              ) : (
-                <Copy className="size-3" />
-              )}
-            </Button>
-          </TooltipTrigger>
-          {!showCopied && (
-            <TooltipContent side="right">
-              <p>Copy and paste to your CLI or Agent</p>
-            </TooltipContent>
-          )}
-        </Tooltip>
-        {showCopied && (
-          <div className="absolute left-full top-1/2 -translate-y-1/2 ml-2 z-50 whitespace-nowrap rounded-md border bg-background px-3 py-2 text-sm font-medium shadow-md flex items-center gap-2">
-            <Check className="size-4 text-green-600" />
-            Copied! Paste to your CLI or Agent
-          </div>
-        )}
-      </div>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="outline"
+            className="shrink-0 size-fit p-2"
+            size="icon"
+            onClick={handleAction}
+          >
+            {walletUrl ? (
+              <ExternalLink className="size-3" />
+            ) : showCopied ? (
+              <Check className="size-3" />
+            ) : (
+              <Copy className="size-3" />
+            )}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="right">
+          <p>
+            {walletUrl
+              ? 'Open in Poncho'
+              : showCopied
+                ? 'Copied!'
+                : 'Copy command'}
+          </p>
+        </TooltipContent>
+      </Tooltip>
     </div>
   );
 };

--- a/apps/scan/src/app/(app)/server/[id]/(overview)/_components/header/index.tsx
+++ b/apps/scan/src/app/(app)/server/[id]/(overview)/_components/header/index.tsx
@@ -1,6 +1,6 @@
 import React, { Suspense } from 'react';
 
-import { Server } from 'lucide-react';
+import { Server, ExternalLink } from 'lucide-react';
 
 import { Card } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -37,12 +37,20 @@ export const HeaderCard: React.FC<Props> = ({ origin }) => {
         />
       </Card>
       <div className="grid grid-cols-1 md:grid-cols-7">
-        <div className="flex flex-col gap-4 p-4 pt-8 md:pt-10 col-span-5">
-          <div className="">
+        <div className="flex flex-col gap-3 p-4 pt-8 md:pt-10 col-span-5">
+          <div className="space-y-1">
             <div className="flex items-center gap-2 min-w-0">
-              <h1 className="text-xl md:text-3xl font-bold wrap-break-word line-clamp-2 min-w-0">
-                {originTitle}
-              </h1>
+              <a
+                href={origin.origin}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-2 min-w-0 hover:opacity-80 transition-opacity"
+              >
+                <h1 className="text-xl md:text-3xl font-bold wrap-break-word line-clamp-2 min-w-0">
+                  {originTitle}
+                </h1>
+                <ExternalLink className="size-4 md:size-5 text-muted-foreground shrink-0" />
+              </a>
               {origin.hasX402V2Resource && (
                 <X402V2Badge className="mt-1 shrink-0" />
               )}
@@ -53,16 +61,6 @@ export const HeaderCard: React.FC<Props> = ({ origin }) => {
                   origin={origin}
                 />
               </div>
-            </div>
-            <div className="flex items-center gap-2">
-              <a
-                href={origin.origin}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-sm font-bold font-mono text-muted-foreground hover:underline break-all"
-              >
-                {origin.origin}
-              </a>
             </div>
             <p
               className={cn(

--- a/apps/scan/src/app/mcp/(home)/(landing-page)/_components/2-client-demos/ide.tsx
+++ b/apps/scan/src/app/mcp/(home)/(landing-page)/_components/2-client-demos/ide.tsx
@@ -55,7 +55,7 @@ const IdeGraphic = () => {
       <div className="flex flex-col md:flex-1 md:overflow-hidden w-full md:w-0">
         <div className="flex items-center bg-muted/50 border-b border-border/50">
           <div className="flex items-center gap-2 px-3 py-2 bg-background border-r border-border/50 text-xs">
-            <FileCode2 className="size-3.5 text-blue-400" />
+            <FileCode2 className="size-3.5 text-primary" />
             <span className="text-foreground">enrichment.ts</span>
             <X className="size-3 text-muted-foreground hover:text-foreground cursor-pointer" />
           </div>

--- a/apps/scan/src/components/ui/button.tsx
+++ b/apps/scan/src/components/ui/button.tsx
@@ -28,26 +28,10 @@ export const buttonVariants = cva(
         primaryGhost: 'hover:bg-primary/20 text-primary',
         link: 'text-primary underline-offset-4 hover:underline',
         success: 'bg-green-600 text-white shadow-sm hover:bg-green-700',
-        turbo: cn(
-          'bg-gradient-to-br from-primary via-primary/80 to-primary text-white hover:opacity-90',
-          'shadow-[0_2px_6px_color-mix(in_oklab,var(--primary)_70%,transparent)]',
-          'hover:shadow-[0_2px_4px_color-mix(in_oklab,var(--primary)_70%,transparent)]',
-          'active:shadow-none',
-          'inset-ring-2 inset-ring-inset inset-ring-border/50',
-          'relative overflow-hidden',
-          'before:content-[""] before:absolute before:w-full before:h-full before:rounded-md before:pointer-events-none',
-          'before:bg-gradient-to-r before:from-transparent before:via-white/10 before:to-transparent before:animate-shimmer'
-        ),
-        turboSecondary: cn(
-          'bg-gradient-to-br from-gray-400 via-gray-500 to-gray-600 text-white hover:opacity-90',
-          'shadow-[0_2px_6px_color-mix(in_oklab,theme(colors.gray.500)_70%,transparent)]',
-          'hover:shadow-[0_2px_4px_color-mix(in_oklab,theme(colors.gray.500)_70%,transparent)]',
-          'active:shadow-none',
-          'inset-ring-2 inset-ring-inset inset-ring-border/50',
-          'relative overflow-hidden',
-          'before:content-[""] before:absolute before:w-full before:h-full before:rounded-md before:pointer-events-none',
-          'before:bg-gradient-to-r before:from-transparent before:via-white/10 before:to-transparent before:animate-shimmer'
-        ),
+        turbo:
+          'bg-gradient-to-br from-primary via-primary/80 to-primary text-white hover:opacity-90 shadow-sm hover:shadow-xs active:shadow-none',
+        turboSecondary:
+          'bg-gradient-to-br from-gray-400 via-gray-500 to-gray-600 text-white hover:opacity-90 shadow-sm hover:shadow-xs active:shadow-none',
         unstyled: '',
       },
       size: {


### PR DESCRIPTION
## Summary
- Simplify "Try with" CTA into single outline button with wallet dropdown (AgentCash, Poncho, awal, Agent Wallet, pay.sh)
- Poncho option opens tryponcho.com/m/ page instead of copying a command
- Add Skip button to email step in post-registration dialog
- Replace origin URL text with ExternalLink icon next to clickable title
- Blue color audit: convert all non-semantic hardcoded blue-* to primary tokens (ngrok alert, admin badges, discovery panel, MCP IDE)
- Simplify turbo/turboSecondary button variants (remove shimmer, ring, custom shadows)
- Remove Card border when nested in tree connector layout
- Standardize spacing: consistent collapsible gaps, edge-to-edge footer border, tighter header spacing
- Unify font family on server header (drop font-mono from URL)
- Add calendar scheduling icon to Support section

## Test plan
- [ ] Visit /register, register a test origin → verify Skip button in step 3 closes dialog
- [ ] Visit /server/:id → verify "Try with" dropdown, Poncho opens in new tab, others copy command
- [ ] Visit /developer → verify ngrok alert uses primary colors
- [ ] Check turbo buttons (e.g. connect wallet) → no shimmer/ring, just gradient + shadow
- [ ] Verify resource cards under an origin → no double border