### PR TITLE
feat(scan): register OpenAPI security:[] endpoints as public resources

### DIFF
--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -646,25 +646,25 @@ export const RegisterResourceForm = () => {
         );
       })()}
 
-      {/* Unprotected endpoints — skipped, not an error */}
+      {/* Unprotected endpoints — registered as free public reads */}
       {!activeBulkResult && skippedResources.length > 0 && (
         <Collapsible>
           <CollapsibleTrigger asChild>
             <button className="text-xs text-yellow-600 dark:text-yellow-500 flex items-center gap-1 hover:text-yellow-700 transition-colors">
               <ChevronDown className="size-3" />
-              {skippedResources.length} unprotected endpoint
-              {skippedResources.length === 1 ? '' : 's'} skipped
+              {skippedResources.length} endpoint
+              {skippedResources.length === 1 ? '' : 's'} not registrable
             </button>
           </CollapsibleTrigger>
           <CollapsibleContent className="pt-2 space-y-2">
             <p className="text-xs text-muted-foreground">
-              These endpoints have no x402 paywall and won&apos;t be registered.
-              If they should be paid, add x402 payment middleware. If they are
-              intentionally free, add{' '}
+              These endpoints use API-key auth only and are not indexed by
+              x402scan. Paid routes need x-payment-info; free public routes
+              should declare{' '}
               <code className="font-mono bg-muted px-1 rounded text-[11px]">
                 &quot;security&quot;: []
               </code>{' '}
-              to their OpenAPI definition to suppress this notice.
+              (no x-payment-info) so they register as public reads.
             </p>
             <div className="space-y-1 max-h-[200px] overflow-y-auto">
               {skippedResources.map((r, idx) => (

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
@@ -142,11 +142,13 @@ export interface DiscoveryPanelProps {
     success: boolean;
     registered: number;
     siwx?: number;
+    public?: number;
     total: number;
     failed: number;
     skipped?: number;
     deprecated?: number;
     failedDetails?: { url: string; error: string; status?: number }[];
+    publicDetails?: { url: string }[];
     siwxDetails?: { url: string }[];
     skippedDetails?: { url: string; error: string; status?: number }[];
     warningDetails?: {
@@ -233,12 +235,15 @@ export function DiscoveryPanel({
   if (!isTestMode && bulkResult?.success) {
     const skippedDetails = bulkResult.skippedDetails ?? [];
     const siwxCount = bulkResult.siwx ?? 0;
+    const publicCount = bulkResult.public ?? 0;
+    const registeredTotal = bulkResult.registered + siwxCount + publicCount;
 
-    // Show error state only if nothing landed positively (no paid registers
-    // and no SIWX detections) and there were real failures.
+    // Show error state only if nothing landed positively (no paid registers,
+    // no SIWX, no public) and there were real failures.
     if (
       bulkResult.registered === 0 &&
       siwxCount === 0 &&
+      publicCount === 0 &&
       bulkResult.failed > 0
     ) {
       return (
@@ -251,8 +256,7 @@ export function DiscoveryPanel({
               </h2>
               <p className="text-sm text-muted-foreground">
                 Failed to register all{' '}
-                {bulkResult.registered +
-                  siwxCount +
+                {registeredTotal +
                   (bulkResult.failedDetails?.length ?? 0)}{' '}
                 resources
               </p>
@@ -335,9 +339,8 @@ export function DiscoveryPanel({
           <Check className="size-6 text-green-600" />
           <div>
             <p className="text-sm font-medium">
-              Successfully registered {bulkResult.registered + siwxCount} of{' '}
-              {bulkResult.registered +
-                siwxCount +
+              Successfully registered {registeredTotal} of{' '}
+              {registeredTotal +
                 (bulkResult.failedDetails?.length ?? 0)}{' '}
               resources
               {notRegisteredCount > 0 && (
@@ -430,24 +433,23 @@ export function DiscoveryPanel({
           </details>
         )}
 
-        {/* Skipped — unprotected/non-registrable endpoints */}
+        {/* Skipped — apiKey-only / non-registrable endpoints */}
         {skippedDetails.length > 0 && (
           <details className="border rounded-md group">
             <summary className="p-3 cursor-pointer hover:bg-muted/50 font-medium text-sm flex items-center gap-2 text-yellow-600">
               <ChevronDown className="size-4 transition-transform group-open:rotate-180" />
               <AlertCircle className="size-4 shrink-0" />
-              {skippedDetails.length} unprotected endpoint
-              {skippedDetails.length === 1 ? '' : 's'} skipped
+              {skippedDetails.length} endpoint
+              {skippedDetails.length === 1 ? '' : 's'} not registrable
             </summary>
             <div className="p-4 pt-2 border-t space-y-2">
               <p className="text-xs text-muted-foreground">
-                These endpoints were identified as unprotected (no x402
-                paywall). They are not registered. If they should be paid, add
-                x402 payment middleware. If they are intentionally free, add{' '}
+                These endpoints use API-key auth only and are not indexed.
+                Free public routes should declare OpenAPI{' '}
                 <code className="font-mono bg-muted px-1 rounded">
                   &quot;security&quot;: []
                 </code>{' '}
-                to their OpenAPI definition to suppress this notice.
+                (no x-payment-info) so they register as public reads.
               </p>
               <div className="space-y-1 max-h-[200px] overflow-y-auto">
                 {skippedDetails.map((skipped, idx) => (

--- a/apps/scan/src/app/(app)/_components/discovery/use-discovery.ts
+++ b/apps/scan/src/app/(app)/_components/discovery/use-discovery.ts
@@ -104,6 +104,7 @@ export interface UseDiscoveryReturn {
     success: true;
     registered: number;
     siwx: number;
+    public: number;
     total: number;
     failed: number;
     skipped?: number;
@@ -135,7 +136,12 @@ export interface UseDiscoveryReturn {
 }
 
 /** Auth modes that are relevant to x402scan (paid + free/SIWX). */
-const REGISTRABLE_AUTH_MODES = new Set(['paid', 'apiKey+paid', 'siwx']);
+const REGISTRABLE_AUTH_MODES = new Set([
+  'paid',
+  'apiKey+paid',
+  'siwx',
+  'unprotected',
+]);
 
 export function useDiscovery({
   url,
@@ -169,8 +175,8 @@ export function useDiscovery({
   const discoveryFound = discoveryQuery.data?.found ?? false;
   const discoveryResources: DiscoveredResource[] = useMemo(() => {
     const raw = discoveryQuery.data?.found ? discoveryQuery.data.resources : [];
-    // Exclude endpoints explicitly classified as non-registrable (unprotected,
-    // apiKey). Keep registrable (paid, siwx) and unclassified (authMode absent)
+    // Exclude endpoints explicitly classified as non-registrable (apiKey).
+    // Keep registrable (paid, siwx, unprotected) and unclassified (authMode absent)
     // — unclassified endpoints may be paid but the discovery package didn't
     // detect it (e.g. bazaar-only endpoints).
     return raw.filter(
@@ -376,12 +382,14 @@ export function useDiscovery({
           success: true as const,
           registered: bulkData.registered,
           siwx: bulkData.siwx,
+          public: bulkData.public,
           total: bulkData.total,
           failed: bulkData.failed,
           skipped: bulkData.skipped,
           deprecated: bulkData.deprecated,
           failedDetails: bulkData.failedDetails,
           siwxDetails: bulkData.siwxDetails,
+          publicDetails: bulkData.publicDetails,
           skippedDetails: bulkData.skippedDetails,
           warningDetails: bulkData.warningDetails,
           originId: bulkData.originId,

--- a/apps/scan/src/app/api/x402/_handlers/registry-register-origin.ts
+++ b/apps/scan/src/app/api/x402/_handlers/registry-register-origin.ts
@@ -42,14 +42,14 @@ export async function handleRegistryRegisterOrigin(
     console.error('revalidatePath failed:', e);
   }
 
-  if (result.registered === 0) {
+  if (result.registered === 0 && result.siwx === 0 && result.public === 0) {
     return jsonResponse(
       {
         success: false,
         error: {
           type: 'no_valid_resources',
           message:
-            'No valid paid x402 resources were found for this origin. Add at least one paid x402 resource that passes validation to complete registration.',
+            'No valid paid x402, SIWX, or public resources were found for this origin. Add at least one resource that passes validation to complete registration.',
         },
         result,
       },
@@ -61,6 +61,7 @@ export async function handleRegistryRegisterOrigin(
     success: true,
     registered: result.registered,
     siwx: result.siwx,
+    public: result.public,
     failed: result.failed,
     skipped: result.skipped,
     deprecated: result.deprecated,
@@ -69,6 +70,8 @@ export async function handleRegistryRegisterOrigin(
     failedDetails:
       result.failedDetails.length > 0 ? result.failedDetails : undefined,
     siwxDetails: result.siwxDetails.length > 0 ? result.siwxDetails : undefined,
+    publicDetails:
+      result.publicDetails.length > 0 ? result.publicDetails : undefined,
     ...contactEmailFields(discoveryResult.contactEmail),
   });
 }

--- a/apps/scan/src/hooks/use-register-from-origin.ts
+++ b/apps/scan/src/hooks/use-register-from-origin.ts
@@ -6,6 +6,7 @@ import { toast } from 'sonner';
 interface RegisterFromOriginSuccessData {
   registered: number;
   siwx: number;
+  public: number;
   failed: number;
   skipped: number;
   deprecated?: number;
@@ -56,6 +57,7 @@ export function useRegisterFromOrigin(
         const parts: string[] = [];
         if (data.registered > 0) parts.push(`${data.registered} registered`);
         if (data.siwx > 0) parts.push(`${data.siwx} SIWX`);
+        if (data.public > 0) parts.push(`${data.public} public`);
         if (data.deprecated > 0) parts.push(`${data.deprecated} removed`);
         if (data.skipped > 0) parts.push(`${data.skipped} skipped`);
         if (data.failed > 0) parts.push(`${data.failed} failed`);
@@ -67,12 +69,14 @@ export function useRegisterFromOrigin(
       onSuccess?.({
         registered: data.registered,
         siwx: data.siwx,
+        public: data.public,
         failed: data.failed,
         skipped: data.skipped,
         deprecated: data.deprecated,
         total: data.total,
         failedDetails: data.failedDetails,
         siwxDetails: data.siwxDetails,
+        publicDetails: data.publicDetails,
         skippedDetails: data.skippedDetails,
         warningDetails: data.warningDetails,
         originId: data.originId,

--- a/apps/scan/src/lib/discovery/register-origin.ts
+++ b/apps/scan/src/lib/discovery/register-origin.ts
@@ -1,7 +1,11 @@
 import { probeX402Endpoint } from './probe';
 import { getCachedProbeResult } from './probe-cache';
 import { getRegistrationErrorMessage } from './utils';
-import { registerResource, registerSiwxResource } from '@/lib/resources';
+import {
+  registerPublicResource,
+  registerResource,
+  registerSiwxResource,
+} from '@/lib/resources';
 import { deprecateStaleResources } from '@/services/db/resources/resource';
 import {
   getOriginResourceCount,
@@ -64,6 +68,7 @@ async function mapSettledWithConcurrency<T, R>(
 export interface RegisterOriginResult {
   registered: number;
   siwx: number;
+  public: number;
   failed: number;
   skipped: number;
   deprecated: number;
@@ -71,6 +76,7 @@ export interface RegisterOriginResult {
   source: string | undefined;
   failedDetails: { url: string; error: string; status?: number }[];
   siwxDetails: { url: string }[];
+  publicDetails: { url: string }[];
   skippedDetails: { url: string; error: string; status?: number }[];
   warningDetails: {
     url: string;
@@ -82,8 +88,8 @@ export interface RegisterOriginResult {
 /**
  * Probe and register all resources from a discovery document.
  * Paid resources are probed and written to the resources table.
- * SIWX (free) resources are written to the resources table without probing
- * (they have no x402 payment options — just a Resource row, no Accepts).
+ * SIWX (identity-gated) and public (`security: []`, no x-payment-info) resources
+ * are written without probing — Resource row only, no Accepts.
  * Endpoints missing an input schema are reported as skipped.
  * Deprecates resources from the same origin that are no longer in the list.
  *
@@ -145,7 +151,27 @@ export async function registerResourcesFromDiscovery(
         };
   }
 
-  const SKIP_AUTH_MODES = new Set(['unprotected', 'apiKey']);
+  async function registerAsPublic(resourceUrl: string, method?: string) {
+    const publicResult = await registerPublicResource(resourceUrl, {
+      method,
+      originMetadataFallback: originInfo,
+      skipMetadataScrape: true,
+    });
+    return publicResult.success
+      ? {
+          success: true as const,
+          public: true as const,
+          url: resourceUrl,
+          resource: publicResult.resource,
+        }
+      : {
+          success: false as const,
+          url: resourceUrl,
+          error: publicResult.error,
+        };
+  }
+
+  const SKIP_AUTH_MODES = new Set(['apiKey']);
 
   const results = await mapSettledWithConcurrency(resources, async resource => {
     const resourceUrl = resource.url;
@@ -166,6 +192,10 @@ export async function registerResourcesFromDiscovery(
         resource.price,
         resource.method
       );
+    }
+
+    if (resource.authMode === 'unprotected') {
+      return registerAsPublic(resourceUrl, resource.method);
     }
 
     // Check server-side probe cache (from the batch test). This skips
@@ -244,6 +274,7 @@ export async function registerResourcesFromDiscovery(
     description: string | null;
   }[] = [];
   const siwxResults: { url: string; method: string }[] = [];
+  const publicResults: { url: string; method: string }[] = [];
   const failedResults: { url: string; error: string; status?: number }[] = [];
   const skippedResults: { url: string; error: string; status?: number }[] = [];
   const warningResults: {
@@ -265,6 +296,11 @@ export async function registerResourcesFromDiscovery(
         if ('siwx' in value && value.siwx === true) {
           siwxResults.push({ url: resourceUrl, method: resourceMethod });
           // Extract originId from SIWX registration result
+          if (!originId && 'resource' in value && value.resource?.origin?.id) {
+            originId = value.resource.origin.id;
+          }
+        } else if ('public' in value && value.public === true) {
+          publicResults.push({ url: resourceUrl, method: resourceMethod });
           if (!originId && 'resource' in value && value.resource?.origin?.id) {
             originId = value.resource.origin.id;
           }
@@ -347,6 +383,10 @@ export async function registerResourcesFromDiscovery(
         url: normalizeResourceUrl(r.url),
         method: r.method,
       })),
+      ...publicResults.map(r => ({
+        url: normalizeResourceUrl(r.url),
+        method: r.method,
+      })),
     ];
     deprecated = await deprecateStaleResources(originId, activeResources);
   }
@@ -374,7 +414,9 @@ export async function registerResourcesFromDiscovery(
   // failed have no origin row — scraping would cause upsertOrigin to create
   // one, re-introducing the orphan problem.
   const originsWithResources = new Set(
-    [...successfulResults, ...siwxResults].map(r => getOriginFromUrl(r.url))
+    [...successfulResults, ...siwxResults, ...publicResults].map(r =>
+      getOriginFromUrl(r.url)
+    )
   );
   const originsToScrape = uniqueOrigins.filter(
     origin =>
@@ -437,6 +479,7 @@ export async function registerResourcesFromDiscovery(
   return {
     registered: successfulResults.length,
     siwx: siwxResults.length,
+    public: publicResults.length,
     failed: failedResults.length,
     skipped: skippedResults.length,
     deprecated,
@@ -444,6 +487,7 @@ export async function registerResourcesFromDiscovery(
     source,
     failedDetails: failedResults,
     siwxDetails: siwxResults,
+    publicDetails: publicResults,
     skippedDetails: skippedResults,
     warningDetails: warningResults,
     originId,

--- a/apps/scan/src/lib/resources.ts
+++ b/apps/scan/src/lib/resources.ts
@@ -324,6 +324,160 @@ export async function registerSiwxResource(
   }
 }
 
+/**
+ * Register a public (free, no-auth) endpoint declared with OpenAPI
+ * `security: []` and no `x-payment-info`. Same persistence shape as SIWX:
+ * Resource row only — no Accepts, no 402 probe.
+ */
+export async function registerPublicResource(
+  url: string,
+  options: {
+    method?: string;
+    originMetadataFallback?: { title?: string; description?: string };
+    /** Skip metadata scrape+upsert — caller handles it (e.g. batch registration). */
+    skipMetadataScrape?: boolean;
+  } = {}
+) {
+  const urlObj = new URL(url);
+  if (
+    urlObj.protocol === 'http:' &&
+    urlObj.hostname !== 'localhost' &&
+    urlObj.hostname !== '127.0.0.1'
+  ) {
+    return {
+      success: false as const,
+      error: 'HTTPS is required for resource registration',
+    };
+  }
+
+  const cleanUrl = normalizeResourceUrl(url);
+  const origin = getOriginFromUrl(cleanUrl);
+
+  try {
+    const resource = await scanDb.$transaction(async tx => {
+      await ensureOriginExists(tx, origin);
+
+      const publicMetadata = { authMode: 'unprotected' as const };
+      const method = options.method ?? '';
+      const existing = await tx.resources.findUnique({
+        where: {
+          resource_method: { resource: cleanUrl, method },
+        },
+        select: { metadata: true },
+      });
+      const mergedMetadata =
+        existing?.metadata &&
+        typeof existing.metadata === 'object' &&
+        !Array.isArray(existing.metadata)
+          ? { ...existing.metadata, ...publicMetadata }
+          : publicMetadata;
+
+      return tx.resources.upsert({
+        where: {
+          resource_method: { resource: cleanUrl, method },
+        },
+        create: {
+          resource: cleanUrl,
+          method,
+          type: 'http',
+          x402Version: 0,
+          lastUpdated: new Date(),
+          metadata: publicMetadata,
+          origin: { connect: { origin } },
+        },
+        update: {
+          type: 'http',
+          x402Version: 0,
+          lastUpdated: new Date(),
+          metadata: mergedMetadata,
+          deprecatedAt: null,
+          origin: { connect: { origin } },
+        },
+        include: { origin: true },
+      });
+    });
+
+    if (!options.skipMetadataScrape) {
+      try {
+        const { og, metadata, favicon } = await scrapeOriginData(origin);
+        const title =
+          metadata?.title ??
+          og?.ogTitle ??
+          options.originMetadataFallback?.title ??
+          null;
+        const description =
+          metadata?.description ??
+          og?.ogDescription ??
+          options.originMetadataFallback?.description ??
+          null;
+
+        await upsertOrigin({
+          origin,
+          title: title ?? undefined,
+          description: description ?? undefined,
+          favicon: favicon ?? undefined,
+          ogImages:
+            og?.ogImage?.flatMap(image => {
+              try {
+                return [
+                  {
+                    url: new URL(image.url, origin).toString(),
+                    height: image.height,
+                    width: image.width,
+                    title: og.ogTitle,
+                    description: og.ogDescription,
+                  },
+                ];
+              } catch {
+                return [];
+              }
+            }) ?? [],
+        });
+      } catch (err) {
+        console.error(
+          '[registerPublicResource] Metadata scrape failed (non-blocking):',
+          err
+        );
+      }
+    }
+
+    return {
+      success: true as const,
+      resource: {
+        id: resource.id,
+        origin: { id: resource.origin.id },
+      },
+    };
+  } catch (error) {
+    const isUniqueViolation =
+      error instanceof Error &&
+      'code' in error &&
+      (error as { code: string }).code === 'P2002';
+    if (isUniqueViolation) {
+      const existing = await scanDb.resources.findUnique({
+        where: {
+          resource_method: {
+            resource: cleanUrl,
+            method: options.method ?? '',
+          },
+        },
+        include: { origin: true },
+      });
+      return {
+        success: true as const,
+        resource: existing
+          ? { id: existing.id, origin: { id: existing.origin.id } }
+          : { id: 'race-resolved', origin: { id: 'race-resolved' } },
+      };
+    }
+    console.error('[registerPublicResource] Failed:', error);
+    return {
+      success: false as const,
+      error: error instanceof Error ? error.message : 'Database error',
+    };
+  }
+}
+
 export const registerResource = async (
   url: string,
   advisory: EndpointMethodAdvisory,

--- a/apps/scan/src/trpc/routers/developer.ts
+++ b/apps/scan/src/trpc/routers/developer.ts
@@ -206,8 +206,8 @@ export const developerRouter = createTRPCRouter({
         }));
 
       // Probe endpoints that are x402-paid or unclassified (might be paid but
-      // discovery didn't detect it). Skip SIWX (identity-gated, not x402) and
-      // explicitly non-paid (unprotected, apiKey).
+      // discovery didn't detect it). Skip SIWX (identity-gated), public
+      // (OpenAPI security: []), and apiKey-only routes.
       const skipModes = new Set(['siwx', 'unprotected', 'apiKey']);
       const probeableResources = input.resources.filter(
         r => !r.invalid && (r.authMode == null || !skipModes.has(r.authMode))

--- a/apps/scan/src/trpc/routers/public/resources.ts
+++ b/apps/scan/src/trpc/routers/public/resources.ts
@@ -221,13 +221,13 @@ export const resourcesRouter = createTRPCRouter({
         discoveryResult.contactEmail
       );
 
-      if (result.registered === 0 && result.siwx === 0) {
+      if (result.registered === 0 && result.siwx === 0 && result.public === 0) {
         return {
           success: false as const,
           error: {
             type: 'noValidResources' as const,
             message:
-              'No valid x402 or free (SIWX) resources were found for this origin. Add at least one resource that passes validation to complete registration.',
+              'No valid x402, SIWX, or public resources were found for this origin. Add at least one resource that passes validation to complete registration.',
           },
           result,
         };


### PR DESCRIPTION
## Problem

Bulk origin registration treats discovery `authMode: unprotected` (OpenAPI operation-level `"security": []` with no `x-payment-info`) as **skipped**, not registered. Origins that expose only intentional free public reads therefore fail with `no_valid_resources` even though the API correctly declares those routes.

Paid x402 and SIWX paths were already handled; unprotected was documented as “add security: [] to suppress the notice” but the scanner still did not persist those endpoints.

## Solution

- Add `registerPublicResource()` — same persistence shape as SIWX (Resource row, no Accepts, no 402 probe), metadata `authMode: unprotected`.
- Wire `authMode === 'unprotected'` through `registerResourcesFromDiscovery` batching.
- Count **public** alongside paid + SIWX in registry API, discovery panel, and success/failure gates.
- Treat `unprotected` as registrable in the discovery hook; keep **apiKey-only** as non-registrable.
- Update registration UI copy so free public routes are indexed when declared with `"security": []`.

## Ishtar / Datebook use case

[Ishtar Datebook](https://github.com/gokhan-vc/numetal-datebook) exposes six free HeartBench / floor / stats reads with explicit OpenAPI `security: []` (leaderboard JSON, scenarios, scenario-by-id, HTML view, plus existing public venue stats). Until this lands, x402scan registration for `ishtar.numetal.xyz` cannot complete with only those free catalog rows.

Companion worker PR: https://github.com/gokhan-vc/numetal-datebook/pull/57 (will update after creation)

## After merge (operator note)

**Merit deploy required.** Once this PR is merged and **production** x402scan ships the change, re-register the origin at:

https://www.x402scan.com/resources/register

Use the same discovery URL as before so the six public HeartBench routes (and any other `security: []` ops) are indexed.

## Access

Opened from fork `avalidurl/x402scan` — no direct push to `Merit-Systems/x402scan`. Happy to adjust if you prefer a maintainer branch.


Made with [Cursor](https://cursor.com)