### PR TITLE
Validate CAIP-2 chain IDs

### DIFF
--- a/packages/external/mcp/src/shared/networks.ts
+++ b/packages/external/mcp/src/shared/networks.ts
@@ -93,8 +93,13 @@ export function getUSDCAddress(network: string): `0x${string}` | undefined {
 /** Extract chain ID from CAIP-2 identifier */
 export function getChainId(network: string): number | undefined {
   const caip2 = toCaip2(network);
-  const match = /^eip155:(\d+)$/.exec(caip2);
-  return match ? parseInt(match[1]!, 10) : undefined;
+  const match = /^eip155:(0|[1-9]\d*)$/.exec(caip2);
+  if (!match) {
+    return undefined;
+  }
+
+  const parsed = Number(match[1]);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
 }
 
 /** Get human-readable chain name */

--- a/packages/external/mcp/test/networks.test.ts
+++ b/packages/external/mcp/test/networks.test.ts
@@ -68,6 +68,11 @@ describe('getChainId', () => {
   it('returns undefined for invalid format', () => {
     expect(getChainId('invalid')).toBeUndefined();
   });
+
+  it('returns undefined for unsafe or noncanonical CAIP-2 chain IDs', () => {
+    expect(getChainId('eip155:9007199254740993')).toBeUndefined();
+    expect(getChainId('eip155:001')).toBeUndefined();
+  });
 });
 
 describe('getChainName', () => {


### PR DESCRIPTION
getChainId parsed any digit string with parseInt, so values like eip155:001 and unsafe integers could be accepted or rounded.

This validates canonical CAIP-2 chain IDs and rejects values that cannot be represented as safe integers.