### PR TITLE
feat: support Polygon resource registration

### DIFF
--- a/apps/scan/src/services/cdp/server-wallet/wallets/index.ts
+++ b/apps/scan/src/services/cdp/server-wallet/wallets/index.ts
@@ -7,6 +7,7 @@ import type { EvmWallets, Wallets } from './types';
 
 const evmWallets = (name: string): EvmWallets => ({
   [Chain.BASE]: evmServerWallet(Chain.BASE)(name),
+  [Chain.POLYGON]: evmServerWallet(Chain.POLYGON)(name),
 });
 
 export const wallets = (name: string): Wallets => ({

--- a/apps/scan/src/types/chain.ts
+++ b/apps/scan/src/types/chain.ts
@@ -9,7 +9,11 @@ export enum Chain {
 
 export type EvmChain = Exclude<Chain, Chain.SOLANA>;
 
-export const SUPPORTED_CHAINS = [Chain.BASE, Chain.SOLANA] as const;
+export const SUPPORTED_CHAINS = [
+  Chain.BASE,
+  Chain.SOLANA,
+  Chain.POLYGON,
+] as const;
 
 export type SupportedChain = (typeof SUPPORTED_CHAINS)[number];
 


### PR DESCRIPTION
Fixes https://github.com/Merit-Systems/x402scan/issues/1012

Adds `Chain.POLYGON` to `SUPPORTED_CHAINS` so resources advertising `eip155:137` can be registered. The registration prober already normalizes `eip155:137` → `polygon` and the facilitators dashboard already tracks Polygon addresses — the allowlist was the only surface rejecting it.

## Changes
- `apps/scan/src/types/chain.ts`: add `Chain.POLYGON` to `SUPPORTED_CHAINS` (prettier-formatted)
- `apps/scan/src/services/cdp/server-wallet/wallets/index.ts`: the one type ripple — `EvmWallets` is keyed by `SupportedEVMChain`, so add a Polygon entry via the existing chain-generic `evmServerWallet` (it already threads `network: chain` to CDP)

## Verification
- `tsc --noEmit`: error set byte-identical to baseline (zero new errors; pre-existing prisma-generate/analytics-db errors unaffected)
- `vitest run`: 158/158 pass
- `eslint --max-warnings 0`: clean on changed files

## Note
If enabling the CDP server-wallet on Polygon isn't desirable yet, I'm happy to rework this as a separate `REGISTRABLE_CHAINS` list (registration/indexing only) — just say the word.