### PR TITLE
chore: bump @agentcash/router to 1.18.0

### DIFF
--- a/apps/scan/package.json
+++ b/apps/scan/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@agentcash/discovery": "1.7.5",
-    "@agentcash/router": "1.10.1",
+    "@agentcash/router": "1.17.0",
     "@ai-sdk/openai": "^2.0.52",
     "@ai-sdk/react": "^2.0.68",
     "@auth/prisma-adapter": "^2.7.4",

--- a/apps/scan/package.json
+++ b/apps/scan/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@agentcash/discovery": "1.7.5",
-    "@agentcash/router": "1.17.0",
+    "@agentcash/router": "1.18.0",
     "@ai-sdk/openai": "^2.0.52",
     "@ai-sdk/react": "^2.0.68",
     "@auth/prisma-adapter": "^2.7.4",

--- a/apps/scan/src/app/api/x402/_lib/utils.ts
+++ b/apps/scan/src/app/api/x402/_lib/utils.ts
@@ -68,3 +68,13 @@ export function asChain(
 ): Chain | undefined {
   return chain as Chain | undefined;
 }
+
+/**
+ * Extract a dynamic path segment from a router handler's request.
+ * The handler's request is a Web Request (not NextRequest), so the
+ * pathname comes from request.url. Safe because Next only routes
+ * paths that match the route's shape.
+ */
+export function extractPathSegment(request: Request, index: number): string {
+  return new URL(request.url).pathname.split('/')[index]!;
+}

--- a/apps/scan/src/app/api/x402/merchants/[address]/stats/route.ts
+++ b/apps/scan/src/app/api/x402/merchants/[address]/stats/route.ts
@@ -1,5 +1,6 @@
 import { router, withCors, OPTIONS } from '@/lib/router';
 import { merchantStatsQuerySchema } from '@/app/api/x402/_lib/schemas';
+import { extractPathSegment } from '@/app/api/x402/_lib/utils';
 import { handleMerchantStats } from '@/app/api/x402/_handlers/merchant-stats';
 
 export { OPTIONS };
@@ -13,7 +14,7 @@ export const GET = withCors(
     .query(merchantStatsQuerySchema)
     .description('Aggregate stats for a merchant')
     .handler(({ query, request }) => {
-      const address = new URL(request.url).pathname.split('/')[4]!;
+      const address = extractPathSegment(request, 4);
       return handleMerchantStats(address, query);
     })
 );

--- a/apps/scan/src/app/api/x402/merchants/[address]/stats/route.ts
+++ b/apps/scan/src/app/api/x402/merchants/[address]/stats/route.ts
@@ -13,7 +13,7 @@ export const GET = withCors(
     .query(merchantStatsQuerySchema)
     .description('Aggregate stats for a merchant')
     .handler(({ query, request }) => {
-      const address = request.nextUrl.pathname.split('/')[4]!;
+      const address = new URL(request.url).pathname.split('/')[4]!;
       return handleMerchantStats(address, query);
     })
 );

--- a/apps/scan/src/app/api/x402/merchants/[address]/transactions/route.ts
+++ b/apps/scan/src/app/api/x402/merchants/[address]/transactions/route.ts
@@ -1,5 +1,6 @@
 import { router, withCors, OPTIONS } from '@/lib/router';
 import { merchantTransactionsQuerySchema } from '@/app/api/x402/_lib/schemas';
+import { extractPathSegment } from '@/app/api/x402/_lib/utils';
 import { handleMerchantTransactions } from '@/app/api/x402/_handlers/merchant-transactions';
 
 export { OPTIONS };
@@ -13,7 +14,7 @@ export const GET = withCors(
     .query(merchantTransactionsQuerySchema)
     .description('Paginated transfers where merchant is recipient')
     .handler(({ query, request }) => {
-      const address = new URL(request.url).pathname.split('/')[4]!;
+      const address = extractPathSegment(request, 4);
       return handleMerchantTransactions(address, query);
     })
 );

--- a/apps/scan/src/app/api/x402/merchants/[address]/transactions/route.ts
+++ b/apps/scan/src/app/api/x402/merchants/[address]/transactions/route.ts
@@ -13,7 +13,7 @@ export const GET = withCors(
     .query(merchantTransactionsQuerySchema)
     .description('Paginated transfers where merchant is recipient')
     .handler(({ query, request }) => {
-      const address = request.nextUrl.pathname.split('/')[4]!;
+      const address = new URL(request.url).pathname.split('/')[4]!;
       return handleMerchantTransactions(address, query);
     })
 );

--- a/apps/scan/src/app/api/x402/origins/[id]/resources/route.ts
+++ b/apps/scan/src/app/api/x402/origins/[id]/resources/route.ts
@@ -13,7 +13,7 @@ export const GET = withCors(
     .query(originResourcesQuerySchema)
     .description('Resources for a specific origin/domain')
     .handler(({ query, request }) => {
-      const id = request.nextUrl.pathname.split('/')[4]!;
+      const id = new URL(request.url).pathname.split('/')[4]!;
       return handleOriginResources(id, query);
     })
 );

--- a/apps/scan/src/app/api/x402/origins/[id]/resources/route.ts
+++ b/apps/scan/src/app/api/x402/origins/[id]/resources/route.ts
@@ -1,5 +1,6 @@
 import { router, withCors, OPTIONS } from '@/lib/router';
 import { originResourcesQuerySchema } from '@/app/api/x402/_lib/schemas';
+import { extractPathSegment } from '@/app/api/x402/_lib/utils';
 import { handleOriginResources } from '@/app/api/x402/_handlers/origin-resources';
 
 export { OPTIONS };
@@ -13,7 +14,7 @@ export const GET = withCors(
     .query(originResourcesQuerySchema)
     .description('Resources for a specific origin/domain')
     .handler(({ query, request }) => {
-      const id = new URL(request.url).pathname.split('/')[4]!;
+      const id = extractPathSegment(request, 4);
       return handleOriginResources(id, query);
     })
 );

--- a/apps/scan/src/app/api/x402/wallets/[address]/stats/route.ts
+++ b/apps/scan/src/app/api/x402/wallets/[address]/stats/route.ts
@@ -15,7 +15,7 @@ export const GET = withCors(
       'Aggregate stats for a wallet (tx count, total amount, unique recipients)'
     )
     .handler(({ query, request }) => {
-      const address = request.nextUrl.pathname.split('/')[4]!;
+      const address = new URL(request.url).pathname.split('/')[4]!;
       return handleWalletStats(address, query);
     })
 );

--- a/apps/scan/src/app/api/x402/wallets/[address]/stats/route.ts
+++ b/apps/scan/src/app/api/x402/wallets/[address]/stats/route.ts
@@ -1,5 +1,6 @@
 import { router, withCors, OPTIONS } from '@/lib/router';
 import { walletStatsQuerySchema } from '@/app/api/x402/_lib/schemas';
+import { extractPathSegment } from '@/app/api/x402/_lib/utils';
 import { handleWalletStats } from '@/app/api/x402/_handlers/wallet-stats';
 
 export { OPTIONS };
@@ -15,7 +16,7 @@ export const GET = withCors(
       'Aggregate stats for a wallet (tx count, total amount, unique recipients)'
     )
     .handler(({ query, request }) => {
-      const address = new URL(request.url).pathname.split('/')[4]!;
+      const address = extractPathSegment(request, 4);
       return handleWalletStats(address, query);
     })
 );

--- a/apps/scan/src/app/api/x402/wallets/[address]/transactions/route.ts
+++ b/apps/scan/src/app/api/x402/wallets/[address]/transactions/route.ts
@@ -1,5 +1,6 @@
 import { router, withCors, OPTIONS } from '@/lib/router';
 import { walletTransactionsQuerySchema } from '@/app/api/x402/_lib/schemas';
+import { extractPathSegment } from '@/app/api/x402/_lib/utils';
 import { handleWalletTransactions } from '@/app/api/x402/_handlers/wallet-transactions';
 
 export { OPTIONS };
@@ -13,7 +14,7 @@ export const GET = withCors(
     .query(walletTransactionsQuerySchema)
     .description('Paginated transfers where wallet is sender')
     .handler(({ query, request }) => {
-      const address = new URL(request.url).pathname.split('/')[4]!;
+      const address = extractPathSegment(request, 4);
       return handleWalletTransactions(address, query);
     })
 );

--- a/apps/scan/src/app/api/x402/wallets/[address]/transactions/route.ts
+++ b/apps/scan/src/app/api/x402/wallets/[address]/transactions/route.ts
@@ -13,7 +13,7 @@ export const GET = withCors(
     .query(walletTransactionsQuerySchema)
     .description('Paginated transfers where wallet is sender')
     .handler(({ query, request }) => {
-      const address = request.nextUrl.pathname.split('/')[4]!;
+      const address = new URL(request.url).pathname.split('/')[4]!;
       return handleWalletTransactions(address, query);
     })
 );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,8 +307,8 @@ importers:
         specifier: 1.7.5
         version: 1.7.5
       '@agentcash/router':
-        specifier: 1.17.0
-        version: 1.17.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.0.9)(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(express@5.2.1)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.4.3)
+        specifier: 1.18.0
+        version: 1.18.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.0.9)(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(express@5.2.1)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.4.3)
       '@ai-sdk/openai':
         specifier: ^2.0.52
         version: 2.0.56(zod@4.4.3)
@@ -1217,8 +1217,8 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
-  '@agentcash/router@1.17.0':
-    resolution: {integrity: sha512-gVDkUMhX2G8EATUroJf5fI/OIJKF+77FPpovJsqa6pZG12yfQofvWVO8heCKUX5su6JJ/xGa0biA1spq2Yz7kw==}
+  '@agentcash/router@1.18.0':
+    resolution: {integrity: sha512-S9g4Amt2OKvnIvkJvnvkD8TbTcbnIgLaOh1U8o3/9IRxCcKMFKmfcaGRd0uYCwU51tXk1LKJvkFnDQsTCkbxPg==}
     peerDependencies:
       zod: ^4.0.0
 
@@ -12422,7 +12422,7 @@ snapshots:
       neverthrow: 8.2.0
       zod: 4.4.3
 
-  '@agentcash/router@1.17.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.0.9)(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(express@5.2.1)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.4.3)':
+  '@agentcash/router@1.18.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.0.9)(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(express@5.2.1)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.4.3)':
     dependencies:
       '@coinbase/x402': 2.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@x402/core': 2.17.0
@@ -24895,7 +24895,7 @@ snapshots:
   porto@0.2.35(@tanstack/react-query@5.90.16(react@19.2.2))(@types/react@19.2.2)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.16)(@types/react@19.2.2)(react@19.2.2)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.2))(viem@2.51.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)))(react@19.2.2)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.2))(viem@2.51.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@2.19.1(@azure/identity@4.13.0)(@azure/storage-blob@12.30.0)(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.2))(@types/react@19.2.2)(@vercel/blob@2.0.0)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(ioredis@5.8.2)(react@19.2.2)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.51.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.4.3)):
     dependencies:
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.16)(@types/react@19.2.2)(react@19.2.2)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.2))(viem@2.51.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
-      hono: 4.11.5
+      hono: 4.12.28
       idb-keyval: 6.2.2
       mipd: 0.0.7(typescript@5.9.3)
       ox: 0.9.14(typescript@5.9.3)(zod@4.4.3)
@@ -24915,7 +24915,7 @@ snapshots:
   porto@0.2.35(@tanstack/react-query@5.90.16(react@19.2.4))(@wagmi/core@2.22.1(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.51.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.51.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.1(@tanstack/react-query@5.90.16(react@19.2.4))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.51.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)):
     dependencies:
       '@wagmi/core': 2.22.1(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.51.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
-      hono: 4.11.5
+      hono: 4.12.28
       idb-keyval: 6.2.2
       mipd: 0.0.7(typescript@5.9.3)
       ox: 0.9.14(typescript@5.9.3)(zod@4.4.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,8 +307,8 @@ importers:
         specifier: 1.7.5
         version: 1.7.5
       '@agentcash/router':
-        specifier: 1.10.1
-        version: 1.10.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.0.9)(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(express@5.2.1)(fastestsmallesttextencoderdecoder@1.0.22)(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2))(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.4.3)
+        specifier: 1.17.0
+        version: 1.17.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.0.9)(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(express@5.2.1)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.4.3)
       '@ai-sdk/openai':
         specifier: ^2.0.52
         version: 2.0.56(zod@4.4.3)
@@ -458,7 +458,7 @@ importers:
         version: 5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@stripe/crypto':
         specifier: ^0.0.4
-        version: 0.0.4(@stripe/stripe-js@1.54.2)
+        version: 0.0.4(@stripe/stripe-js@9.8.0)
       '@t3-oss/env-nextjs':
         specifier: catalog:env
         version: 0.13.10(typescript@5.9.3)(valibot@1.2.0(typescript@5.9.3))(zod@4.4.3)
@@ -1217,10 +1217,9 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
-  '@agentcash/router@1.10.1':
-    resolution: {integrity: sha512-xCo6k8cM4Xxel6aZWFwDewzps0CI8jAt4vYC61HG98Cdhz2C8NQVRJEgW3Kk2zU0jzwf0RMTcXnOFduK/ZutcQ==}
+  '@agentcash/router@1.17.0':
+    resolution: {integrity: sha512-gVDkUMhX2G8EATUroJf5fI/OIJKF+77FPpovJsqa6pZG12yfQofvWVO8heCKUX5su6JJ/xGa0biA1spq2Yz7kw==}
     peerDependencies:
-      next: '>=15.0.0'
       zod: ^4.0.0
 
   '@ai-sdk/gateway@2.0.2':
@@ -5493,8 +5492,9 @@ packages:
     peerDependencies:
       '@stripe/stripe-js': ^1.46.0
 
-  '@stripe/stripe-js@1.54.2':
-    resolution: {integrity: sha512-R1PwtDvUfs99cAjfuQ/WpwJ3c92+DAMy9xGApjqlWQMj0FKQabUAys2swfTRNzuYAYJh7NqK2dzcYVNkKLEKUg==}
+  '@stripe/stripe-js@9.8.0':
+    resolution: {integrity: sha512-DHJpol/98VKyojNSYmpkB5vOMnlf87hPe0wPxyaYTNiTMk5QjKMXDfSZLwGctYIXAgAWDFeRABc8lFAj0BELyw==}
+    engines: {node: '>=12.16'}
 
   '@swc/core-darwin-arm64@1.15.10':
     resolution: {integrity: sha512-U72pGqmJYbjrLhMndIemZ7u9Q9owcJczGxwtfJlz/WwMaGYAV/g4nkGiUVk/+QSX8sFCAjanovcU1IUsP2YulA==}
@@ -6562,17 +6562,31 @@ packages:
   '@x402/core@2.11.0':
     resolution: {integrity: sha512-aqTfZc/BULrlWnd3I0lsqRQaH4gjJd8CsPcL16XqK2Lx5c6QDm+zCljgUVS1yj9BGJoZeQWTzI5hE+SVFkqMTw==}
 
+  '@x402/core@2.17.0':
+    resolution: {integrity: sha512-BBooe9Kewl5KLaKadElFwhZzZ+n/X/m2djzGtc7OY51D8fk2vHTVvDZtBFEJYdJxtQoUZMKX73hew0ss81FENQ==}
+
   '@x402/evm@2.11.0':
     resolution: {integrity: sha512-F8uU1txDZA+wc/sEnmaHAyYvoTi/w39r7K3a44MmQHSxECDTEuB3A0FwbxOxUPLN1eyCxTAFKEiqlGe3bwybKA==}
 
+  '@x402/evm@2.17.0':
+    resolution: {integrity: sha512-MjeouRdVJ1Y20Ikk03RHlnyOuo2FRkh0Nnrxt8aku2qt5fr5M7U8pUGn5iR6aFfRK3xlh48bp0Kypv1zjKuegw==}
+
   '@x402/extensions@2.11.0':
     resolution: {integrity: sha512-S0SOoUsx4WtWqiWZuqslSzhopW/JcrEbnEC5l2sIQH/TABWzR0DgJLy36C43tD6TOJc0tEPN9bHuD+V8DYWomA==}
+
+  '@x402/extensions@2.17.0':
+    resolution: {integrity: sha512-oYQPLJkRWiSutEVAsyNxwKh4EyviG//s8Ms7Jwkx4J8csm1gd7TfCQTsLwDmieYA5B2Qp8ajebdTkL+bT9/sQA==}
 
   '@x402/fetch@2.11.0':
     resolution: {integrity: sha512-sDkoq1ZZt10/UVa75bCXTbWkXMbPOOQpkdSxWB0ybHtlmqT7PM6hU4DVCov4iL792W1Oi38VtxfUw5EkvdvYtw==}
 
   '@x402/svm@2.11.0':
     resolution: {integrity: sha512-MmhLlEeb3FtgTxO4n3RkZszKEBBnYLfNnX8P3TvqVYP1u9gY2SgbYW4K3TsPAv00edCxoCOqYixI2JurYjW4Sw==}
+    peerDependencies:
+      '@solana/kit': '>=5.1.0'
+
+  '@x402/svm@2.17.0':
+    resolution: {integrity: sha512-BXSaLBBoP8bfBAKDdwg7c2UYuTfbZOB7gZByCK3LWkROqmTnqxQlQ683urfpYwbvlK0EbZ3TIcqR/Rx42EuVzw==}
     peerDependencies:
       '@solana/kit': '>=5.1.0'
 
@@ -7674,6 +7688,13 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
+  did-auth-challenge@0.0.1:
+    resolution: {integrity: sha512-3S8MZ3MXHnslGEAzfCZPKlnputjVJUENdceZam4KBFf4vwmYP8yPPVAfgBsVGGZfD6hITnoC+fLq2qtNn3Wm8g==}
+    engines: {node: '>=18'}
+
+  did-resolver@4.1.0:
+    resolution: {integrity: sha512-S6fWHvCXkZg2IhS4RcVHxwuyVejPR7c+a4Go0xbQ9ps5kILa8viiYQgrM4gfTyeTjJ0ekgJH9gk/BawTpmkbZA==}
+
   dijkstrajs@1.0.3:
     resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
 
@@ -8113,6 +8134,10 @@ packages:
 
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
 
   eventsource@3.0.7:
@@ -8632,6 +8657,10 @@ packages:
     resolution: {integrity: sha512-WemPi9/WfyMwZs+ZUXdiwcCh9Y+m7L+8vki9MzDw3jJ+W9Lc+12HGsd368Qc1vZi1xwW8BWMMsnK5efYKPdt4g==}
     engines: {node: '>=16.9.0'}
 
+  hono@4.12.28:
+    resolution: {integrity: sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==}
+    engines: {node: '>=16.9.0'}
+
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
@@ -8738,8 +8767,8 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
-  incur@0.4.7:
-    resolution: {integrity: sha512-4ZYF2IP5aV+r5qT0zRf9v4ZxqI90ds3UjqMSeedWfyaRG+btPBwXeZc/DDflnjymFskZTNPswVjZrJDQzJcNXw==}
+  incur@0.4.11:
+    resolution: {integrity: sha512-3mAuuiaA1YaSFm5Ydz76kYZpJAkICPjN/Ep4AyldwTm4x9IsBvKhrOPH8FkzU7T/XSGu+qSN/Av4zc2n5bwYjQ==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -9148,6 +9177,10 @@ packages:
   keccak@3.0.4:
     resolution: {integrity: sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q==}
     engines: {node: '>=10.0.0'}
+
+  key-did-resolver@4.0.0:
+    resolution: {integrity: sha512-+U2nd/0rjO4Yqe2hnHBD7ygcLRfT43Oje9IIjv1BlBi0lopwxZpIFQ7GekguOHK02r+JGdl8mpJVNHs5lvXVOA==}
+    engines: {node: '>=14.14'}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -9738,14 +9771,14 @@ packages:
       react-dom:
         optional: true
 
-  mppx@0.6.28:
-    resolution: {integrity: sha512-R39xdhjBlcUBFaNCooyvYCE0iRTS6yhbZyFTZO88PPb9TFdQGLMdowevltkjeRsVAP/hRf9PGbsEUcOcFFOuwA==}
+  mppx@0.8.6:
+    resolution: {integrity: sha512-JND+libFbDer9V9oLwqohBF5TU+QNByPf7uKF6nlVniEJzmBTLpfnENO99K7PNBUZZzEOPIVjeNC1sF9FnJjUA==}
     hasBin: true
     peerDependencies:
       '@modelcontextprotocol/sdk': '>=1.25.0'
       elysia: '>=1'
       express: '>=5'
-      hono: '>=4.12.18'
+      hono: '>=4.12.25'
       viem: 2.51.2
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
@@ -9773,6 +9806,9 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  multiformats@13.4.2:
+    resolution: {integrity: sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==}
 
   multiformats@9.9.0:
     resolution: {integrity: sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==}
@@ -10037,16 +10073,16 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
-  ox@0.14.22:
-    resolution: {integrity: sha512-nb5msL8qWbPglhIfZbGJAfw3cqiJjFMiWmACt7kgyWtLib12tcctbHufMT9Hb0Lr6Pt4k9I3dbpueTpbhvbqvA==}
+  ox@0.14.25:
+    resolution: {integrity: sha512-8DoibKtxE8yw63Y2jjMhlbjaURev6WCx4QR4MWLusl2/qIaeTzMJMBIYIDl1KOF45+8H1Ur6eLTdPlUoO8PlRw==}
     peerDependencies:
       typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  ox@0.14.25:
-    resolution: {integrity: sha512-8DoibKtxE8yw63Y2jjMhlbjaURev6WCx4QR4MWLusl2/qIaeTzMJMBIYIDl1KOF45+8H1Ur6eLTdPlUoO8PlRw==}
+  ox@0.14.29:
+    resolution: {integrity: sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==}
     peerDependencies:
       typescript: '>=5.4.0'
     peerDependenciesMeta:
@@ -11586,6 +11622,9 @@ packages:
   uint8arrays@3.1.1:
     resolution: {integrity: sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==}
 
+  uint8arrays@5.1.1:
+    resolution: {integrity: sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==}
+
   ulid@2.4.0:
     resolution: {integrity: sha512-fIRiVTJNcSRmXKPZtGzFQv9WRrZ3M9eoptl/teFJvjOzmpU+/K/JH6HZ8deBfb5vMEpicJcLn7JmvdknlMq7Zg==}
     hasBin: true
@@ -11827,6 +11866,9 @@ packages:
       react:
         optional: true
 
+  varint@6.0.0:
+    resolution: {integrity: sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==}
+
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
@@ -11969,6 +12011,9 @@ packages:
   walk-up-path@4.0.0:
     resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
     engines: {node: 20 || >=22}
+
+  web-did-resolver@2.0.32:
+    resolution: {integrity: sha512-L91/ApTmDjgzS0UDstTKn3kN/1hlQBnVcUN8K29e3xhVBpPktHYC6uvVAQ8ohbIg9D6wrrbaBQvfRArDxgJG2g==}
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
@@ -12377,15 +12422,16 @@ snapshots:
       neverthrow: 8.2.0
       zod: 4.4.3
 
-  '@agentcash/router@1.10.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.0.9)(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(express@5.2.1)(fastestsmallesttextencoderdecoder@1.0.22)(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2))(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.4.3)':
+  '@agentcash/router@1.17.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.0.9)(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(express@5.2.1)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.4.3)':
     dependencies:
       '@coinbase/x402': 2.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@x402/core': 2.11.0
-      '@x402/evm': 2.11.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@x402/extensions': 2.11.0(bufferutil@4.0.9)(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@x402/svm': 2.11.0(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
-      mppx: 0.6.28(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(typescript@5.9.3)(viem@2.51.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
-      next: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2)
+      '@x402/core': 2.17.0
+      '@x402/evm': 2.17.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@x402/extensions': 2.17.0(bufferutil@4.0.9)(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@x402/svm': 2.17.0(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
+      did-auth-challenge: 0.0.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      hono: 4.12.28
+      mppx: 0.8.6(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.28)(typescript@5.9.3)(viem@2.51.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
       viem: 2.51.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       zod: 4.4.3
       zod-openapi: 5.4.6(zod@4.4.3)
@@ -12400,7 +12446,6 @@ snapshots:
       - ethers
       - express
       - fastestsmallesttextencoderdecoder
-      - hono
       - typescript
       - utf-8-validate
       - ws
@@ -17981,11 +18026,11 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
-  '@stripe/crypto@0.0.4(@stripe/stripe-js@1.54.2)':
+  '@stripe/crypto@0.0.4(@stripe/stripe-js@9.8.0)':
     dependencies:
-      '@stripe/stripe-js': 1.54.2
+      '@stripe/stripe-js': 9.8.0
 
-  '@stripe/stripe-js@1.54.2': {}
+  '@stripe/stripe-js@9.8.0': {}
 
   '@swc/core-darwin-arm64@1.15.10':
     optional: true
@@ -20040,9 +20085,23 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
+  '@x402/core@2.17.0':
+    dependencies:
+      zod: 3.25.76
+
   '@x402/evm@2.11.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@x402/core': 2.11.0
+      viem: 2.51.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
+  '@x402/evm@2.17.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@x402/core': 2.17.0
       viem: 2.51.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -20056,6 +20115,23 @@ snapshots:
       '@scure/base': 1.2.6
       '@signinwithethereum/siwe': 4.2.0(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(viem@2.51.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
       '@x402/core': 2.11.0
+      ajv: 8.17.1
+      jose: 5.10.0
+      tweetnacl: 1.0.3
+      viem: 2.51.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - bufferutil
+      - ethers
+      - typescript
+      - utf-8-validate
+
+  '@x402/extensions@2.17.0(bufferutil@4.0.9)(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@noble/curves': 1.9.7
+      '@scure/base': 1.2.6
+      '@signinwithethereum/siwe': 4.2.0(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(viem@2.51.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
+      '@x402/core': 2.17.0
       ajv: 8.17.1
       jose: 5.10.0
       tweetnacl: 1.0.3
@@ -20084,6 +20160,16 @@ snapshots:
       '@solana-program/token-2022': 0.6.1(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
       '@solana/kit': 5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@x402/core': 2.11.0
+    transitivePeerDependencies:
+      - '@solana/sysvars'
+
+  '@x402/svm@2.17.0(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
+    dependencies:
+      '@solana-program/compute-budget': 0.11.0(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))
+      '@solana-program/token': 0.9.0(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))
+      '@solana-program/token-2022': 0.6.1(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
+      '@solana/kit': 5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@x402/core': 2.17.0
     transitivePeerDependencies:
       - '@solana/sysvars'
 
@@ -21219,6 +21305,24 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  did-auth-challenge@0.0.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3):
+    dependencies:
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+      did-resolver: 4.1.0
+      key-did-resolver: 4.0.0
+      viem: 2.51.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      web-did-resolver: 2.0.32
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+      - zod
+
+  did-resolver@4.1.0: {}
+
   dijkstrajs@1.0.3: {}
 
   dir-glob@3.0.1:
@@ -21956,6 +22060,8 @@ snapshots:
 
   eventsource-parser@3.0.6: {}
 
+  eventsource-parser@3.1.0: {}
+
   eventsource@3.0.7:
     dependencies:
       eventsource-parser: 3.0.6
@@ -22663,6 +22769,8 @@ snapshots:
 
   hono@4.11.5: {}
 
+  hono@4.12.28: {}
+
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
@@ -22782,7 +22890,7 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
-  incur@0.4.7:
+  incur@0.4.11:
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@modelcontextprotocol/server': 2.0.0-alpha.2(@cfworker/json-schema@4.1.1)
@@ -23217,6 +23325,13 @@ snapshots:
       node-addon-api: 2.0.2
       node-gyp-build: 4.8.4
       readable-stream: 3.6.2
+
+  key-did-resolver@4.0.0:
+    dependencies:
+      '@noble/curves': 1.9.7
+      multiformats: 13.4.2
+      uint8arrays: 5.1.1
+      varint: 6.0.0
 
   keyv@4.5.4:
     dependencies:
@@ -24062,15 +24177,18 @@ snapshots:
       react: 19.2.2
       react-dom: 19.2.2(react@19.2.2)
 
-  mppx@0.6.28(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(typescript@5.9.3)(viem@2.51.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)):
+  mppx@0.8.6(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.28)(typescript@5.9.3)(viem@2.51.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)):
     dependencies:
-      incur: 0.4.7
-      ox: 0.14.22(typescript@5.9.3)(zod@4.4.3)
+      '@stripe/stripe-js': 9.8.0
+      eventsource-parser: 3.1.0
+      incur: 0.4.11
+      ox: 0.14.29(typescript@5.9.3)(zod@4.4.3)
       viem: 2.51.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       express: 5.2.1(supports-color@10.2.2)
+      hono: 4.12.28
     transitivePeerDependencies:
       - typescript
 
@@ -24083,6 +24201,8 @@ snapshots:
   ms@2.1.2: {}
 
   ms@2.1.3: {}
+
+  multiformats@13.4.2: {}
 
   multiformats@9.9.0: {}
 
@@ -24358,21 +24478,6 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
-  ox@0.14.22(typescript@5.9.3)(zod@4.4.3):
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.1
-      '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.4(typescript@5.9.3)(zod@4.4.3)
-      eventemitter3: 5.0.1
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - zod
-
   ox@0.14.25(typescript@5.9.3)(zod@3.22.4):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
@@ -24404,6 +24509,21 @@ snapshots:
       - zod
 
   ox@0.14.25(typescript@5.9.3)(zod@4.4.3):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.4(typescript@5.9.3)(zod@4.4.3)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+
+  ox@0.14.29(typescript@5.9.3)(zod@4.4.3):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -26469,6 +26589,10 @@ snapshots:
     dependencies:
       multiformats: 9.9.0
 
+  uint8arrays@5.1.1:
+    dependencies:
+      multiformats: 13.4.2
+
   ulid@2.4.0: {}
 
   unbox-primitive@1.1.0:
@@ -26688,6 +26812,8 @@ snapshots:
       use-sync-external-store: 1.2.0(react@19.2.4)
     optionalDependencies:
       react: 19.2.4
+
+  varint@6.0.0: {}
 
   vary@1.1.2: {}
 
@@ -27009,6 +27135,13 @@ snapshots:
       - zod
 
   walk-up-path@4.0.0: {}
+
+  web-did-resolver@2.0.32:
+    dependencies:
+      cross-fetch: 4.1.0
+      did-resolver: 4.1.0
+    transitivePeerDependencies:
+      - encoding
 
   web-namespaces@2.0.1: {}
 


### PR DESCRIPTION
## Summary

Bumps `@agentcash/router` 1.10.1 → **1.18.0** (`apps/scan`) and fixes the one breaking change that bites us: since 1.16 the router is framework-agnostic, so the `request` inside `.handler()` is a Web `Request` — `request.nextUrl` is `undefined` at runtime.

1.17 → 1.18 is additive only (`beforeSettle` may return `'skip'` for conditional settlement); this app doesn't use settlement hooks.

## Changes

- `apps/scan/package.json`: router pin 1.10.1 → 1.18.0
- 5 paid routes extracted a path segment via `request.nextUrl.pathname` inside `.handler()`; that's now a shared `extractPathSegment(request, n)` helper in `api/x402/_lib/utils.ts` using `new URL(request.url).pathname` (same expression, one definition — mirrors the fix pattern in Merit-Systems/the-stables#555):
  - `x402/merchants/{address}/transactions` + `/stats`
  - `x402/wallets/{address}/transactions` + `/stats`
  - `x402/origins/{id}/resources`
- Plain Next.js handlers (`proxy-image`, `resources/label`, `invite/redeem`) receive a real `NextRequest` from Next itself and are untouched.
