### PR TITLE
fix: Top Servers volume/txns/buyers inflated by facilitator count

### DIFF
--- a/apps/scan/src/services/transfers/sellers/list-mv.ts
+++ b/apps/scan/src/services/transfers/sellers/list-mv.ts
@@ -71,29 +71,53 @@ export const listTopSellersMVUncached = async (
   const t0 = performance.now();
   const offset = pagination.page * pagination.page_size;
 
+  const orderByClause = Prisma.sql`ORDER BY ${Prisma.raw(
+    `"${sorting.id === 'editorial' ? 'recipient' : sorting.id}"`
+  )} ${
+    sorting.id !== 'editorial' && sorting.desc
+      ? Prisma.raw('DESC')
+      : Prisma.raw('ASC')
+  }`;
+
+  // Each MV row is already aggregated per (recipient, chain), so grouping by
+  // recipient (to fold multiple chains into one) and SUM-ing is correct on its
+  // own. facilitator_ids must be flattened in a per-recipient outer subquery —
+  // a `LATERAL unnest(facilitator_ids)` in the FROM clause fans each row out
+  // once per facilitator and multiplies tx_count/total_amount/unique_buyers by
+  // the facilitator count. Mirrors the buyers query in ../buyers/list-mv.ts.
   const items = await queryRaw(
     Prisma.sql`
-    SELECT 
-      recipient,
-      COALESCE(ARRAY_AGG(DISTINCT unnested_facilitator) FILTER (WHERE unnested_facilitator IS NOT NULL), ARRAY[]::text[]) as facilitator_ids,
-      COALESCE(SUM(total_transactions), 0)::integer as tx_count,
-      COALESCE(SUM(total_amount), 0)::float as total_amount,
-      MAX(latest_block_timestamp) as latest_block_timestamp,
-      COALESCE(SUM(unique_buyers), 0)::integer as unique_buyers,
-      COALESCE(ARRAY_AGG(DISTINCT chain) FILTER (WHERE chain IS NOT NULL), ARRAY[]::text[]) as chains
-    FROM ${Prisma.raw(tableName)},
-      LATERAL unnest(facilitator_ids) AS unnested_facilitator
-    ${whereClause}
-    GROUP BY recipient
-    ORDER BY ${Prisma.raw(
-      `"${sorting.id === 'editorial' ? 'recipient' : sorting.id}"`
-    )} ${
-      sorting.id !== 'editorial' && sorting.desc
-        ? Prisma.raw('DESC')
-        : Prisma.raw('ASC')
-    }
-    LIMIT ${pagination.page_size}
-    OFFSET ${offset}`,
+    WITH paginated AS (
+      SELECT
+        recipient,
+        COALESCE(SUM(total_transactions), 0)::integer as tx_count,
+        COALESCE(SUM(total_amount), 0)::float as total_amount,
+        MAX(latest_block_timestamp) as latest_block_timestamp,
+        COALESCE(SUM(unique_buyers), 0)::integer as unique_buyers,
+        COALESCE(ARRAY_AGG(DISTINCT chain) FILTER (WHERE chain IS NOT NULL), ARRAY[]::text[]) as chains
+      FROM ${Prisma.raw(tableName)}
+      ${whereClause}
+      GROUP BY recipient
+      ${orderByClause}
+      LIMIT ${pagination.page_size}
+      OFFSET ${offset}
+    )
+    SELECT
+      p.recipient,
+      COALESCE(
+        (SELECT ARRAY_AGG(DISTINCT f) FILTER (WHERE f IS NOT NULL)
+         FROM ${Prisma.raw(tableName)} mv, LATERAL unnest(mv.facilitator_ids) AS f
+         WHERE mv.recipient = p.recipient
+           ${input.chain ? Prisma.sql`AND mv.chain = ${input.chain}` : Prisma.empty}),
+        ARRAY[]::text[]
+      ) as facilitator_ids,
+      p.tx_count,
+      p.total_amount,
+      p.latest_block_timestamp,
+      p.unique_buyers,
+      p.chains
+    FROM paginated p
+    ${orderByClause}`,
     z.array(
       z.object({
         recipient: mixedAddressSchema,


### PR DESCRIPTION
## Problem

Mason flagged the home "Top Servers" leaderboard volume as suspicious (real vs wash vs counting bug). It's a **counting bug**: every metric — Volume, Txns, **and** Buyers — is multiplied by the number of distinct facilitators a server has transacted through.

Decoding the screenshot against the prod transfers replica, every row is `true_value × facilitator_count`:

| Server (screenshot) | Displayed | True | ×factor |
|---|---|---|---|
| ARVOS | $57.57M / 61.38M txns / 64.14K buyers | $11.51M / 12.38M / 12,827 | **×5** (`coinbase, daydreams, openx402, payAI, x402rs`) |
| QRBase | $14.00M | $6.99M | ×2 |
| ainalyst | $13.69M | $2.74M | ×5 |
| Barvis | $12.99M | $2.60M | ×5 |
| Canza | $12.35M | $2.06M | ×6 |
| ACP | $9.79M | $4.88M | ×2 |

Because the multiplier is the (arbitrary) facilitator count, the **ranking itself is distorted** — a modest server routing through 6 facilitators outranks a much larger one on a single facilitator.

## Root cause

`listTopSellersMVUncached` (`apps/scan/src/services/transfers/sellers/list-mv.ts`) queried the `recipient_stats_aggregated_<tf>` materialized views with:

```sql
FROM recipient_stats_aggregated_0d, LATERAL unnest(facilitator_ids) AS unnested_facilitator
... GROUP BY recipient
```

Each MV row is **already aggregated per `(recipient, chain)`** with `total_amount`/`total_transactions`/`unique_buyers` and a `facilitator_ids` array. The `LATERAL unnest(facilitator_ids)` fans that single row out once per facilitator, and the subsequent `SUM()`s re-add the already-aggregated totals — so an N-facilitator recipient gets N× volume, N× txns, N× buyers. The unnest was only there to rebuild the output `facilitator_ids` array; the facilitator **filter** (`facilitatorIds::text[] && facilitator_ids`) works on the array directly and never needed it.

Introduced in `1f7b4dff` "feat: add materialized views for recipient and origin stats" — the fanout shipped with the MV feature and lived ~6 months. The sibling **buyers** query (`../buyers/list-mv.ts`) was written correctly and even carries a comment warning about this exact hazard; only sellers had it.

## Fix

Mirror the already-correct buyers query: group + paginate by `recipient` with **no** unnest, then flatten `facilitator_ids` in a per-recipient outer subquery. `SUM()` now folds only across chains (as intended), and `facilitator_ids` is still returned for display. Single-file change.

## Verification

Reproduced and verified on the prod transfers replica (`TRANSFERS_DB_URL_REPLICA_1`, read-only):
- Buggy `LATERAL unnest` query returns **$57,570,282 / 61,877,565 / 64,135** for recipient `0xf7b1356…` (matches the screenshot's ARVOS row).
- Raw MV row / corrected query returns the true **$11,514,056 / 12,375,513 / 12,827** with 5 facilitators — exactly 5×.
- `types:check` + `lint` + `prettier` clean.

The top-level metric cards (`stats.overall`) are **not** affected — they use a different query with no `LATERAL unnest`; verified the headline total ($51.98M) matches the true per-recipient sum, not an inflated figure.
