### PR TITLE
Document merchant onboarding pitfalls

### DIFF
--- a/apps/scan/src/app/(app)/(home)/integration-spec/_content/markdown.ts
+++ b/apps/scan/src/app/(app)/(home)/integration-spec/_content/markdown.ts
@@ -33,6 +33,7 @@ Recommended:
 
 - Fixed: \`{ price: { mode: "fixed", currency: "USD", amount: "<amount>" } }\`
 - Dynamic: \`{ price: { mode: "dynamic", currency: "USD", min: "<min>", max: "<max>" } }\`
+- OpenAPI \`x-payment-info.price.amount\` is decimal USD; runtime x402 v2 \`accepts[].amount\` is token atomic units (for USDC, \`0.01\` => \`"10000"\`).
 
 ### Minimal valid example
 
@@ -146,5 +147,7 @@ If your OpenAPI spec includes endpoints that are neither x402-paid nor SIWX (e.g
 | Not Found | OpenAPI not found at \`{origin}/openapi.json\` | Add an OpenAPI document at \`{origin}/openapi.json\` |
 | Input/Output Schema Missing | Operation has no input or output schema | Add an input and output schema to the operation |
 | No Payment Modes Detected | No payment modes detected in the response | Add a valid payment mode to the response (x402) |
+| Expected 402, got 400 | Request validation rejected the unauthenticated probe before payment middleware ran | Let probes reach the \`402\` challenge before body/query validation, or add schemas/examples that let probes send valid input |
+| Malformed Runtime Amount | Runtime x402 v2 \`accepts[].amount\` or legacy \`maxAmountRequired\` used decimal dollars | Encode runtime amounts in token atomic units (for USDC, \`0.01\` => \`"10000"\`) |
 | No valid x402 response / No 402 challenge | Endpoint is free but not marked as such | Add \`"security": []\` to the operation in your OpenAPI spec |
 `;

--- a/apps/scan/src/app/(app)/(home)/integration-spec/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/integration-spec/page.tsx
@@ -58,7 +58,8 @@ SIWX (identity-only) routes:
 
 Rules:
 - Runtime 402 behavior is authoritative over static metadata.
-- "amount" is for both runtime accepts and x-payment-info fixed pricing.
+- OpenAPI x-payment-info.price.amount is decimal USD; runtime x402 v2 accepts[].amount is token atomic units (for USDC, 0.01 => "10000").
+- Registration probes must reach a 402 challenge before body/query validation rejects the request.
 
 Workflow:
 0) Install the agentcash MCP server:
@@ -243,6 +244,12 @@ export default function DiscoverySpecPage() {
                     }
                   </code>
                 </li>
+                <li>
+                  OpenAPI <code>x-payment-info.price.amount</code> is decimal
+                  USD; runtime x402 v2 <code>accepts[].amount</code> is token
+                  atomic units. For USDC, <code>0.01</code> becomes{' '}
+                  <code>&quot;10000&quot;</code>.
+                </li>
               </ul>
               <h3 className="text-sm font-semibold">Minimal valid example</h3>
               <CodeBlock
@@ -420,6 +427,11 @@ export default function DiscoverySpecPage() {
               with at least one x402 entry in <code>accepts</code>.
             </li>
             <li>
+              Request validation should let unauthenticated probes reach the{' '}
+              <code>402</code> challenge before body/query schema checks reject
+              the request.
+            </li>
+            <li>
               Endpoints without an input schema are non-invocable and are
               skipped during registration. Publish an OpenAPI schema (or a{' '}
               <code>402</code> body that carries one) to make the endpoint
@@ -470,6 +482,33 @@ export default function DiscoverySpecPage() {
                     error: 'No Payment Modes Detected',
                     cause: 'No payment modes detected in the response',
                     fix: 'Add a valid payment mode to the response (x402)',
+                  },
+                  {
+                    error: 'Expected 402, got 400',
+                    cause:
+                      'Request validation rejected the unauthenticated probe before payment middleware ran',
+                    fix: (
+                      <>
+                        <span>
+                          Let probes reach the <code>402</code> challenge before
+                          body/query validation, or add schemas/examples that
+                          let probes send valid input
+                        </span>
+                      </>
+                    ),
+                  },
+                  {
+                    error: 'Malformed Runtime Amount',
+                    cause: (
+                      <>
+                        <span>Runtime x402 </span>
+                        <code>accepts[].amount</code>
+                        <span> or legacy </span>
+                        <code>maxAmountRequired</code>
+                        <span> used decimal dollars</span>
+                      </>
+                    ),
+                    fix: 'Encode runtime amounts in token atomic units (for USDC, 0.01 => "10000")',
                   },
                 ];
                 return (

--- a/docs/DISCOVERY.md
+++ b/docs/DISCOVERY.md
@@ -106,9 +106,11 @@ Accepted challenge transport:
 For payable indexing in `x402scan`, challenge data should include:
 - non-empty `accepts`
 - Bazaar-style input schema (`extensions.bazaar.info` + schema-derived input)
+- runtime v2 `accepts[].amount` or legacy `maxAmountRequired` encoded in token atomic units (for USDC, `0.01` => `"10000"`)
 
 Compatibility behavior:
 - `402` + `accepts: []` + `extensions["sign-in-with-x"]` => SIWX auth-only, marked `skipped`.
+- Request validation should let unauthenticated probes reach the `402` challenge before body/query schema checks reject the request.
 - Missing input schema => strict non-invocable, marked `skipped`.
 
 ---
@@ -142,7 +144,9 @@ When a user clicks **Register This URL Only**:
 ## Common Failure Reasons
 
 - `Expected 402, got 404/405/429`
+- `Expected 402, got 400` from request validation running before payment challenge
 - `parseResponse: Accepts must contain at least one valid payment requirement`
+- malformed runtime amount, especially decimal dollars instead of token atomic units in v2 `accepts[].amount` or legacy `maxAmountRequired`
 - `parseResponse: Missing input schema`
 - discovery fetch/parse failures for OpenAPI or `/.well-known/x402`
 
@@ -169,7 +173,8 @@ curl -i -X GET https://yourdomain.com/api/route
 
 ## Recommended Migration Order
 
-1. Ensure routes return valid x402 challenges (`402`, parseable, non-empty `accepts` for payable routes).
+1. Ensure routes return valid x402 challenges (`402`, parseable, non-empty `accepts` for payable routes, runtime amounts in token atomic units).
 2. Add OpenAPI discovery + `x-payment-info` + security declarations.
-3. Keep `/.well-known/x402` compat during migration.
-4. Remove compat paths when your consumers no longer depend on them.
+3. Confirm unauthenticated probes reach `402` before request validation rejects missing body/query data.
+4. Keep `/.well-known/x402` compat during migration.
+5. Remove compat paths when your consumers no longer depend on them.


### PR DESCRIPTION
## Summary

- Clarify discovery and registration guidance for merchant setup pitfalls.
- Document that unauthenticated probes need to reach `402` before request validation rejects missing input.
- Clarify x402 runtime amount encoding, including v2 `accepts[].amount`, legacy `maxAmountRequired`, and USDC atomic-unit examples.
