### PR TITLE
Add Figment facilitator (Solana USDC)

### DIFF
--- a/apps/scan/public/figment.svg
+++ b/apps/scan/public/figment.svg
@@ -1,0 +1,4 @@
+<svg width="1200" height="1200" viewBox="0 0 1200 1200" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect width="1200" height="1200" fill="#FFF29B"/>
+    <path d="M510.741 433.63V577.333H794.444V666.963H510.741V905.481H410V342.519H810V433.63H510.741Z" fill="#111111"/>
+</svg>

--- a/packages/external/facilitators/src/facilitators/figment.ts
+++ b/packages/external/facilitators/src/facilitators/figment.ts
@@ -1,0 +1,28 @@
+import { Network } from '../types';
+import { USDC_SOLANA_TOKEN } from '../constants';
+
+import type { Facilitator, FacilitatorConfig } from '../types';
+
+export const figment: FacilitatorConfig = {
+  url: 'https://api.figment.io/x402',
+};
+
+export const figmentFacilitator = {
+  id: 'figment-facilitator',
+  metadata: {
+    name: 'Figment',
+    image: 'https://x402scan.com/figment.svg',
+    docsUrl: 'https://docs.figment.io/reference/x402',
+    color: '#FFF29B',
+  },
+  config: figment,
+  addresses: {
+    [Network.SOLANA]: [
+      {
+        address: '93syNmtT1tTd5ZtPwHqzGf6CM7fKhMmArpv4AM4FtyNX',
+        tokens: [USDC_SOLANA_TOKEN],
+        dateOfFirstTransaction: new Date('2026-06-26'),
+      },
+    ],
+  },
+} as const satisfies Facilitator;

--- a/packages/external/facilitators/src/facilitators/index.ts
+++ b/packages/external/facilitators/src/facilitators/index.ts
@@ -28,3 +28,4 @@ export { relai, relaiFacilitator } from './relai';
 export { bitrefill, bitrefillFacilitator } from './bitrefill';
 export { cascade, cascadeFacilitator } from './cascade';
 export { fluxa, fluxaFacilitator } from './fluxa';
+export { figment, figmentFacilitator } from './figment';

--- a/packages/external/facilitators/src/lists/all.ts
+++ b/packages/external/facilitators/src/lists/all.ts
@@ -28,6 +28,7 @@ import {
   bitrefillFacilitator,
   cascadeFacilitator,
   fluxaFacilitator,
+  figmentFacilitator,
 } from '../facilitators';
 
 import { validateUniqueFacilitators } from './validate';
@@ -64,6 +65,7 @@ const FACILITATORS = validateUniqueFacilitators([
   bitrefillFacilitator,
   cascadeFacilitator,
   fluxaFacilitator,
+  figmentFacilitator,
 ]);
 
 export const allFacilitators: Facilitator[] =


### PR DESCRIPTION
Adds the **Figment** x402 facilitator.

- **id:** `figment-facilitator`
- **Chain/token:** Solana USDC
- **Fee-payer:** `93syNmtT1tTd5ZtPwHqzGf6CM7fKhMmArpv4AM4FtyNX`
- **First transaction:** 2026-06-26 (live)
- **Docs:** https://docs.figment.io/reference/x402
- **Facilitator URL:** https://api.figment.io/x402

Logo added at `apps/scan/public/figment.svg`. `types:check` and `format:check` pass.