### PR TITLE
Fix resource price labels for non-USDC accepts

### DIFF
--- a/apps/scan/src/app/(app)/_components/resources/resource-card.tsx
+++ b/apps/scan/src/app/(app)/_components/resources/resource-card.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/components/ui/tooltip';
 
 import { Header } from './header/index';
-import { formatPricingLabel, isSiwxResource } from './utils';
+import { formatPricingLabel, getMaxUsdcAmount, isSiwxResource } from './utils';
 
 import { cn } from '@/lib/utils';
 import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard';
@@ -26,6 +26,7 @@ interface SerializedAccept {
   maxAmountRequired: number;
   network: string;
   scheme: string;
+  asset?: string | null;
 }
 
 interface Props {
@@ -163,8 +164,8 @@ const ResourcePricing: React.FC<{
 }> = ({ accepts, pricingMode, price }) => {
   const isDynamic =
     pricingMode === 'dynamic' || accepts.some(a => a.scheme !== 'exact');
-  const maxAmount = Math.max(...accepts.map(a => a.maxAmountRequired));
-  const label = formatPricingLabel({ maxAmount, isDynamic, price });
+  const maxUsdAmount = getMaxUsdcAmount(accepts);
+  const label = formatPricingLabel({ maxUsdAmount, isDynamic, price });
 
   return (
     <span className="text-xs font-semibold text-primary font-mono shrink-0">

--- a/apps/scan/src/app/(app)/_components/resources/utils.test.ts
+++ b/apps/scan/src/app/(app)/_components/resources/utils.test.ts
@@ -3,6 +3,7 @@ import {
   getBazaarMethod,
   parseMinFromPriceString,
   parseMaxFromPriceString,
+  getMaxUsdcAmount,
   formatPricingLabel,
 } from './utils';
 import { Methods } from '@/types/x402';
@@ -81,21 +82,33 @@ describe('parseMaxFromPriceString', () => {
 
 describe('formatPricingLabel', () => {
   it('shows exact price for non-dynamic', () => {
-    expect(formatPricingLabel({ maxAmount: 300, isDynamic: false })).toBe(
+    expect(formatPricingLabel({ maxUsdAmount: 300, isDynamic: false })).toBe(
       '$300.00'
     );
   });
 
   it('shows "Up to" for dynamic without price', () => {
-    expect(formatPricingLabel({ maxAmount: 300, isDynamic: true })).toBe(
+    expect(formatPricingLabel({ maxUsdAmount: 300, isDynamic: true })).toBe(
       'Up to $300.00'
+    );
+  });
+
+  it('shows paid for fixed pricing without USD metadata or a USDC accept', () => {
+    expect(formatPricingLabel({ maxUsdAmount: null, isDynamic: false })).toBe(
+      'Paid'
+    );
+  });
+
+  it('shows paid for dynamic pricing without USD metadata or a USDC accept', () => {
+    expect(formatPricingLabel({ maxUsdAmount: null, isDynamic: true })).toBe(
+      'Paid'
     );
   });
 
   it('shows "Up to" for dynamic with zero min', () => {
     expect(
       formatPricingLabel({
-        maxAmount: 300,
+        maxUsdAmount: 300,
         isDynamic: true,
         price: '0-300.00 USD',
       })
@@ -105,7 +118,7 @@ describe('formatPricingLabel', () => {
   it('shows range for dynamic with nonzero min', () => {
     expect(
       formatPricingLabel({
-        maxAmount: 300,
+        maxUsdAmount: 300,
         isDynamic: true,
         price: '50-300.00 USD',
       })
@@ -115,7 +128,7 @@ describe('formatPricingLabel', () => {
   it('shows range with small decimals', () => {
     expect(
       formatPricingLabel({
-        maxAmount: 5,
+        maxUsdAmount: 5,
         isDynamic: true,
         price: '0.01-5.00 USD',
       })
@@ -125,21 +138,71 @@ describe('formatPricingLabel', () => {
   it('shows "Up to" for dynamic with unparseable price', () => {
     expect(
       formatPricingLabel({
-        maxAmount: 300,
+        maxUsdAmount: 300,
         isDynamic: true,
         price: 'garbage',
       })
     ).toBe('Up to $300.00');
   });
 
-  it('ignores price when not dynamic', () => {
+  it('does not treat an ambiguous bare fixed price as USD', () => {
     expect(
       formatPricingLabel({
-        maxAmount: 300,
+        maxUsdAmount: null,
+        isDynamic: false,
+        price: '0.05',
+      })
+    ).toBe('Paid');
+  });
+
+  it('does not treat an ambiguous bare dynamic range as USD', () => {
+    expect(
+      formatPricingLabel({
+        maxUsdAmount: null,
+        isDynamic: true,
+        price: '0.001000-0.126000',
+      })
+    ).toBe('Paid');
+  });
+
+  it('preserves explicit zero-dollar fixed metadata', () => {
+    expect(
+      formatPricingLabel({
+        maxUsdAmount: null,
+        isDynamic: false,
+        price: '$0.00',
+      })
+    ).toBe('$0.00');
+  });
+
+  it('uses fixed USD price metadata instead of heterogeneous accept amounts', () => {
+    expect(
+      formatPricingLabel({
+        maxUsdAmount: null,
+        isDynamic: false,
+        price: '0.05 USD',
+      })
+    ).toBe('$0.05');
+  });
+
+  it('falls back to max amount for fixed pricing with range metadata', () => {
+    expect(
+      formatPricingLabel({
+        maxUsdAmount: 300,
         isDynamic: false,
         price: '50-300.00 USD',
       })
     ).toBe('$300.00');
+  });
+
+  it('uses dynamic USD metadata when no USDC accept exists', () => {
+    expect(
+      formatPricingLabel({
+        maxUsdAmount: null,
+        isDynamic: true,
+        price: '0.001000-0.126000 USD',
+      })
+    ).toBe('< $0.01–$0.13');
   });
 
   it('uses price string max when probed maxAmount is lower (dynamic pricing)', () => {
@@ -147,7 +210,7 @@ describe('formatPricingLabel', () => {
     // discovery price string has the real max ($0.126).
     expect(
       formatPricingLabel({
-        maxAmount: 0.001,
+        maxUsdAmount: 0.001,
         isDynamic: true,
         price: '0.001000-0.126000 USD',
       })
@@ -157,11 +220,59 @@ describe('formatPricingLabel', () => {
   it('uses probed maxAmount when it exceeds price string max', () => {
     expect(
       formatPricingLabel({
-        maxAmount: 500,
+        maxUsdAmount: 500,
         isDynamic: true,
         price: '50-300.00 USD',
       })
     ).toBe('$50.00–$500.00');
+  });
+});
+
+describe('getMaxUsdcAmount', () => {
+  it('prefers known USDC accepts over custom-token accepts', () => {
+    expect(
+      getMaxUsdcAmount([
+        {
+          network: 'base',
+          asset: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+          maxAmountRequired: 0.05,
+        },
+        {
+          network: 'solana',
+          asset: '6GGY8GViCR5v4xR4Lxb4nfiAJsEoJua5Gj6YecxbJ4BQ',
+          maxAmountRequired: 1333.728512,
+        },
+      ])
+    ).toBe(0.05);
+  });
+
+  it('returns null when no known USDC accept exists', () => {
+    expect(
+      getMaxUsdcAmount([
+        {
+          network: 'solana',
+          asset: '6GGY8GViCR5v4xR4Lxb4nfiAJsEoJua5Gj6YecxbJ4BQ',
+          maxAmountRequired: 1,
+        },
+        {
+          network: 'solana',
+          asset: 'AnotherTokenMint111111111111111111111111111111',
+          maxAmountRequired: 2,
+        },
+      ])
+    ).toBeNull();
+  });
+
+  it('ignores non-finite USDC amounts', () => {
+    expect(
+      getMaxUsdcAmount([
+        {
+          network: 'base',
+          asset: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+          maxAmountRequired: Number.POSITIVE_INFINITY,
+        },
+      ])
+    ).toBeNull();
   });
 });
 

--- a/apps/scan/src/app/(app)/_components/resources/utils.ts
+++ b/apps/scan/src/app/(app)/_components/resources/utils.ts
@@ -1,14 +1,32 @@
-import { formatCurrency } from '@/lib/utils';
+import { formatCurrency, USDC_ADDRESS } from '@/lib/utils';
 import { Methods } from '@/types/x402';
 import type { Resources } from '@x402scan/scan-db';
+
+interface PricingAccept {
+  maxAmountRequired: number;
+  network: string;
+  asset?: string | null;
+}
+
+const UNKNOWN_PAID_LABEL = 'Paid';
+
+function hasUsdPriceMarker(price: string): boolean {
+  return /^\s*\$/.test(price) || /\bUSD\s*$/i.test(price);
+}
+
+function parseFinitePriceAmount(value: string | undefined): number {
+  if (!value) return 0;
+  const parsed = parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
 
 /**
  * Parse the min value from a discovery price string like "50-300.00 USD".
  * Returns the numeric min, or 0 if unparseable.
  */
 export function parseMinFromPriceString(price: string): number {
-  const match = /^(\d+(?:\.\d+)?)\s*-/.exec(price);
-  return match?.[1] ? parseFloat(match[1]) : 0;
+  const match = /^\s*\$?\s*(\d+(?:\.\d+)?)\s*-/.exec(price);
+  return parseFinitePriceAmount(match?.[1]);
 }
 
 /**
@@ -16,8 +34,42 @@ export function parseMinFromPriceString(price: string): number {
  * Returns the numeric max, or 0 if unparseable.
  */
 export function parseMaxFromPriceString(price: string): number {
-  const match = /^\d+(?:\.\d+)?\s*-\s*(\d+(?:\.\d+)?)/.exec(price);
-  return match?.[1] ? parseFloat(match[1]) : 0;
+  const match = /^\s*\$?\s*\d+(?:\.\d+)?\s*-\s*\$?\s*(\d+(?:\.\d+)?)/.exec(
+    price
+  );
+  return parseFinitePriceAmount(match?.[1]);
+}
+
+/**
+ * Parse a fixed USD discovery price string like "0.05 USD".
+ * Returns null for ranges or ambiguous non-USD values.
+ */
+export function parseFixedUsdPriceString(price: string): number | null {
+  if (!hasUsdPriceMarker(price)) return null;
+  const match = /^\s*\$?\s*(\d+(?:\.\d+)?)\s*(?:USD)?\s*$/i.exec(price);
+  if (!match?.[1]) return null;
+  const value = parseFloat(match[1]);
+  return Number.isFinite(value) ? value : null;
+}
+
+export function isKnownUsdcAccept(accept: PricingAccept): boolean {
+  if (!accept.asset) return false;
+  if (accept.network === 'base') {
+    return accept.asset.toLowerCase() === USDC_ADDRESS.base;
+  }
+  if (accept.network === 'solana') {
+    return accept.asset === USDC_ADDRESS.solana;
+  }
+  return false;
+}
+
+export function getMaxUsdcAmount(accepts: PricingAccept[]): number | null {
+  const usdcAmounts = accepts
+    .filter(isKnownUsdcAccept)
+    .map(a => a.maxAmountRequired)
+    .filter(Number.isFinite);
+  if (usdcAmounts.length === 0) return null;
+  return Math.max(...usdcAmounts);
 }
 
 /**
@@ -27,21 +79,37 @@ export function parseMaxFromPriceString(price: string): number {
  * - Dynamic without range → "Up to $300.00"
  */
 export function formatPricingLabel(opts: {
-  maxAmount: number;
+  maxUsdAmount?: number | null;
   isDynamic: boolean;
   price?: string;
 }): string {
-  if (!opts.isDynamic) return formatCurrency(opts.maxAmount);
-  const minAmount = opts.price ? parseMinFromPriceString(opts.price) : 0;
+  if (!opts.isDynamic) {
+    const fixedUsdAmount = opts.price
+      ? parseFixedUsdPriceString(opts.price)
+      : null;
+    if (fixedUsdAmount !== null) return formatCurrency(fixedUsdAmount);
+    if (opts.maxUsdAmount != null) return formatCurrency(opts.maxUsdAmount);
+    return UNKNOWN_PAID_LABEL;
+  }
+  const hasUsdPrice = opts.price ? hasUsdPriceMarker(opts.price) : false;
+  const minAmount =
+    opts.price && hasUsdPrice ? parseMinFromPriceString(opts.price) : 0;
   // For dynamic pricing the probed maxAmountRequired may only reflect the
   // minimum request (empty params). Prefer the max from the discovery price
   // string when it's larger.
-  const parsedMax = opts.price ? parseMaxFromPriceString(opts.price) : 0;
-  const effectiveMax = Math.max(opts.maxAmount, parsedMax);
-  if (minAmount > 0) {
+  const parsedMax =
+    opts.price && hasUsdPrice ? parseMaxFromPriceString(opts.price) : 0;
+  const effectiveMax =
+    opts.maxUsdAmount != null
+      ? Math.max(opts.maxUsdAmount, parsedMax)
+      : parsedMax;
+  if (minAmount > 0 && effectiveMax > 0) {
     return `${formatCurrency(minAmount)}–${formatCurrency(effectiveMax)}`;
   }
-  return `Up to ${formatCurrency(effectiveMax)}`;
+  if (effectiveMax > 0) {
+    return `Up to ${formatCurrency(effectiveMax)}`;
+  }
+  return UNKNOWN_PAID_LABEL;
 }
 
 export function isSiwxResource(resource: Pick<Resources, 'metadata'>): boolean {

--- a/apps/scan/src/app/(app)/_components/resources/utils.ts
+++ b/apps/scan/src/app/(app)/_components/resources/utils.ts
@@ -44,7 +44,7 @@ export function parseMaxFromPriceString(price: string): number {
  * Parse a fixed USD discovery price string like "0.05 USD".
  * Returns null for ranges or ambiguous non-USD values.
  */
-export function parseFixedUsdPriceString(price: string): number | null {
+function parseFixedUsdPriceString(price: string): number | null {
   if (!hasUsdPriceMarker(price)) return null;
   const match = /^\s*\$?\s*(\d+(?:\.\d+)?)\s*(?:USD)?\s*$/i.exec(price);
   if (!match?.[1]) return null;
@@ -52,7 +52,7 @@ export function parseFixedUsdPriceString(price: string): number | null {
   return Number.isFinite(value) ? value : null;
 }
 
-export function isKnownUsdcAccept(accept: PricingAccept): boolean {
+function isKnownUsdcAccept(accept: PricingAccept): boolean {
   if (!accept.asset) return false;
   if (accept.network === 'base') {
     return accept.asset.toLowerCase() === USDC_ADDRESS.base;


### PR DESCRIPTION
## Summary

Fixes resource price labels when an endpoint advertises non-USDC x402 accepts alongside, or instead of, USD-denominated pricing metadata.

The previous resource card path serialized every accept with USDC decimals, took the maximum amount across heterogeneous assets, and formatted that value as USD. For merchants like Claw Hunter, this turned a custom Solana Token-2022 accept amount into labels like `$1.33K` even though discovery metadata and USDC accepts indicated `$0.05`.

## Changes

- Treat known USDC accepts as the only accept-derived USD amount source.
- Prefer explicit fixed USD metadata such as `0.05 USD` for fixed-price labels.
- Use explicit USD range metadata for dynamic labels even when no USDC accept is available.
- Fall back to a neutral `Paid` label instead of inventing a dollar value from custom-token amounts.
- Avoid treating ambiguous bare strings like `0.05` or `0.001-0.126` as USD in the display formatter.
- Add regression coverage for Claw Hunter-shaped multi-asset accepts, custom-token-only cases, explicit zero-dollar metadata, ambiguous metadata, and non-finite amount guards.
