### PR TITLE
Track all post-registration modal button clicks

### DIFF
--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -885,6 +885,12 @@ function PostRegistrationDialog({
                     variant="ghost"
                     className="text-muted-foreground"
                     onClick={() => {
+                      posthog.capture('registration:step_click', {
+                        origin_id: originId,
+                        hostname,
+                        app_surface: 'x402scan',
+                        step_name: 'skip_email',
+                      });
                       dismissMethodRef.current = 'skip';
                       setOpen(false);
                     }}
@@ -894,7 +900,19 @@ function PostRegistrationDialog({
                 </form>
               ) : (
                 contactEmail && (
-                  <Link href={CALENDAR_URL} target="_blank" className="flex-1">
+                  <Link
+                    href={CALENDAR_URL}
+                    target="_blank"
+                    className="flex-1"
+                    onClick={() => {
+                      posthog.capture('registration:step_click', {
+                        origin_id: originId,
+                        hostname,
+                        app_surface: 'x402scan',
+                        step_name: 'schedule_call',
+                      });
+                    }}
+                  >
                     <Button className="w-full">Schedule a call &rarr;</Button>
                   </Link>
                 )
@@ -908,6 +926,14 @@ function PostRegistrationDialog({
                   href={`https://tryponcho.com/m/${hostname}`}
                   target="_blank"
                   className="underline"
+                  onClick={() => {
+                    posthog.capture('registration:link_click', {
+                      origin_id: originId,
+                      hostname,
+                      app_surface: 'x402scan',
+                      action: 'visit_merchant_page',
+                    });
+                  }}
                 >
                   tryponcho.com/m/{hostname}
                 </Link>


### PR DESCRIPTION
## Summary
- Add PostHog tracking for **Skip** button (`step_name: skip_email`) — fires when merchant declines to enter email
- Add PostHog tracking for **Schedule a Call** button (`step_name: schedule_call`) — fires when merchant clicks the calendar link (only visible after email submit)
- Add PostHog tracking for **merchant page link click** (`action: visit_merchant_page`) — fires when merchant clicks the `tryponcho.com/m/{hostname}` link (distinct from copying it)

Previously only Review API Page, Test Endpoints, email submit, and the copy-link button were tracked.

## Test plan
- [ ] Register a test origin, verify all 3 new events appear in PostHog
- [ ] Verify existing tracking (Review API Page, Test Endpoints, email submit, copy link) still works
- [ ] Check PostHog dashboard "Onboarding Actions — x402scan" shows new series