### PR TITLE
feat(scan): add Agent402.Tools to ecosystem page

### DIFF
--- a/apps/scan/src/lib/ecosystem/default.ts
+++ b/apps/scan/src/lib/ecosystem/default.ts
@@ -4,7 +4,7 @@ export const defaultEcosystemItems: EcosystemItem[] = [
   {
     name: 'Agent402.Tools',
     description:
-      'The applied layer of Agentic Finance (AIFI): 500+ deterministic pay-per-call tools for AI agents over x402 and MPP on the same 402 (plus MCP): search, finance, government data, media, an OpenAI-compatible LLM gateway, and a Smart Order Router, settling USDC across twelve chains (and USDG on Robinhood Chain).',
+      '500+ deterministic pay-per-call tools for AI agents over x402 and MPP on the same 402 (plus MCP): search, finance, government data, media, an OpenAI-compatible LLM gateway, and a Smart Order Router, settling USDC across twelve chains (and USDG on Robinhood Chain). The applied layer of agentic finance.',
     logoUrl: 'https://agent402.tools/logo.png',
     websiteUrl: 'https://agent402.tools',
     category: 'Services/Endpoints',

--- a/apps/scan/src/lib/ecosystem/default.ts
+++ b/apps/scan/src/lib/ecosystem/default.ts
@@ -2,6 +2,14 @@ import type { EcosystemItem } from './schema';
 
 export const defaultEcosystemItems: EcosystemItem[] = [
   {
+    name: 'Agent402.Tools',
+    description:
+      '500+ deterministic pay-per-call tools for AI agents over x402 and MCP: search, finance, government data, media, an OpenAI-compatible LLM gateway, and a task router, settling USDC across ten chains.',
+    logoUrl: 'https://agent402.tools/logo.png',
+    websiteUrl: 'https://agent402.tools',
+    category: 'Services/Endpoints',
+  },
+  {
     name: 'awesome-x402',
     description: 'A curated list of resources for the x402 ecosystem.',
     logoUrl: 'https://www.merit.systems/logo/dark.svg',

--- a/apps/scan/src/lib/ecosystem/default.ts
+++ b/apps/scan/src/lib/ecosystem/default.ts
@@ -4,7 +4,7 @@ export const defaultEcosystemItems: EcosystemItem[] = [
   {
     name: 'Agent402.Tools',
     description:
-      '500+ deterministic pay-per-call tools for AI agents over x402 and MCP: search, finance, government data, media, an OpenAI-compatible LLM gateway, and a task router, settling USDC across ten chains.',
+      'The applied layer of Agentic Finance (AIFI): 500+ deterministic pay-per-call tools for AI agents over x402 and MPP on the same 402 (plus MCP): search, finance, government data, media, an OpenAI-compatible LLM gateway, and a Smart Order Router, settling USDC across twelve chains (and USDG on Robinhood Chain).',
     logoUrl: 'https://agent402.tools/logo.png',
     websiteUrl: 'https://agent402.tools',
     category: 'Services/Endpoints',


### PR DESCRIPTION
Adds Agent402.Tools to defaultEcosystemItems.

- 500+ deterministic pay-per-call tools for AI agents over x402 and MCP, settling USDC across ten chains (Base primary)
- Already visible to x402scan through on-chain settlement and CDP Bazaar discovery; this adds the ecosystem-page listing
- Live since June 2026 with public revenue, status, and reliability pages: https://agent402.tools
- Open source: https://github.com/MikeyPetrillo/Agent402

Also submitted upstream to the coinbase/x402 partners-data your sync script reads (coinbase/x402#260), but that repo has not merged ecosystem additions since April, hence the default.ts route.