### PR TITLE
Add time-range selector to origin Activity section

### DIFF
--- a/apps/scan/src/app/(app)/server/[id]/(overview)/_components/activity/index.tsx
+++ b/apps/scan/src/app/(app)/server/[id]/(overview)/_components/activity/index.tsx
@@ -32,7 +32,7 @@ export const OriginActivity: React.FC<Props> = ({ originId }) => {
         recipients: {
           include: addresses,
         },
-        timeframe: ActivityTimeframe.ThirtyDays,
+        timeframe: ActivityTimeframe.AllTime,
       },
       {
         enabled: !!metadata,
@@ -42,7 +42,7 @@ export const OriginActivity: React.FC<Props> = ({ originId }) => {
     api.public.stats.bucketed.useQuery(
       {
         numBuckets: 48,
-        timeframe: ActivityTimeframe.ThirtyDays,
+        timeframe: ActivityTimeframe.AllTime,
         recipients: {
           include: addresses,
         },

--- a/apps/scan/src/app/(app)/server/[id]/(overview)/_components/activity/index.tsx
+++ b/apps/scan/src/app/(app)/server/[id]/(overview)/_components/activity/index.tsx
@@ -9,6 +9,9 @@ import { api } from '@/trpc/client';
 import { convertTokenAmount, formatTokenAmount } from '@/lib/token';
 
 import { ActivityTimeframe } from '@/types/timeframes';
+import { TimeRangeProvider } from '@/app/(app)/_contexts/time-range/provider';
+import { RangeSelector } from '@/app/(app)/_contexts/time-range/component';
+import { useTimeRangeContext } from '@/app/(app)/_contexts/time-range/hook';
 
 import type { ChartData } from '@/components/ui/charts/chart/types';
 interface Props {
@@ -16,6 +19,16 @@ interface Props {
 }
 
 export const OriginActivity: React.FC<Props> = ({ originId }) => {
+  return (
+    <TimeRangeProvider initialTimeframe={ActivityTimeframe.ThirtyDays}>
+      <OriginActivityContent originId={originId} />
+    </TimeRangeProvider>
+  );
+};
+
+const OriginActivityContent: React.FC<Props> = ({ originId }) => {
+  const { timeframe } = useTimeRangeContext();
+
   const [metadata] = api.public.origins.getMetadata.useSuspenseQuery(originId);
 
   const addresses = Array.from(
@@ -32,7 +45,7 @@ export const OriginActivity: React.FC<Props> = ({ originId }) => {
         recipients: {
           include: addresses,
         },
-        timeframe: ActivityTimeframe.AllTime,
+        timeframe,
       },
       {
         enabled: !!metadata,
@@ -42,7 +55,7 @@ export const OriginActivity: React.FC<Props> = ({ originId }) => {
     api.public.stats.bucketed.useQuery(
       {
         numBuckets: 48,
-        timeframe: ActivityTimeframe.AllTime,
+        timeframe,
         recipients: {
           include: addresses,
         },
@@ -58,7 +71,7 @@ export const OriginActivity: React.FC<Props> = ({ originId }) => {
     isBucketedStatsLoading ||
     isOverallStatsLoading
   ) {
-    return <LoadingOriginActivity />;
+    return <LoadingOriginActivity action={<RangeSelector />} />;
   }
 
   const chartData: ChartData<{
@@ -77,7 +90,7 @@ export const OriginActivity: React.FC<Props> = ({ originId }) => {
   }));
 
   return (
-    <OriginActivityContainer>
+    <OriginActivityContainer action={<RangeSelector />}>
       <OverallStatsCard
         title="Transactions"
         value={overallStats.total_transactions.toLocaleString(undefined, {
@@ -155,9 +168,13 @@ export const OriginActivity: React.FC<Props> = ({ originId }) => {
   );
 };
 
-export const LoadingOriginActivity = () => {
+export const LoadingOriginActivity = ({
+  action,
+}: {
+  action?: React.ReactNode;
+}) => {
   return (
-    <OriginActivityContainer>
+    <OriginActivityContainer action={action}>
       <LoadingOverallStatsCard type="bar" title="Transactions" />
       <LoadingOverallStatsCard type="bar" title="Volume" />
       <LoadingOverallStatsCard type="bar" title="Buyers" />
@@ -167,11 +184,13 @@ export const LoadingOriginActivity = () => {
 
 const OriginActivityContainer = ({
   children,
+  action,
 }: {
   children: React.ReactNode;
+  action?: React.ReactNode;
 }) => {
   return (
-    <OriginOverviewSection title="Activity">
+    <OriginOverviewSection title="Activity" action={action}>
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">{children}</div>
     </OriginOverviewSection>
   );

--- a/apps/scan/src/app/(app)/server/[id]/(overview)/_components/share-modal.tsx
+++ b/apps/scan/src/app/(app)/server/[id]/(overview)/_components/share-modal.tsx
@@ -113,7 +113,7 @@ export const ShareModal: React.FC<Props> = ({
   const { data: overallStats } = api.public.stats.overall.useQuery(
     {
       recipients: { include: addresses },
-      timeframe: ActivityTimeframe.ThirtyDays,
+      timeframe: ActivityTimeframe.AllTime,
     },
     { enabled: isOpen && addresses.length > 0 }
   );
@@ -121,7 +121,7 @@ export const ShareModal: React.FC<Props> = ({
   const { data: bucketedStats } = api.public.stats.bucketed.useQuery(
     {
       numBuckets: 48,
-      timeframe: ActivityTimeframe.ThirtyDays,
+      timeframe: ActivityTimeframe.AllTime,
       recipients: { include: addresses },
     },
     { enabled: isOpen && addresses.length > 0 }


### PR DESCRIPTION
## What

Adds a time-range selector to the origin detail page (`/server/[id]`), horizontally aligned with the **Activity** title — the same `RangeSelector` the marketplace/home page uses (Past 24h / 7d / 15d / 30d / All Time).

- **Activity section** now defaults to **Past 30 Days** and updates the Transactions / Volume / Buyers cards + chart as the user switches range.
- **Share modal** is intentionally **fixed to All Time** — no selector there, so shared images always represent full history.

## Changes

`activity/index.tsx`:
- Wrap `OriginActivity` in `TimeRangeProvider` (`initialTimeframe = ThirtyDays`); split out an inner `OriginActivityContent` that reads `timeframe` from `useTimeRangeContext()` and passes it to the `stats.overall` + `stats.bucketed` queries.
- Render `RangeSelector` in the section's existing `action` slot (no layout work — `OriginOverviewSection` already renders `{action}` beside the title).
- Keep the selector mounted during per-timeframe loading (optional `action` threaded into `LoadingOriginActivity`) so it doesn't flicker out on every switch.

`share-modal.tsx`: left at `ActivityTimeframe.AllTime` (from the earlier commit on this branch) — no change.

## Why it's safe

- Reuses existing, production-proven infra: `TimeRangeProvider` / `RangeSelector` / `useTimeRangeContext` (same components the home page uses) and the per-timeframe materialized views (`recipient_stats_aggregated_{0,1,7,14,30}d`, `recipient_stats_bucketed_*`), all cache-warmed.
- The provider only wraps the Activity component; the header's share modal is a sibling and is deliberately not affected.
- Switching timeframe runs the non-suspense `useQuery`s, so the page-level Suspense boundary is never re-triggered — the loading state is handled inline with the selector kept visible.

## Verification

- `pnpm install` + Prisma generate in a fresh worktree.
- `pnpm check` — 72/72 tasks pass (typecheck + format).
- `pnpm lint` — 22/22 pass (`eslint --max-warnings 0`).
- Not yet booted against a live DB — happy to run it against a Neon branch and screenshot an origin page if you want a visual confirm.