### PR TITLE
Show descriptions for public/free endpoints on server pages

### DIFF
--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/form.tsx
@@ -671,8 +671,8 @@ export const RegisterResourceForm = () => {
               <code className="font-mono bg-muted px-1 rounded text-[11px]">
                 &quot;security&quot;: []
               </code>{' '}
-              on them in your OpenAPI spec and they will be registered and
-              shown as public endpoints.
+              on them in your OpenAPI spec and they will be registered and shown
+              as public endpoints.
             </p>
             <div className="space-y-1 max-h-[200px] overflow-y-auto">
               {skippedResources.map((r, idx) => (

--- a/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
+++ b/apps/scan/src/app/(app)/_components/discovery/discovery-panel.tsx
@@ -459,8 +459,7 @@ export function DiscoveryPanel({
               <p className="text-xs text-muted-foreground">
                 These endpoints were identified as unprotected (no x402
                 paywall). They are not registered. If they should be paid, add
-                x402 payment middleware. If they are intentionally free,
-                declare{' '}
+                x402 payment middleware. If they are intentionally free, declare{' '}
                 <code className="font-mono bg-muted px-1 rounded">
                   &quot;security&quot;: []
                 </code>{' '}

--- a/apps/scan/src/app/(app)/_components/resources/header/index.tsx
+++ b/apps/scan/src/app/(app)/_components/resources/header/index.tsx
@@ -27,9 +27,15 @@ export const Header: React.FC<Props> = ({
   hideOrigin = false,
 }) => {
   // Free resources have no 402 response to describe them; paid ones may
-  // omit accepts descriptions. Fall back to the description captured from
-  // the origin's openapi spec at registration.
+  // omit accepts descriptions (or carry an empty string). Fall back to the
+  // description captured from the origin's openapi spec at registration.
+  const responseDescription = getDescription(response);
   const metadataDescription = getResourceMetadataDescription(resource.metadata);
+  const description = responseDescription?.length
+    ? responseDescription
+    : metadataDescription
+      ? cleanExternalText(metadataDescription)
+      : undefined;
   return (
     <div className="flex-1 flex flex-col gap-2 w-0">
       <div className="flex md:items-center justify-between flex-col md:flex-row gap-4 md:gap-0 flex-1">
@@ -45,12 +51,7 @@ export const Header: React.FC<Props> = ({
         </div>
       </div>
       <p className="text-xs text-muted-foreground line-clamp-2">
-        {/* || not ??: a 402 body carrying an empty-string description
-            should still fall back to the openapi text. */}
-        {getDescription(response) ||
-          (metadataDescription
-            ? cleanExternalText(metadataDescription)
-            : undefined)}
+        {description}
       </p>
     </div>
   );

--- a/apps/scan/src/app/(app)/_components/resources/header/index.tsx
+++ b/apps/scan/src/app/(app)/_components/resources/header/index.tsx
@@ -7,6 +7,8 @@ import { Tags } from '@/app/(app)/_components/tags';
 import type { Resources, Tag } from '@x402scan/scan-db/types';
 import type { Methods } from '@/types/x402';
 import { getDescription, type ParsedX402Response } from '@/lib/x402';
+import { getResourceMetadataDescription } from '@/lib/resource-auth';
+import { cleanExternalText } from '@/lib/utils';
 import { X402V2Badge } from '@/app/(app)/_components/x402/v2-badge';
 
 interface Props {
@@ -24,6 +26,10 @@ export const Header: React.FC<Props> = ({
   response,
   hideOrigin = false,
 }) => {
+  // Free resources have no 402 response to describe them; paid ones may
+  // omit accepts descriptions. Fall back to the description captured from
+  // the origin's openapi spec at registration.
+  const metadataDescription = getResourceMetadataDescription(resource.metadata);
   return (
     <div className="flex-1 flex flex-col gap-2 w-0">
       <div className="flex md:items-center justify-between flex-col md:flex-row gap-4 md:gap-0 flex-1">
@@ -38,8 +44,11 @@ export const Header: React.FC<Props> = ({
           {resource.x402Version === 2 && <X402V2Badge />}
         </div>
       </div>
-      <p className="text-xs text-muted-foreground">
-        {getDescription(response)}
+      <p className="text-xs text-muted-foreground line-clamp-2">
+        {getDescription(response) ??
+          (metadataDescription
+            ? cleanExternalText(metadataDescription)
+            : undefined)}
       </p>
     </div>
   );

--- a/apps/scan/src/app/(app)/_components/resources/header/index.tsx
+++ b/apps/scan/src/app/(app)/_components/resources/header/index.tsx
@@ -45,7 +45,9 @@ export const Header: React.FC<Props> = ({
         </div>
       </div>
       <p className="text-xs text-muted-foreground line-clamp-2">
-        {getDescription(response) ??
+        {/* || not ??: a 402 body carrying an empty-string description
+            should still fall back to the openapi text. */}
+        {getDescription(response) ||
           (metadataDescription
             ? cleanExternalText(metadataDescription)
             : undefined)}

--- a/apps/scan/src/lib/discovery/endpoint-description.test.ts
+++ b/apps/scan/src/lib/discovery/endpoint-description.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { endpointDescription } from './endpoint-description';
+
+describe('endpointDescription', () => {
+  it('returns the summary for real text', () => {
+    expect(
+      endpointDescription({
+        method: 'GET',
+        path: '/v1/catalog',
+        summary: 'Lists purchasable records',
+      })
+    ).toBe('Lists purchasable records');
+  });
+
+  it('drops the "METHOD /path" placeholder', () => {
+    expect(
+      endpointDescription({
+        method: 'GET',
+        path: '/v1/catalog',
+        summary: 'GET /v1/catalog',
+      })
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when the summary is missing or empty', () => {
+    expect(
+      endpointDescription({ method: 'GET', path: '/v1/catalog' })
+    ).toBeUndefined();
+    expect(
+      endpointDescription({ method: 'GET', path: '/v1/catalog', summary: '' })
+    ).toBeUndefined();
+  });
+});

--- a/apps/scan/src/lib/discovery/endpoint-description.test.ts
+++ b/apps/scan/src/lib/discovery/endpoint-description.test.ts
@@ -23,6 +23,15 @@ describe('endpointDescription', () => {
     ).toBeUndefined();
   });
 
+  it('caps oversized descriptions', () => {
+    const result = endpointDescription({
+      method: 'GET',
+      path: '/v1/catalog',
+      summary: 'x'.repeat(10_000),
+    });
+    expect(result).toHaveLength(500);
+  });
+
   it('returns undefined when the summary is missing or empty', () => {
     expect(
       endpointDescription({ method: 'GET', path: '/v1/catalog' })

--- a/apps/scan/src/lib/discovery/endpoint-description.ts
+++ b/apps/scan/src/lib/discovery/endpoint-description.ts
@@ -1,3 +1,6 @@
+/** External origins control this text — cap what we persist per resource. */
+const MAX_DESCRIPTION_LENGTH = 500;
+
 /**
  * Display description for a discovered endpoint. The discovery package folds
  * the openapi operation's `summary ?? description` into `summary`, defaulting
@@ -10,7 +13,8 @@ export function endpointDescription(endpoint: {
   summary?: string;
 }): string | undefined {
   if (!endpoint.summary) return undefined;
-  return endpoint.summary === `${endpoint.method} ${endpoint.path}`
-    ? undefined
-    : endpoint.summary;
+  if (endpoint.summary === `${endpoint.method} ${endpoint.path}`) {
+    return undefined;
+  }
+  return endpoint.summary.slice(0, MAX_DESCRIPTION_LENGTH);
 }

--- a/apps/scan/src/lib/discovery/endpoint-description.ts
+++ b/apps/scan/src/lib/discovery/endpoint-description.ts
@@ -1,0 +1,16 @@
+/**
+ * Display description for a discovered endpoint. The discovery package folds
+ * the openapi operation's `summary ?? description` into `summary`, defaulting
+ * to a "METHOD /path" placeholder when the merchant set neither — meaningless
+ * next to the route itself, so it's dropped.
+ */
+export function endpointDescription(endpoint: {
+  method: string;
+  path: string;
+  summary?: string;
+}): string | undefined {
+  if (!endpoint.summary) return undefined;
+  return endpoint.summary === `${endpoint.method} ${endpoint.path}`
+    ? undefined
+    : endpoint.summary;
+}

--- a/apps/scan/src/lib/discovery/register-origin.test.ts
+++ b/apps/scan/src/lib/discovery/register-origin.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { probeX402Endpoint } from './probe';
 import { registerResourcesFromDiscovery } from './register-origin';
-import { registerFreeResource } from '@/lib/resources';
+import { registerFreeResource, registerResource } from '@/lib/resources';
 import { deprecateStaleResources } from '@/services/db/resources/resource';
 import { getOriginResourceCount } from '@/services/db/resources/origin';
 
@@ -249,6 +249,46 @@ describe('registerResourcesFromDiscovery — catalog registration', () => {
         { url: `${ORIGIN}/v1/admin`, method: 'POST' },
         { url: `${ORIGIN}/v1/me`, method: 'GET' },
       ])
+    );
+  });
+
+  it('passes endpoint descriptions through to free and paid registration', async () => {
+    await registerResourcesFromDiscovery(
+      [
+        {
+          url: `${ORIGIN}/v1/rooms`,
+          method: 'POST',
+          authMode: 'paid',
+          description: 'Create a video room',
+        },
+        {
+          url: `${ORIGIN}/v1/catalog`,
+          method: 'GET',
+          authMode: 'unprotected',
+          description: 'Lists purchasable records',
+        },
+        {
+          url: `${ORIGIN}/v1/me`,
+          method: 'GET',
+          authMode: 'siwx',
+          description: 'Current identity',
+        },
+      ],
+      'openapi'
+    );
+
+    expect(registerFreeResource).toHaveBeenCalledWith(
+      `${ORIGIN}/v1/catalog`,
+      expect.objectContaining({ description: 'Lists purchasable records' })
+    );
+    expect(registerFreeResource).toHaveBeenCalledWith(
+      `${ORIGIN}/v1/me`,
+      expect.objectContaining({ description: 'Current identity' })
+    );
+    expect(registerResource).toHaveBeenCalledWith(
+      `${ORIGIN}/v1/rooms`,
+      expect.anything(),
+      expect.objectContaining({ description: 'Create a video room' })
     );
   });
 

--- a/apps/scan/src/lib/discovery/register-origin.ts
+++ b/apps/scan/src/lib/discovery/register-origin.ts
@@ -113,6 +113,7 @@ export async function registerResourcesFromDiscovery(
     authMode?: AuthMode;
     pricingMode?: string;
     price?: string;
+    description?: string;
   }[],
   source: string | undefined,
   originInfo?: { title: string; description?: string },
@@ -134,18 +135,22 @@ export async function registerResourcesFromDiscovery(
   );
 
   async function registerAsFree(
-    resourceUrl: string,
-    authMode: FreeAuthMode,
-    pricingMode?: string,
-    price?: string,
-    method?: string
+    resource: {
+      url: string;
+      method?: string;
+      pricingMode?: string;
+      price?: string;
+      description?: string;
+    },
+    authMode: FreeAuthMode
   ) {
-    const freeResult = await registerFreeResource(resourceUrl, {
+    const freeResult = await registerFreeResource(resource.url, {
       authMode,
-      method,
+      method: resource.method,
       originMetadataFallback: originInfo,
-      pricingMode,
-      price,
+      pricingMode: resource.pricingMode,
+      price: resource.price,
+      description: resource.description,
       skipMetadataScrape: true,
     });
     return freeResult.success
@@ -153,12 +158,12 @@ export async function registerResourcesFromDiscovery(
           success: true as const,
           free: true as const,
           authMode,
-          url: resourceUrl,
+          url: resource.url,
           resource: freeResult.resource,
         }
       : {
           success: false as const,
-          url: resourceUrl,
+          url: resource.url,
           error: freeResult.error,
         };
   }
@@ -180,105 +185,97 @@ export async function registerResourcesFromDiscovery(
   const mainResults = await mapSettledWithConcurrency(
     mainResources,
     async resource => {
-    const resourceUrl = resource.url;
+      const resourceUrl = resource.url;
 
-    // Openapi-declared free endpoints were partitioned out above — anything
-    // still carrying these modes came from a source we don't trust for
-    // catalog listing.
-    if (resource.authMode === 'unprotected') {
-      return {
-        success: false as const,
-        url: resourceUrl,
-        error: 'Unprotected endpoint (no x402 paywall)',
-        skipped: true as const,
-      };
-    }
-    if (resource.authMode === 'apiKey') {
-      return {
-        success: false as const,
-        url: resourceUrl,
-        error: 'Non-registrable endpoint (declare it in openapi.json)',
-        skipped: true as const,
-      };
-    }
-
-    if (resource.authMode === 'siwx') {
-      return registerAsFree(
-        resourceUrl,
-        'siwx',
-        resource.pricingMode,
-        resource.price,
-        resource.method
-      );
-    }
-
-    // Check server-side probe cache (from the batch test). This skips
-    // re-probing and avoids rate limiting. The cache is server-authoritative
-    // — advisory data never round-trips through the client.
-    const cached = probeSessionId
-      ? await getCachedProbeResult(probeSessionId, resourceUrl)
-      : null;
-    let advisory: EndpointMethodAdvisory;
-    let probeWarnings: AuditWarning[] = [];
-
-    if (cached) {
-      advisory = cached.advisory;
-      probeWarnings = cached.warnings;
-    } else {
-      const probeResult = await probeX402Endpoint(resourceUrl, resource.method);
-
-      if (!probeResult.success) {
+      // Openapi-declared free endpoints were partitioned out above — anything
+      // still carrying these modes came from a source we don't trust for
+      // catalog listing.
+      if (resource.authMode === 'unprotected') {
         return {
           success: false as const,
           url: resourceUrl,
-          error: probeResult.error,
-          ...(probeResult.skipped ? { skipped: true as const } : {}),
-          ...(probeResult.statusCode !== undefined
-            ? { status: probeResult.statusCode }
-            : {}),
+          error: 'Unprotected endpoint (no x402 paywall)',
+          skipped: true as const,
+        };
+      }
+      if (resource.authMode === 'apiKey') {
+        return {
+          success: false as const,
+          url: resourceUrl,
+          error: 'Non-registrable endpoint (declare it in openapi.json)',
+          skipped: true as const,
         };
       }
 
-      advisory = probeResult.advisory;
+      if (resource.authMode === 'siwx') {
+        return registerAsFree(resource, 'siwx');
+      }
 
-      // Drop discovery-level schema warnings superseded by other checks.
-      probeWarnings = probeResult.warnings.filter(w => {
-        if (w.code === 'SCHEMA_INPUT_MISSING' && advisory.inputSchema)
-          return false;
-        if (w.code === 'SCHEMA_OUTPUT_MISSING') return false;
-        return true;
+      // Check server-side probe cache (from the batch test). This skips
+      // re-probing and avoids rate limiting. The cache is server-authoritative
+      // — advisory data never round-trips through the client.
+      const cached = probeSessionId
+        ? await getCachedProbeResult(probeSessionId, resourceUrl)
+        : null;
+      let advisory: EndpointMethodAdvisory;
+      let probeWarnings: AuditWarning[] = [];
+
+      if (cached) {
+        advisory = cached.advisory;
+        probeWarnings = cached.warnings;
+      } else {
+        const probeResult = await probeX402Endpoint(
+          resourceUrl,
+          resource.method
+        );
+
+        if (!probeResult.success) {
+          return {
+            success: false as const,
+            url: resourceUrl,
+            error: probeResult.error,
+            ...(probeResult.skipped ? { skipped: true as const } : {}),
+            ...(probeResult.statusCode !== undefined
+              ? { status: probeResult.statusCode }
+              : {}),
+          };
+        }
+
+        advisory = probeResult.advisory;
+
+        // Drop discovery-level schema warnings superseded by other checks.
+        probeWarnings = probeResult.warnings.filter(w => {
+          if (w.code === 'SCHEMA_INPUT_MISSING' && advisory.inputSchema)
+            return false;
+          if (w.code === 'SCHEMA_OUTPUT_MISSING') return false;
+          return true;
+        });
+      }
+
+      // v1 rejection is handled inside registerResource() — no duplicate check needed here.
+
+      if (advisory.authMode === 'siwx') {
+        return registerAsFree(resource, 'siwx');
+      }
+
+      const result = await registerResource(resourceUrl, advisory, {
+        notifyNewServer: false,
+        originMetadataFallback: originInfo,
+        warnings: probeWarnings,
+        pricingMode: resource.pricingMode,
+        price: resource.price,
+        description: resource.description,
+        method: resource.method,
+        skipMetadataScrape: true,
       });
-    }
 
-    // v1 rejection is handled inside registerResource() — no duplicate check needed here.
+      if (result.success) return result;
 
-    if (advisory.authMode === 'siwx') {
-      return registerAsFree(
-        resourceUrl,
-        'siwx',
-        resource.pricingMode,
-        resource.price,
-        resource.method
-      );
-    }
-
-    const result = await registerResource(resourceUrl, advisory, {
-      notifyNewServer: false,
-      originMetadataFallback: originInfo,
-      warnings: probeWarnings,
-      pricingMode: resource.pricingMode,
-      price: resource.price,
-      method: resource.method,
-      skipMetadataScrape: true,
-    });
-
-    if (result.success) return result;
-
-    return {
-      success: false as const,
-      url: resourceUrl,
-      error: getRegistrationErrorMessage(result.error),
-    };
+      return {
+        success: false as const,
+        url: resourceUrl,
+        error: getRegistrationErrorMessage(result.error),
+      };
     }
   );
 
@@ -287,8 +284,11 @@ export async function registerResourcesFromDiscovery(
   // rows for another.
   const succeededOrigins = new Set(
     mainResults.flatMap((r, i) =>
-      r.status === 'fulfilled' && r.value && 'success' in r.value &&
-      r.value.success && mainResources[i]
+      r.status === 'fulfilled' &&
+      r.value &&
+      'success' in r.value &&
+      r.value.success &&
+      mainResources[i]
         ? [getOriginFromUrl(mainResources[i].url)]
         : []
     )
@@ -308,11 +308,8 @@ export async function registerResourcesFromDiscovery(
         };
       }
       return registerAsFree(
-        resource.url,
-        resource.authMode === 'apiKey' ? 'apiKey' : 'unprotected',
-        resource.pricingMode,
-        resource.price,
-        resource.method
+        resource,
+        resource.authMode === 'apiKey' ? 'apiKey' : 'unprotected'
       );
     }
   );

--- a/apps/scan/src/lib/resource-auth.ts
+++ b/apps/scan/src/lib/resource-auth.ts
@@ -31,3 +31,24 @@ export function getResourceAuthMode(metadata: unknown): FreeAuthMode | null {
 export function isFreeResource(resource: { metadata: unknown }): boolean {
   return getResourceAuthMode(resource.metadata) !== null;
 }
+
+/**
+ * Endpoint display description captured from discovery at registration time
+ * (openapi operation summary/description). The only description source for
+ * free resources; a fallback for paid ones whose 402 accepts lack one.
+ */
+export function getResourceMetadataDescription(
+  metadata: unknown
+): string | null {
+  if (
+    metadata != null &&
+    typeof metadata === 'object' &&
+    !Array.isArray(metadata) &&
+    'description' in metadata &&
+    typeof (metadata as { description: unknown }).description === 'string' &&
+    (metadata as { description: string }).description.length > 0
+  ) {
+    return (metadata as { description: string }).description;
+  }
+  return null;
+}

--- a/apps/scan/src/lib/resources.ts
+++ b/apps/scan/src/lib/resources.ts
@@ -169,6 +169,8 @@ export async function registerFreeResource(
     originMetadataFallback?: { title?: string; description?: string };
     pricingMode?: string;
     price?: string;
+    /** Endpoint display description from discovery — stored in metadata. */
+    description?: string;
     /** Skip metadata scrape+upsert — caller handles it (e.g. batch registration). */
     skipMetadataScrape?: boolean;
   } = {}
@@ -196,6 +198,7 @@ export async function registerFreeResource(
         authMode: options.authMode ?? 'siwx',
         ...(options.pricingMode ? { pricingMode: options.pricingMode } : {}),
         ...(options.price ? { price: options.price } : {}),
+        ...(options.description ? { description: options.description } : {}),
       };
 
       // Merge with existing metadata to avoid clobbering fields set by
@@ -345,6 +348,9 @@ export const registerResource = async (
     pricingMode?: string;
     /** Price string from discovery document (e.g. "50-300.00 USD"). */
     price?: string;
+    /** Endpoint display description from discovery — stored in metadata as a
+     *  display fallback when the 402 response's accepts lack one. */
+    description?: string;
     /** HTTP method from discovery — preferred over advisory.method which
      *  is always POST (x402 payment protocol). */
     method?: string;
@@ -491,13 +497,16 @@ export const registerResource = async (
     x402Version,
     lastUpdated: new Date(),
     accepts: mappedAccepts,
-    ...(options.pricingMode || options.price
+    ...(options.pricingMode || options.price || options.description
       ? {
           metadata: {
             ...(options.pricingMode
               ? { pricingMode: options.pricingMode }
               : {}),
             ...(options.price ? { price: options.price } : {}),
+            ...(options.description
+              ? { description: options.description }
+              : {}),
           },
         }
       : {}),

--- a/apps/scan/src/services/discovery/fetch-discovery.ts
+++ b/apps/scan/src/services/discovery/fetch-discovery.ts
@@ -1,5 +1,6 @@
 import { discoverOriginSchema } from '@agentcash/discovery';
 
+import { endpointDescription } from '@/lib/discovery/endpoint-description';
 import { getOriginFromUrl } from '@/lib/url';
 import { isLocalUrl, isTunnelUrl } from '@/lib/url-helpers';
 import {
@@ -100,6 +101,7 @@ export async function fetchDiscoveryDocument(
         const url = endpoint.path.includes('://')
           ? endpoint.path
           : `${expectedOrigin}${endpoint.path.startsWith('/') ? '' : '/'}${endpoint.path}`;
+        const description = endpointDescription(endpoint);
         return [
           {
             url,
@@ -109,6 +111,7 @@ export async function fetchDiscoveryDocument(
               ? { pricingMode: endpoint.pricingMode }
               : {}),
             ...(endpoint.price ? { price: endpoint.price } : {}),
+            ...(description ? { description } : {}),
           },
         ];
       } catch {

--- a/apps/scan/src/types/discovery.ts
+++ b/apps/scan/src/types/discovery.ts
@@ -25,6 +25,11 @@ export interface DiscoveredResource {
   pricingMode?: string;
   /** Price string from discovery doc (e.g. "50-300.00 USD"). */
   price?: string;
+  /**
+   * Display description from the openapi operation's summary/description
+   * (folded by the discovery package), placeholder-filtered.
+   */
+  description?: string;
   /** If true, this resource failed validation */
   invalid?: boolean;
   /** Error message if resource is invalid */


### PR DESCRIPTION
## Problem

Merchant report: free catalog endpoints (`security: []` public, apiKey, SIWX) show no description in the Resources list, and there's no way to set one. Paid endpoints get theirs from the 402 response's `accepts[].description` / `resource.description`.

## Root cause

Free resources have no 402 response — `listOriginsWithResources` returns `data: {}` for them, so `getDescription()` always came back empty. The description was being dropped at the very start of the chain: `@agentcash/discovery` already folds each openapi operation's `summary ?? description` into `endpoint.summary`, but `fetchDiscoveryDocument` never mapped it into `DiscoveredResource`, so registration never saw it.

## Fix

- `fetch-discovery` maps the discovery summary into `DiscoveredResource.description`, dropping the package's `"METHOD /path"` placeholder (emitted when the merchant set neither summary nor description — noise next to the route itself) and capping at 500 chars (external origins control this text).
- Registration threads it into `Resource.metadata.description`, following the existing free-row metadata pattern (`authMode`, `pricingMode`, `price`) — no schema migration. Paid rows store it too via the same metadata merge, as a display fallback.
- The resource `Header` renders the 402-body description first, falling back to `metadata.description` (cleaned with `cleanExternalText`, clamped to two lines). Empty-string 402 descriptions also fall through.

Merchants set it in their openapi spec: operation `summary` (preferred) or `description`. Existing rows pick it up on the next (re-)registration of the origin.

Known limitation (matches existing `pricingMode`/`price` merge semantics): removing the text from the spec doesn't clear a previously stored value on re-register.

## Verification

- New test in `register-origin.test.ts` (written failing-first) asserting descriptions flow into `registerFreeResource` (public + siwx) and `registerResource` (paid) options.
- New `endpoint-description.test.ts` covering placeholder filtering and the 500-char cap.
- `npx vitest run`: 193 passed (16 files). `pnpm format && pnpm lint && pnpm check`: clean.