### PR TITLE
Block Vercel preview deployments at registration

### DIFF
--- a/apps/scan/src/app/api/resources/sync/route.ts
+++ b/apps/scan/src/app/api/resources/sync/route.ts
@@ -10,6 +10,7 @@ import { upsertResource } from '@/services/db/resources/resource';
 import { checkCronSecret } from '@/lib/cron';
 import { notifyNewServer } from '@/lib/discord-notifications';
 import { getOriginFromUrl } from '@/lib/url';
+import { isVercelPreviewDeployment } from '@/lib/discovery/vercel-preview';
 import { normalizeChainId } from '@/lib/x402';
 
 import type { AcceptsNetwork } from '@x402scan/scan-db/types';
@@ -93,6 +94,16 @@ export const GET = async (request: NextRequest) => {
       })
     );
 
+    // Reject Vercel preview deployments (serve `x-robots-tag: noindex` and get
+    // torn down). Checked once per origin so a preview origin's resources are
+    // never upserted, even via facilitator sync.
+    const previewOrigins = new Set<string>();
+    await Promise.all(
+      Array.from(allOrigins).map(async origin => {
+        if (await isVercelPreviewDeployment(origin)) previewOrigins.add(origin);
+      })
+    );
+
     // Step 2: Process resources (upsert to database)
     console.log('Starting resource processing');
     const resourceProcessingStart = Date.now();
@@ -100,6 +111,23 @@ export const GET = async (request: NextRequest) => {
     const resourceResults = await Promise.allSettled(
       resources.map(async facilitatorResource => {
         try {
+          let resourceOrigin: string | undefined;
+          try {
+            resourceOrigin = getOriginFromUrl(facilitatorResource.resource);
+          } catch {
+            resourceOrigin = undefined;
+          }
+          if (resourceOrigin && previewOrigins.has(resourceOrigin)) {
+            console.warn('Skipping Vercel preview deployment', {
+              resource: facilitatorResource.resource,
+            });
+            return {
+              resource: facilitatorResource.resource,
+              success: false,
+              error: 'Vercel preview deployment',
+            };
+          }
+
           const result = await upsertResource({
             ...facilitatorResource,
             accepts: facilitatorResource.accepts.map(accept => ({

--- a/apps/scan/src/lib/discovery/vercel-preview.test.ts
+++ b/apps/scan/src/lib/discovery/vercel-preview.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { isVercelHost, isVercelPreviewDeployment } from './vercel-preview';
+
+describe('isVercelHost', () => {
+  it('detects *.vercel.app subdomains', () => {
+    expect(isVercelHost('https://nemu-gamma.vercel.app/api/price')).toBe(true);
+    expect(
+      isVercelHost('https://agentcash-egwf1g5ii-merit-systems.vercel.app/')
+    ).toBe(true);
+  });
+
+  it('allows custom domains', () => {
+    expect(isVercelHost('https://stableenrich.dev/api')).toBe(false);
+    expect(isVercelHost('https://api.example.com')).toBe(false);
+  });
+
+  it('does not false-positive on lookalike hosts', () => {
+    // hostname is `myvercel.app` — ends with `vercel.app` but not `.vercel.app`
+    expect(isVercelHost('https://myvercel.app')).toBe(false);
+    // `vercel.app.evil.com` is a different registrable domain
+    expect(isVercelHost('https://vercel.app.evil.com')).toBe(false);
+  });
+
+  it('returns false for invalid URLs', () => {
+    expect(isVercelHost('not-a-url')).toBe(false);
+    expect(isVercelHost('')).toBe(false);
+  });
+});
+
+describe('isVercelPreviewDeployment', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function stubFetch(impl: typeof fetch) {
+    const spy = vi.fn(impl);
+    vi.stubGlobal('fetch', spy);
+    return spy;
+  }
+
+  it('returns true for a *.vercel.app deployment serving x-robots-tag: noindex', async () => {
+    const spy = stubFetch(() =>
+      Promise.resolve(
+        new Response(null, { headers: { 'x-robots-tag': 'noindex' } })
+      )
+    );
+    expect(
+      await isVercelPreviewDeployment('https://preview-abc123.vercel.app/api/x')
+    ).toBe(true);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns true when noindex is one of several directives', async () => {
+    stubFetch(() =>
+      Promise.resolve(
+        new Response(null, { headers: { 'x-robots-tag': 'noindex, nofollow' } })
+      )
+    );
+    expect(
+      await isVercelPreviewDeployment('https://preview-abc123.vercel.app/')
+    ).toBe(true);
+  });
+
+  it('returns false for a production *.vercel.app alias without the header', async () => {
+    stubFetch(() => Promise.resolve(new Response(null, { headers: {} })));
+    expect(
+      await isVercelPreviewDeployment('https://agent402.vercel.app/api/x')
+    ).toBe(false);
+  });
+
+  it('short-circuits non-vercel hosts without any network call', async () => {
+    const spy = stubFetch(() => Promise.resolve(new Response(null)));
+    expect(
+      await isVercelPreviewDeployment('https://stableenrich.dev/api')
+    ).toBe(false);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('fails open (returns false) when the probe errors', async () => {
+    stubFetch(() => Promise.reject(new Error('network down')));
+    expect(
+      await isVercelPreviewDeployment('https://preview-abc123.vercel.app/')
+    ).toBe(false);
+  });
+});

--- a/apps/scan/src/lib/discovery/vercel-preview.ts
+++ b/apps/scan/src/lib/discovery/vercel-preview.ts
@@ -1,0 +1,56 @@
+const VERCEL_APP_SUFFIX = '.vercel.app';
+const PREVIEW_CHECK_TIMEOUT_MS = 8000;
+/** Two attempts: a sleeping preview can cold-start past the first timeout; the
+ *  first request wakes it so the second reads the edge-injected header. */
+const PREVIEW_CHECK_ATTEMPTS = 2;
+
+/**
+ * Error shown when an origin is rejected as a Vercel preview deployment.
+ * Mirrors the tone of the ephemeral-tunnel rejection in `register-endpoint.ts`.
+ */
+export const VERCEL_PREVIEW_ERROR_MESSAGE =
+  'Vercel preview deployments are ephemeral and get torn down, so agents ' +
+  "can't reliably reach them. Deploy to production and register that URL instead.";
+
+/** True when the URL is hosted on a `*.vercel.app` subdomain. Pure, no I/O. */
+export function isVercelHost(url: string): boolean {
+  try {
+    return new URL(url).hostname.toLowerCase().endsWith(VERCEL_APP_SUFFIX);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * True when the URL is a Vercel **preview / non-production** deployment.
+ *
+ * Vercel injects `x-robots-tag: noindex` at the edge on every deployment URL
+ * except the production target, so a `*.vercel.app` host that serves `noindex`
+ * is a preview/branch/deployment-scoped URL — ephemeral and unsafe to register.
+ * Clean production aliases (`<project>.vercel.app`) and custom domains never
+ * carry the header (verified across 19 live production aliases).
+ *
+ * Fails open: non-`*.vercel.app` hosts never touch the network, and any probe
+ * error returns false — only a confirmed `noindex` blocks registration.
+ */
+export async function isVercelPreviewDeployment(url: string): Promise<boolean> {
+  if (!isVercelHost(url)) return false;
+  const origin = new URL(url).origin;
+  for (let attempt = 0; attempt < PREVIEW_CHECK_ATTEMPTS; attempt++) {
+    try {
+      const res = await fetch(origin, {
+        method: 'HEAD',
+        redirect: 'manual',
+        signal: AbortSignal.timeout(PREVIEW_CHECK_TIMEOUT_MS),
+      });
+      return (res.headers.get('x-robots-tag')?.toLowerCase() ?? '').includes(
+        'noindex'
+      );
+    } catch {
+      // Timeout / network error — retry once (the first hit may have woken a
+      // cold preview), then fail open so a transient blip never blocks a
+      // legitimate production origin.
+    }
+  }
+  return false;
+}

--- a/apps/scan/src/services/discovery/fetch-discovery.ts
+++ b/apps/scan/src/services/discovery/fetch-discovery.ts
@@ -2,6 +2,10 @@ import { discoverOriginSchema } from '@agentcash/discovery';
 
 import { getOriginFromUrl } from '@/lib/url';
 import { isLocalUrl, isTunnelUrl } from '@/lib/url-helpers';
+import {
+  isVercelPreviewDeployment,
+  VERCEL_PREVIEW_ERROR_MESSAGE,
+} from '@/lib/discovery/vercel-preview';
 
 import type {
   DiscoveredResource,
@@ -48,6 +52,16 @@ export async function fetchDiscoveryDocument(
       resources: [],
       error:
         "Tunnel URLs are ephemeral and can't be reliably discovered by agents. Deploy your API to a permanent URL to register.",
+    };
+  }
+
+  // Reject Vercel preview deployments — they serve `x-robots-tag: noindex`
+  // and get torn down, so agents can't reliably reach them after registration.
+  if (await isVercelPreviewDeployment(origin)) {
+    return {
+      success: false,
+      resources: [],
+      error: VERCEL_PREVIEW_ERROR_MESSAGE,
     };
   }
 


### PR DESCRIPTION
## Problem

Origins registered from **Vercel preview deployments** show up healthy at registration but go dead soon after — preview URLs are ephemeral and get torn down (we saw this with the four "Nemu" origins, which registered with valid x402 v2 accepts and are now `404 DEPLOYMENT_NOT_FOUND`).

## Signal (verified)

Vercel injects `x-robots-tag: noindex` at the edge on **every deployment URL except the production target**. Confirmed empirically:
- Live previews (`poncho-…`, `agentcash-…` merit builds) → `200` + `x-robots-tag: noindex`
- 19/19 live production `*.vercel.app` aliases → no such header
- Custom domains → no header

So `host is *.vercel.app` **AND** `x-robots-tag: noindex` reliably identifies a preview/non-production deployment.

## Change

- **`lib/discovery/vercel-preview.ts`** — `isVercelPreviewDeployment(url)`: short-circuits non-`*.vercel.app` hosts (no network), else a `HEAD` with an 8s timeout and one retry (cold-start resilience), returns true only on a confirmed `noindex`. Fails open so a transient blip never blocks a legitimate origin.
- **`services/discovery/fetch-discovery.ts`** — gate right after the existing `isLocalUrl`/`isTunnelUrl` checks. This is the chokepoint all four user-facing register surfaces funnel through (REST + tRPC, single + origin), so the rejection message surfaces on each exactly like the tunnel rejection does today.
- **`api/resources/sync/route.ts`** — per-origin gate so the facilitator-sync cron never upserts a preview origin's resources.

## Testing

- 9 unit tests (mocked fetch): host matching, `noindex`→block, production-alias→allow, non-vercel short-circuit (asserts no network call), fail-open on error.
- Full suite: **148/148** pass.
- Real-origin verification (read-only, no DB writes): live previews blocked; live production `*.vercel.app` (`agent402`, `402dog`) and custom domains **not** blocked; dead/404 preview fails open. This run caught a cold-start timeout that prompted the retry + 8s timeout.
