### PR TITLE
Require openapi.json for single-endpoint registration

### DIFF
--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -84,13 +84,17 @@ function getErrorMessageFromRegisterResult(result: {
     parseErrors?: string[];
   };
 }): string {
-  if (
-    result.error.type === 'noDiscovery' ||
-    result.error.type === 'notInSpec'
-  ) {
+  if (result.error.type === 'noDiscovery') {
     return (
       result.error.message ??
       'No discovery document found. Add an openapi.json to your origin to register endpoints.'
+    );
+  }
+
+  if (result.error.type === 'notInSpec') {
+    return (
+      result.error.message ??
+      "This endpoint is not listed in the origin's openapi.json."
     );
   }
 

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -427,6 +427,7 @@ export const RegisterResourceForm = () => {
               isLoading ||
               isBatchTestLoading ||
               !isValidUrl ||
+              (!discoveryFound && !isDiscoveryLoading) ||
               (!!currentManualFailed && !currentManualTested)
             }
             onClick={() => {
@@ -513,18 +514,16 @@ export const RegisterResourceForm = () => {
                 !isDiscoveryLoading &&
                 !hasDiscoveryResources &&
                 !isOriginOnly && (
-                  <div className="text-xs text-muted-foreground space-y-1">
-                    {isBatchTestLoading ? (
-                      <div className="flex items-center gap-2">
-                        <Loader2 className="size-3 animate-spin" />
-                        Testing endpoint...
-                      </div>
-                    ) : currentManualTested ? (
-                      <div className="flex items-center gap-2 text-green-700">
-                        <Check className="size-3" />
-                        Valid 402 response.
-                      </div>
-                    ) : null}
+                  <div className="text-sm space-y-1">
+                    <p className="text-red-600">
+                      {discoveryError?.includes('TypeError')
+                        ? "Couldn't reach this URL."
+                        : (discoveryError ??
+                          'No discovery document found at this origin.')}
+                    </p>
+                    {!discoveryError?.includes('TypeError') && (
+                      <DiscoveryFixHint noDiscovery />
+                    )}
                   </div>
                 )}
             </div>

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -79,11 +79,18 @@ interface ManualRegistrationResult {
 function getErrorMessageFromRegisterResult(result: {
   success: false;
   error: {
-    type: 'parseErrors' | 'no402' | 'tunnel';
+    type: 'parseErrors' | 'no402' | 'tunnel' | 'noDiscovery';
     message?: string;
     parseErrors?: string[];
   };
 }): string {
+  if (result.error.type === 'noDiscovery') {
+    return (
+      result.error.message ??
+      'No discovery document found. Add an openapi.json to your origin to register endpoints.'
+    );
+  }
+
   if (result.error.type === 'tunnel') {
     return result.error.message ?? 'Tunnel URLs are not supported';
   }

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -79,12 +79,15 @@ interface ManualRegistrationResult {
 function getErrorMessageFromRegisterResult(result: {
   success: false;
   error: {
-    type: 'parseErrors' | 'no402' | 'tunnel' | 'noDiscovery';
+    type: 'parseErrors' | 'no402' | 'tunnel' | 'noDiscovery' | 'notInSpec';
     message?: string;
     parseErrors?: string[];
   };
 }): string {
-  if (result.error.type === 'noDiscovery') {
+  if (
+    result.error.type === 'noDiscovery' ||
+    result.error.type === 'notInSpec'
+  ) {
     return (
       result.error.message ??
       'No discovery document found. Add an openapi.json to your origin to register endpoints.'

--- a/apps/scan/src/app/api/x402/_handlers/registry-register.ts
+++ b/apps/scan/src/app/api/x402/_handlers/registry-register.ts
@@ -1,6 +1,7 @@
 import type { registryRegisterBodySchema } from '@/app/api/x402/_lib/schemas';
 import { jsonResponse } from '@/app/api/x402/_lib/utils';
 import { registerEndpoint } from '@/lib/discovery/register-endpoint';
+import { urlMatchesDiscoveredResource } from '@/lib/url';
 import { fetchDiscoveryDocument } from '@/services/discovery';
 import { revalidatePath } from 'next/cache';
 import type { z } from 'zod';
@@ -32,6 +33,24 @@ export async function handleRegistryRegister(
         },
       },
       404
+    );
+  }
+
+  const urlInSpec = discoveryResult.resources.some(r =>
+    urlMatchesDiscoveredResource(body.url, r.url)
+  );
+
+  if (!urlInSpec) {
+    return jsonResponse(
+      {
+        success: false,
+        error: {
+          type: 'not_in_spec',
+          message:
+            "This endpoint is not listed in the origin's openapi.json. Add it to the spec before registering.",
+        },
+      },
+      422
     );
   }
 

--- a/apps/scan/src/app/api/x402/_handlers/registry-register.ts
+++ b/apps/scan/src/app/api/x402/_handlers/registry-register.ts
@@ -16,12 +16,28 @@ export async function handleRegistryRegister(
   body: z.infer<typeof registryRegisterBodySchema>
 ) {
   const origin = new URL(body.url).origin;
-  const [result, discoveryResult] = await Promise.all([
-    registerEndpoint(body.url),
-    fetchDiscoveryDocument(origin),
-  ]);
+
+  // Discovery document (openapi.json) is required before we probe the endpoint.
+  const discoveryResult = await fetchDiscoveryDocument(origin);
+
+  if (!discoveryResult.success) {
+    return jsonResponse(
+      {
+        success: false,
+        error: {
+          type: 'no_discovery',
+          message:
+            discoveryResult.error ??
+            'No discovery document found. Add an openapi.json to your origin to register endpoints.',
+        },
+      },
+      404
+    );
+  }
 
   const contactEmail = discoveryResult.contactEmail;
+
+  const result = await registerEndpoint(body.url);
 
   try {
     if (result.success && result.resource?.origin?.id) {

--- a/apps/scan/src/lib/url.ts
+++ b/apps/scan/src/lib/url.ts
@@ -35,3 +35,34 @@ export const normalizeUrl = (url: string): string => {
     return url;
   }
 };
+
+/**
+ * Check whether a concrete URL matches a discovered resource URL that may
+ * contain OpenAPI path templates (e.g. /v1/candles/{coin}/{interval}).
+ * Origins must match exactly; template segments ({...}) match any value.
+ */
+export function urlMatchesDiscoveredResource(
+  inputUrl: string,
+  discoveredUrl: string
+): boolean {
+  try {
+    const input = new URL(inputUrl);
+    const discovered = new URL(discoveredUrl);
+
+    if (input.origin !== discovered.origin) return false;
+
+    const inputSegments = input.pathname.replace(/\/+$/, '').split('/');
+    const discoveredSegments = discovered.pathname
+      .replace(/\/+$/, '')
+      .split('/');
+
+    if (inputSegments.length !== discoveredSegments.length) return false;
+
+    return discoveredSegments.every(
+      (seg, i) =>
+        (seg.startsWith('{') && seg.endsWith('}')) || seg === inputSegments[i]
+    );
+  } catch {
+    return false;
+  }
+}

--- a/apps/scan/src/lib/url.ts
+++ b/apps/scan/src/lib/url.ts
@@ -58,10 +58,13 @@ export function urlMatchesDiscoveredResource(
 
     if (inputSegments.length !== discoveredSegments.length) return false;
 
-    return discoveredSegments.every(
-      (seg, i) =>
-        (seg.startsWith('{') && seg.endsWith('}')) || seg === inputSegments[i]
-    );
+    return discoveredSegments.every((seg, i) => {
+      const decoded = decodeURIComponent(seg);
+      return (
+        (decoded.startsWith('{') && decoded.endsWith('}')) ||
+        seg === inputSegments[i]
+      );
+    });
   } catch {
     return false;
   }

--- a/apps/scan/src/trpc/routers/public/resources.ts
+++ b/apps/scan/src/trpc/routers/public/resources.ts
@@ -140,6 +140,21 @@ export const resourcesRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ input }) => {
+      const origin = new URL(input.url).origin;
+      const discoveryResult = await fetchDiscoveryDocument(origin);
+
+      if (!discoveryResult.success) {
+        return {
+          success: false as const,
+          error: {
+            type: 'noDiscovery' as const,
+            message:
+              discoveryResult.error ??
+              'No discovery document found. Add an openapi.json to your origin to register endpoints.',
+          },
+        };
+      }
+
       const result = await registerEndpoint(input.url.toString());
       try {
         if (result.success && result.resource?.origin?.id) {

--- a/apps/scan/src/trpc/routers/public/resources.ts
+++ b/apps/scan/src/trpc/routers/public/resources.ts
@@ -24,6 +24,7 @@ import { mixedAddressSchema } from '@/lib/schemas';
 
 import { registerEndpoint } from '@/lib/discovery/register-endpoint';
 import { registerResourcesFromDiscovery } from '@/lib/discovery/register-origin';
+import { urlMatchesDiscoveredResource } from '@/lib/url';
 import { TRPCError } from '@trpc/server';
 import {
   listResourceTags,
@@ -151,6 +152,21 @@ export const resourcesRouter = createTRPCRouter({
             message:
               discoveryResult.error ??
               'No discovery document found. Add an openapi.json to your origin to register endpoints.',
+          },
+        };
+      }
+
+      const urlInSpec = discoveryResult.resources.some(r =>
+        urlMatchesDiscoveredResource(input.url.toString(), r.url)
+      );
+
+      if (!urlInSpec) {
+        return {
+          success: false as const,
+          error: {
+            type: 'notInSpec' as const,
+            message:
+              "This endpoint is not listed in the origin's openapi.json. Add it to the spec before registering.",
           },
         };
       }


### PR DESCRIPTION
## Summary
- Single-endpoint registration (`/api/x402/registry/register` + TRPC `register` mutation) now requires a valid `openapi.json` discovery document before probing
- Verifies the specific endpoint URL is listed in the `openapi.json` — not just that the spec exists (supports OpenAPI path templates like `/v1/candles/{coin}/{interval}`)
- Registration form now shows "No discovery document found" and disables the Add button when an origin has no `openapi.json` — previously it showed "Valid 402 response" which was misleading
- Previously, origins could register by probing a URL directly — bypassing discovery entirely (e.g. `trust.nsgoods.org` registered with only a `/.well-known/x402`)

## Changes
- **`registry-register.ts`** — REST handler gates on discovery + membership check before probing
- **`resources.ts`** — TRPC `register` mutation gets the same two gates
- **`url.ts`** — New `urlMatchesDiscoveredResource()` utility that matches concrete URLs against OpenAPI paths with template segments (`{param}` → wildcard). Uses `decodeURIComponent` to handle `new URL()` percent-encoding of braces.
- **`form.tsx`** — Handles `noDiscovery` and `notInSpec` error types; shows discovery error in pre-validation step and disables Add button when no openapi.json

## Test plan
- [x] Enter `trust.nsgoods.org/agent-trust` → should show "No discovery document found" instead of "Valid 402 response", Add button disabled
- [x] Enter origin-only `trust.nsgoods.org` → should show "No discovery document found" 
- [x] Enter an endpoint NOT in a valid openapi.json → should get `notInSpec` error on submit
- [ ] Enter a valid endpoint from an origin with openapi.json → should succeed as before
- [ ] Verify templated paths (e.g. `/v1/data/{id}`) match concrete URLs correctly