### PR TITLE
Add Base CDP facilitator address 0x2a89407a

### DIFF
--- a/packages/external/facilitators/src/facilitators/coinbase.ts
+++ b/packages/external/facilitators/src/facilitators/coinbase.ts
@@ -145,6 +145,11 @@ export const coinbaseFacilitator = {
         tokens: [USDC_BASE_TOKEN],
         dateOfFirstTransaction: new Date('2025-12-16'),
       },
+      {
+        address: '0x2a89407a98a0732b7fd578c4e156b7166540eb5a',
+        tokens: [USDC_BASE_TOKEN],
+        dateOfFirstTransaction: new Date('2026-06-15'),
+      },
     ],
     [Network.SOLANA]: [
       {


### PR DESCRIPTION
## Summary
- Add `0x2a89407a98a0732b7fd578c4e156b7166540eb5a` to the Coinbase facilitator Base addresses
- Enables transfer sync to track USDC activity from this CDP facilitator wallet (sync start: 2026-06-15)

## Test plan
- [ ] Verify the address appears in facilitator config for Base
- [ ] Confirm Base CDP/Bitquery sync picks up transfers from the new address after deploy


Made with [Cursor](https://cursor.com)