### PR TITLE
feat(scan): add InsumerAPI to ecosystem page

### DIFF
--- a/apps/scan/src/lib/ecosystem/default.ts
+++ b/apps/scan/src/lib/ecosystem/default.ts
@@ -2,6 +2,14 @@ import type { EcosystemItem } from './schema';
 
 export const defaultEcosystemItems: EcosystemItem[] = [
   {
+    name: 'InsumerAPI',
+    description:
+      'Signed on-chain condition checks for AI agents: token balances, NFT ownership, EAS attestations, and agent standing (ERC-8004 registration, ERC-7710 delegation validity) across 38 chains. Pay per call in USDC on Base with x402, no API key. Every answer is an ECDSA-signed boolean, verifiable offline via JWKS.',
+    logoUrl: 'https://insumermodel.com/images/logo-icon-square.png',
+    websiteUrl: 'https://insumermodel.com/ai-agent-verification-api/',
+    category: 'Services/Endpoints',
+  },
+  {
     name: 'awesome-x402',
     description: 'A curated list of resources for the x402 ecosystem.',
     logoUrl: 'https://www.merit.systems/logo/dark.svg',


### PR DESCRIPTION
Adds InsumerAPI to the ecosystem page under Services/Endpoints.

InsumerAPI answers on-chain condition checks with ECDSA-signed booleans across 38 chains, and all three metered endpoints (/v1/attest, /v1/trust, /v1/trust/batch) are payable per call over x402 (USDC on Base, CDP facilitator) with no API key. The agent standing condition types verify ERC-8004 registration and ERC-7710 delegation validity, with an EIP-1186 revocation proof option.

Discovery is already wired for x402scan: a credential-less GET on any metered path returns the v2 quote with extensions.bazaar.info, /openapi.json at the API domain carries x-payment-info per the discovery spec, and /.well-known/x402 lists the resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)