### PR TITLE
feat(facilitators): add 15 Coinbase CDP relayers on Base (active 2026-06-13)

### DIFF
--- a/packages/external/facilitators/src/facilitators/coinbase.ts
+++ b/packages/external/facilitators/src/facilitators/coinbase.ts
@@ -145,6 +145,81 @@ export const coinbaseFacilitator = {
         tokens: [USDC_BASE_TOKEN],
         dateOfFirstTransaction: new Date('2025-12-16'),
       },
+      {
+        address: '0x14fda13953fc30428938e6bf950d036e77214e52',
+        tokens: [USDC_BASE_TOKEN],
+        dateOfFirstTransaction: new Date('2026-06-13'),
+      },
+      {
+        address: '0x2a89407a98a0732b7fd578c4e156b7166540eb5a',
+        tokens: [USDC_BASE_TOKEN],
+        dateOfFirstTransaction: new Date('2026-06-13'),
+      },
+      {
+        address: '0x42dd53906b49c202e8e934b059dc019e04634b00',
+        tokens: [USDC_BASE_TOKEN],
+        dateOfFirstTransaction: new Date('2026-06-13'),
+      },
+      {
+        address: '0x4c934c63c786157fefd990945b25ea60a0fb0205',
+        tokens: [USDC_BASE_TOKEN],
+        dateOfFirstTransaction: new Date('2026-06-13'),
+      },
+      {
+        address: '0x59b7ebc67a3d627fabaf06768c818638452ae704',
+        tokens: [USDC_BASE_TOKEN],
+        dateOfFirstTransaction: new Date('2026-06-13'),
+      },
+      {
+        address: '0x625d8a65134079f8faaac39a7947c73d93c6ac39',
+        tokens: [USDC_BASE_TOKEN],
+        dateOfFirstTransaction: new Date('2026-06-13'),
+      },
+      {
+        address: '0x64cc42b1ce598e3abcfbb64df4688521ddbf1f0a',
+        tokens: [USDC_BASE_TOKEN],
+        dateOfFirstTransaction: new Date('2026-06-13'),
+      },
+      {
+        address: '0x68efafe862d89ce66dd3d7b07d5a3747a0871164',
+        tokens: [USDC_BASE_TOKEN],
+        dateOfFirstTransaction: new Date('2026-06-13'),
+      },
+      {
+        address: '0x772003a2e9c2ccc8af956870a37a66f64f8cec38',
+        tokens: [USDC_BASE_TOKEN],
+        dateOfFirstTransaction: new Date('2026-06-13'),
+      },
+      {
+        address: '0x8cda367232d78c067116e3260da881d2da8ffa39',
+        tokens: [USDC_BASE_TOKEN],
+        dateOfFirstTransaction: new Date('2026-06-13'),
+      },
+      {
+        address: '0x93f6601151ccb08f333ab4b1cccfb1e188c0be44',
+        tokens: [USDC_BASE_TOKEN],
+        dateOfFirstTransaction: new Date('2026-06-13'),
+      },
+      {
+        address: '0xb87e1a2cc2b4643f2892768e80e41167f17c5860',
+        tokens: [USDC_BASE_TOKEN],
+        dateOfFirstTransaction: new Date('2026-06-13'),
+      },
+      {
+        address: '0xca5e87f82b3fa093800e6ad67d621a427d79c70d',
+        tokens: [USDC_BASE_TOKEN],
+        dateOfFirstTransaction: new Date('2026-06-13'),
+      },
+      {
+        address: '0xe72f0af4cf41356d433723547f1412ca27fbb1b8',
+        tokens: [USDC_BASE_TOKEN],
+        dateOfFirstTransaction: new Date('2026-06-13'),
+      },
+      {
+        address: '0xe74817f4cdc15844314812b2271276e64e890fae',
+        tokens: [USDC_BASE_TOKEN],
+        dateOfFirstTransaction: new Date('2026-06-13'),
+      },
     ],
     [Network.SOLANA]: [
       {


### PR DESCRIPTION
## Summary

Adds **15 Coinbase CDP facilitator relayer addresses** on **Base** that began settling x402 payments on **2026-06-13** but are not yet in `coinbase.ts`. Because x402scan attributes settlements by the relayer (`msg.sender`) that submits the on-chain `transferWithAuthorization`, settlements from these unlisted relayers are currently **not counted** toward Coinbase — undercounting Coinbase facilitator volume on Base.

## Why these are Coinbase CDP relayers (on-chain evidence)

All 15 addresses share the on-chain fingerprint of the relayers already listed in `coinbase.ts`:

1. **Same gas funder.** Every one of the 15 is funded for gas by `0x022e88961EfFbFD1E5ECDe0fbd89e7006d9B05ef` — the **same wallet** that funds relayers already attributed to Coinbase here (e.g. `0x8f5cb67b…`, `0x67b9ce70…`, `0xa32ccda9…`). Shared funding wallet ⇒ same operator.
2. **Same behaviour.** Each only calls `transferWithAuthorization` on native USDC (`0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`), settling EIP-3009 x402 payments.
3. **Multi-merchant.** They settle for many distinct recipient merchants, not a single seller — i.e. shared facilitator infrastructure.
4. **New batch.** First transaction `2026-06-13` for all 15 — a relayer rotation/expansion that post-dates the last sync (the existing newest entries are dated `2025-12-16`).

They are interleaved block-by-block with the already-listed Coinbase relayers settling identical payments.

### Addresses added (Base, USDC)

```
0x14fda13953fc30428938e6bf950d036e77214e52
0x2a89407a98a0732b7fd578c4e156b7166540eb5a
0x42dd53906b49c202e8e934b059dc019e04634b00
0x4c934c63c786157fefd990945b25ea60a0fb0205
0x59b7ebc67a3d627fabaf06768c818638452ae704
0x625d8a65134079f8faaac39a7947c73d93c6ac39
0x64cc42b1ce598e3abcfbb64df4688521ddbf1f0a
0x68efafe862d89ce66dd3d7b07d5a3747a0871164
0x772003a2e9c2ccc8af956870a37a66f64f8cec38
0x8cda367232d78c067116e3260da881d2da8ffa39
0x93f6601151ccb08f333ab4b1cccfb1e188c0be44
0xb87e1a2cc2b4643f2892768e80e41167f17c5860
0xca5e87f82b3fa093800e6ad67d621a427d79c70d
0xe72f0af4cf41356d433723547f1412ca27fbb1b8
0xe74817f4cdc15844314812b2271276e64e890fae
```

## How to verify

For any address above, on Base:
- It is funded by `0x022e8896…` (same as existing Coinbase relayers), and
- Its outbound txs are all `transferWithAuthorization` to the USDC contract for varied recipients.

Happy to adjust formatting or split per-token if preferred.
