### PR TITLE
fix: render share-card chart for single-bucket origins

### DIFF
--- a/apps/scan/src/app/(app)/server/[id]/(overview)/_components/screenshot-card.tsx
+++ b/apps/scan/src/app/(app)/server/[id]/(overview)/_components/screenshot-card.tsx
@@ -72,16 +72,23 @@ function AreaChart({
   height: number;
   color: string;
 }) {
-  if (data.length < 2) return null;
-  const max = Math.max(...data, 1);
+  if (data.length === 0) return null;
+  // A brand-new / low-activity origin can have all its activity in a single
+  // materialized bucket, so the query returns one point. Duplicate it so the
+  // path spans the full width and renders a flat line instead of nothing.
+  const series = data.length === 1 ? [data[0]!, data[0]!] : data;
+  // Scale to the data's real peak. Only fall back to 1 when every value is 0,
+  // otherwise fractional metrics like volume (dollars, often < 1) get squished
+  // to the bottom edge and the line looks absent.
+  const max = Math.max(...series) || 1;
   const padX = 4;
   const padTop = 90;
   const padBottom = 4;
   const chartW = width - padX * 2;
   const chartH = height - padTop - padBottom;
 
-  const points = data.map((val, i) => ({
-    x: padX + (i / (data.length - 1)) * chartW,
+  const points = series.map((val, i) => ({
+    x: padX + (i / (series.length - 1)) * chartW,
     y: padTop + chartH - (val / max) * chartH,
   }));
 
@@ -331,7 +338,7 @@ export const ScreenshotCard: React.FC<Props> = ({
               // Place label in the zone (left / center / right) with the lowest chart values
               const data = activeChartData;
               const len = data.length;
-              const max = Math.max(...data, 1);
+              const max = Math.max(...data) || 1;
               const third = Math.max(1, Math.ceil(len / 3));
               const zoneMax = (start: number, end: number) =>
                 Math.max(...data.slice(start, end)) / max;


### PR DESCRIPTION
## Problem

On the origin **Share this page** modal, the chart area renders labels but **no line** — for every metric (Volume, Buyers, Transactions). Reported on the ClaudeLines origin (3 txns, \$0.45, 3 buyers).

## Root cause

The modal's `AreaChart` (a hand-rolled SVG in `screenshot-card.tsx`) bails out with `if (data.length < 2) return null`. The card itself renders whenever `dataReady = stats && chartData.length > 0` — so with a **single** data point (`1 > 0` true), the card shows stats/labels but `AreaChart` draws nothing.

A single point is the norm for new/low-activity origins: the share modal queries `stats.bucketed` at the **AllTime** timeframe, which reads `recipient_stats_bucketed_0d` — a materialized view bucketed at **1-day** granularity with no gap-fill. Verified against prod: ClaudeLines' recipient has exactly one row in that MV:

```
bucket                 txns   amount(6dp)  buyers
2026-07-12 00:00:00     3     450000        3
```

Secondary issue: the y-axis floor `Math.max(...data, 1)` was written for integer counts. For fractional **volume** (dollars, often < 1) it squished the line to the bottom edge, so even with ≥2 buckets the volume line looked absent.

## Fix

`screenshot-card.tsx` `AreaChart`:
- Bail only on `data.length === 0`. For a single point, duplicate it so the path spans the full width and renders a flat line instead of nothing.
- Scale the y-axis to the data's real peak (`Math.max(...series) || 1`) so fractional volume values aren't pinned to the bottom.

Scope is intentionally the one component that had the bug. Every other chart in the app uses the shared **recharts** components (no `length < 2` guard), so they already render single-bucket origins fine — confirmed, not affected.

## Out of scope

Server-side gap-fill / honoring `numBuckets` in `getBucketedStatisticsMV`. It's shared by ~15 chart surfaces (broad blast radius) and — because the AllTime MV is 1-day granularity — wouldn't improve a 2-day-old origin like ClaudeLines beyond the flat line here. Tracked as a separate consideration (finer AllTime bucket resolution is the real lever, an MV redesign).

## Verification

- `pnpm exec eslint <file> --max-warnings 0` → clean
- `pnpm exec prettier --check <file>` → clean
- `tsc --noEmit` → no new errors in the changed file (pre-existing repo errors are unrelated missing generated-DB module decls in a fresh worktree)
- Data layer verified via psql against the transfers DB: ClaudeLines' AllTime MV returns exactly 1 bucket row, reproducing `chartData.length === 1`

Not exercised: live browser render of the modal (needs the running app against prod data); the fix is a pure client-render change validated statically + at the data layer.