### PR TITLE
feat: add XDC Network (50) and XDC Apothem testnet (51)

### DIFF
--- a/.changeset/add-xdc-network.md
+++ b/.changeset/add-xdc-network.md
@@ -1,0 +1,5 @@
+---
+"@x402scan/mcp": patch
+---
+
+Add XDC Network (`eip155:50`) and XDC Apothem testnet (`eip155:51`) to the MCP network configs, including their native Circle USDC addresses.

--- a/apps/scan/src/lib/x402/chain-mapping.ts
+++ b/apps/scan/src/lib/x402/chain-mapping.ts
@@ -18,6 +18,8 @@ const EvmNetworkToChainId: Record<string, number> = {
   story: 1514,
   educhain: 41923,
   'skale-base-sepolia': 324705682,
+  xdc: 50,
+  'xdc-testnet': 51,
 };
 
 const SvmNetworkToChainId: Record<string, number> = {

--- a/packages/external/mcp/src/shared/networks.ts
+++ b/packages/external/mcp/src/shared/networks.ts
@@ -6,6 +6,8 @@ import {
   optimism,
   arbitrum,
   polygon,
+  xdc,
+  xdcTestnet,
 } from 'viem/chains';
 
 import type { Chain } from 'viem';
@@ -60,6 +62,18 @@ const CHAIN_CONFIGS: Record<string, ChainConfig> = {
     v1Name: 'polygon',
     usdcAddress: '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
   },
+  'eip155:50': {
+    chain: xdc,
+    caip2: 'eip155:50',
+    v1Name: 'xdc',
+    usdcAddress: '0xfA2958CB79b0491CC627c1557F441eF849Ca8eb1',
+  },
+  'eip155:51': {
+    chain: xdcTestnet,
+    caip2: 'eip155:51',
+    v1Name: 'xdc-testnet',
+    usdcAddress: '0xb5AB69F7bBada22B28e79C8FFAECe55eF1c771D4',
+  },
 };
 
 const V1_TO_CAIP2: Record<string, string> = {
@@ -70,6 +84,8 @@ const V1_TO_CAIP2: Record<string, string> = {
   optimism: 'eip155:10',
   arbitrum: 'eip155:42161',
   polygon: 'eip155:137',
+  xdc: 'eip155:50',
+  'xdc-testnet': 'eip155:51',
 };
 
 export const DEFAULT_NETWORK = 'eip155:8453';


### PR DESCRIPTION
## Summary

Adds **XDC Network** mainnet (`eip155:50`) and **XDC Apothem** testnet (`eip155:51`) so x402scan recognizes XDC transactions and the MCP server supports XDC.

XDC is an EVM-compatible L1 (XDPoS) with **native Circle USDC** (EIP-3009-capable), so it slots into x402's exact scheme. USDC addresses were verified on-chain (2026-06-22).

## Changes

- **`apps/scan/src/lib/x402/chain-mapping.ts`** — add `xdc: 50` and `xdc-testnet: 51` to `EvmNetworkToChainId`, so the scanner maps XDC chain IDs ↔ network names (alongside abstract/sei/iotex/peaq/etc.).
- **`packages/external/mcp/src/shared/networks.ts`** — add `eip155:50` and `eip155:51` to `CHAIN_CONFIGS` (using viem's `xdc` / `xdcTestnet`) with native USDC addresses, plus `V1_TO_CAIP2` aliases (`xdc`, `xdc-testnet`).
- Changeset (`patch`) for `@x402scan/mcp`.

## Verified data

| | XDC mainnet (50) | XDC Apothem (51) |
|---|---|---|
| USDC (Circle, native) | `0xfA2958CB79b0491CC627c1557F441eF849Ca8eb1` | `0xb5AB69F7bBada22B28e79C8FFAECe55eF1c771D4` |
| EIP-712 domain | name `USDC`, version `2`, 6 decimals | same |
| EIP-3009 | ✅ `transferWithAuthorization` | ✅ |

USDC `name()`/`version()`/`decimals()` and EIP-3009 support were read directly from the token contracts on XDC mainnet (`rpc.xdc.org`) and Apothem.

## Notes

`apps/scan` is private (no changeset needed); the changeset covers the published `@x402scan/mcp`. viem `2.51.2` already ships `xdc`/`xdcTestnet`.
