### PR TITLE
Collapse proxy-routed transfer chains into one payment during sync

### DIFF
--- a/sync/transfers/trigger/lib/collapse.ts
+++ b/sync/transfers/trigger/lib/collapse.ts
@@ -1,0 +1,112 @@
+import type { TransferEventData } from '@/trigger/types';
+
+// Some facilitators don't settle payments directly from buyer to merchant.
+// Meridian, for example, routes every payment through a fee-proxy contract:
+// the buyer's transferWithAuthorization moves funds buyer -> proxy, then the
+// proxy forwards them proxy -> merchant minus a 1% fee, all in one
+// transaction. fluxa routes through a fixed escrow the same way, and
+// thirdweb's proxy fans out to fee collectors and the merchant.
+//
+// We ingest every USDC Transfer event in facilitator-submitted transactions,
+// so each such payment produces two (or more) rows and its count and volume
+// are doubled in every stat that sums over rows (issue #1024).
+//
+// Within a single transaction, an address that receives funds and forwards
+// them afterwards is such a pass-through, not a real buyer or seller. This
+// collapses each chain buyer -> proxy -> ... -> merchant into one transfer:
+// the origin leg's sender and log_index, the terminal leg's recipient, and
+// the terminal leg's amount (what the merchant actually received). When a
+// proxy fans out into several transfers, the one closest in amount to the
+// incoming payment is the settlement; the rest (fee payouts) and any legs
+// that don't pair up cleanly are kept as-is rather than guessed at.
+export function collapseTransferChains(
+  batch: TransferEventData[]
+): TransferEventData[] {
+  const byTx = new Map<string, TransferEventData[]>();
+  for (const event of batch) {
+    const key = `${event.chain}:${event.tx_hash}`;
+    const legs = byTx.get(key);
+    if (legs) {
+      legs.push(event);
+    } else {
+      byTx.set(key, [event]);
+    }
+  }
+
+  const collapsed: TransferEventData[] = [];
+  for (const legs of byTx.values()) {
+    if (legs.length === 1) {
+      collapsed.push(legs[0]!);
+    } else {
+      collapsed.push(...collapseTx(legs));
+    }
+  }
+  return collapsed;
+}
+
+function collapseTx(legs: TransferEventData[]): TransferEventData[] {
+  const sorted = [...legs].sort(
+    (a, b) => (a.log_index ?? 0) - (b.log_index ?? 0)
+  );
+  const position = new Map(sorted.map((leg, index) => [leg, index]));
+
+  const firstReceived = new Map<string, number>();
+  const lastSent = new Map<string, number>();
+  sorted.forEach((leg, index) => {
+    if (!firstReceived.has(leg.recipient)) {
+      firstReceived.set(leg.recipient, index);
+    }
+    lastSent.set(leg.sender, index);
+  });
+
+  const isPassThrough = (address: string) => {
+    const received = firstReceived.get(address);
+    const sent = lastSent.get(address);
+    return received !== undefined && sent !== undefined && received < sent;
+  };
+
+  const consumed = new Set<TransferEventData>();
+  const result: TransferEventData[] = [];
+
+  for (const origin of sorted) {
+    if (consumed.has(origin) || isPassThrough(origin.sender)) {
+      continue;
+    }
+    consumed.add(origin);
+
+    let terminal = origin;
+    while (isPassThrough(terminal.recipient)) {
+      const candidates = sorted.filter(
+        leg =>
+          !consumed.has(leg) &&
+          leg.sender === terminal.recipient &&
+          position.get(leg)! > position.get(terminal)!
+      );
+      if (candidates.length === 0) {
+        break;
+      }
+      const target = terminal.amount;
+      const next = candidates.reduce((best, leg) =>
+        Math.abs(leg.amount - target) < Math.abs(best.amount - target)
+          ? leg
+          : best
+      );
+      consumed.add(next);
+      terminal = next;
+    }
+
+    result.push(
+      terminal === origin
+        ? origin
+        : { ...origin, recipient: terminal.recipient, amount: terminal.amount }
+    );
+  }
+
+  for (const leg of sorted) {
+    if (!consumed.has(leg)) {
+      result.push(leg);
+    }
+  }
+
+  return result;
+}

--- a/sync/transfers/trigger/sync.ts
+++ b/sync/transfers/trigger/sync.ts
@@ -11,6 +11,7 @@ import {
 import { logger, schedules } from '@trigger.dev/sdk/v3';
 import { Network, QueryProvider } from './types';
 import { fetchTransfers } from './fetch/fetch';
+import { collapseTransferChains } from './lib/collapse';
 
 import type { Facilitator, FacilitatorConfig, SyncConfig } from './types';
 
@@ -153,10 +154,11 @@ async function syncFacilitator(
           since,
           now,
           async batch => {
-            const syncResult = await createManyTransferEvents(batch);
+            const collapsed = collapseTransferChains(batch);
+            const syncResult = await createManyTransferEvents(collapsed);
             totalSaved += syncResult.count;
             logger.log(
-              `[${syncConfig.chain}] Saved ${syncResult.count} transfers (${batch.length} fetched, ${batch.length - syncResult.count} duplicates)`
+              `[${syncConfig.chain}] Saved ${syncResult.count} transfers (${batch.length} fetched, ${batch.length - collapsed.length} collapsed, ${collapsed.length - syncResult.count} duplicates)`
             );
           },
           async (_windowStart, windowEnd, resultCount) => {
@@ -210,10 +212,11 @@ async function syncFacilitator(
       since,
       now,
       async batch => {
-        const syncResult = await createManyTransferEvents(batch);
+        const collapsed = collapseTransferChains(batch);
+        const syncResult = await createManyTransferEvents(collapsed);
         totalSaved += syncResult.count;
         logger.log(
-          `[${syncConfig.chain}] Saved ${syncResult.count} transfers (${batch.length} fetched, ${batch.length - syncResult.count} duplicates)`
+          `[${syncConfig.chain}] Saved ${syncResult.count} transfers (${batch.length} fetched, ${batch.length - collapsed.length} collapsed, ${collapsed.length - syncResult.count} duplicates)`
         );
       }
     );


### PR DESCRIPTION
Fixes #1024.

Some facilitators settle payments through an intermediary instead of paying the merchant directly. Meridian routes every payment through a fee-proxy contract (buyer → proxy → merchant, proxy keeps 1%), fluxa routes through a fixed escrow, and thirdweb's proxy fans out to fee collectors plus the merchant. Each such payment emits two or more USDC Transfer events in one transaction, we store each event as its own `TransferEvent` row, and every stat that sums over rows counts the payment twice (or more).

Verified on-chain and in prod: tx `0x9e073f…` (Meridian) is one payment with one `AuthorizationUsed`, stored as two rows and counted as $18.23 instead of a single ~$9.16 payment. In the last 7 days on Base, 94.7% of fluxa's transactions, 99.9% of mrdn's, and 98.8% of thirdweb's are multi-leg. All-time, mrdn alone carries ~105k forwarding rows worth $2.6M of phantom volume.

The fix collapses these at ingestion, before rows are written. Within a single transaction, an address that receives funds and forwards them afterwards is a pass-through, not a real buyer or seller. Each chain buyer → proxy → … → merchant becomes one row: the origin leg's sender and log_index, the terminal leg's recipient, and the terminal leg's amount (what the merchant actually received). When a proxy fans out into several transfers, the one closest in amount to the incoming payment is the settlement; fee payouts and anything that doesn't pair up cleanly are kept as-is rather than guessed at. Direct payments and batched settlements of separate payments are untouched.

Validated against 76 real transactions sampled from prod and checked against on-chain receipts (`AuthorizationUsed` count and Transfer endpoints via Base RPC): 15 mrdn, 15 fluxa, 15 thirdweb, 15 payAI, 15 ultravioletadao, 1 coinbase — all collapse to exactly one row per authorization, and payAI/ultravioleta batches of independent payments are correctly left unmerged.

This only affects new ingestion. Existing double-counted rows stay as they are — backfill is deliberately out of scope here.