### PR TITLE
fix(scan): include issuedAt in SIWE sign-in message

### DIFF
--- a/apps/scan/src/auth/providers/siwe/message.test.ts
+++ b/apps/scan/src/auth/providers/siwe/message.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { createSiweMessage } from './message';
+
+describe('createSiweMessage', () => {
+  it('creates a valid message with an issued-at timestamp', () => {
+    const now = new Date('2026-07-10T12:00:00.000Z');
+    const message = createSiweMessage({
+      domain: 'www.x402scan.com',
+      uri: 'https://www.x402scan.com',
+      address: '0x0000000000000000000000000000000000000000',
+      chainId: 8453,
+      nonce: 'aBcDeFgH',
+      now,
+    });
+
+    expect(message.prepareMessage()).toContain(
+      'Issued At: 2026-07-10T12:00:00.000Z'
+    );
+    expect(message.expirationTime).toBe('2026-07-10T14:00:00.000Z');
+  });
+});

--- a/apps/scan/src/auth/providers/siwe/message.ts
+++ b/apps/scan/src/auth/providers/siwe/message.ts
@@ -1,0 +1,32 @@
+import { SiweMessage } from '@signinwithethereum/siwe';
+import { SIWE_STATEMENT } from './constants';
+
+interface CreateSiweMessageOptions {
+  domain: string;
+  uri: string;
+  address: string;
+  chainId: number;
+  nonce: string;
+  now?: Date;
+}
+
+export function createSiweMessage({
+  domain,
+  uri,
+  address,
+  chainId,
+  nonce,
+  now = new Date(),
+}: CreateSiweMessageOptions) {
+  return new SiweMessage({
+    domain,
+    uri,
+    version: '1',
+    address,
+    statement: SIWE_STATEMENT,
+    nonce,
+    chainId,
+    issuedAt: now.toISOString(),
+    expirationTime: new Date(now.getTime() + 2 * 60 * 60 * 1000).toISOString(),
+  });
+}

--- a/apps/scan/src/auth/providers/siwe/sign-in.ts
+++ b/apps/scan/src/auth/providers/siwe/sign-in.ts
@@ -1,5 +1,5 @@
-import { SiweMessage } from '@signinwithethereum/siwe';
-import { SIWE_PROVIDER_ID, SIWE_STATEMENT } from './constants';
+import { SIWE_PROVIDER_ID } from './constants';
+import { createSiweMessage } from './message';
 import { getCsrfToken, signIn } from 'next-auth/react';
 
 interface SignInWithEthereumOptions {
@@ -17,15 +17,12 @@ export async function signInWithEthereum({
   email,
   redirectTo,
 }: SignInWithEthereumOptions) {
-  const message = new SiweMessage({
+  const message = createSiweMessage({
     domain: window.location.host,
     uri: window.location.origin,
-    version: '1',
     address,
-    statement: SIWE_STATEMENT,
     nonce: await getCsrfToken(),
     chainId,
-    expirationTime: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
   });
   await signIn(SIWE_PROVIDER_ID, {
     message: JSON.stringify(message),


### PR DESCRIPTION
## Summary

- include an explicit `issuedAt` timestamp in EVM SIWE sign-in messages
- keep the two-hour expiration relative to the same timestamp
- add a regression test that prepares the message successfully

## Root cause

The scan app currently resolves `@signinwithethereum/siwe` 4.2.0. Its parser requires a valid ISO 8601 `issuedAt`, but the Composer sign-in path does not provide one. `new SiweMessage(...)` therefore throws `SiweError: Unable to parse the message` before the wallet can sign.

This makes Composer sign-in fail across wallets and browsers even when the wallet is connected correctly.

## Validation

- scan test suite: 16 files and 189 tests passed
- ESLint passed for all three changed files
- Prettier check passed for all three changed files

The repository-wide type check currently depends on generated database clients that are not present in a fresh checkout; this change introduces no new file-level lint or test failures.
