### PR TITLE
Add BridgeNode facilitator (Solana USDC)

### DIFF
--- a/packages/external/facilitators/src/facilitators/bridgenode.ts
+++ b/packages/external/facilitators/src/facilitators/bridgenode.ts
@@ -1,0 +1,28 @@
+import { Network } from '../types';
+import { USDC_SOLANA_TOKEN } from '../constants';
+
+import type { Facilitator, FacilitatorConfig } from '../types';
+
+export const bridgenode: FacilitatorConfig = {
+  url: 'https://bridgenode.cc',
+};
+
+export const bridgenodeFacilitator = {
+  id: 'bridgenode',
+  metadata: {
+    name: 'BridgeNode',
+    image: 'https://bridgenode.cc/favicon.ico',
+    docsUrl: 'https://bridgenode.cc',
+    color: '#6366F1',
+  },
+  config: bridgenode,
+  addresses: {
+    [Network.SOLANA]: [
+      {
+        address: 'BHMDv3ri3LBEZjEzJgDZeUiguVX7LmsCstTXbM3dL8rN',
+        tokens: [USDC_SOLANA_TOKEN],
+        dateOfFirstTransaction: new Date('2026-07-25'),
+      },
+    ],
+  },
+} as const satisfies Facilitator;

--- a/packages/external/facilitators/src/facilitators/index.ts
+++ b/packages/external/facilitators/src/facilitators/index.ts
@@ -30,3 +30,4 @@ export { bitrefill, bitrefillFacilitator } from './bitrefill';
 export { cascade, cascadeFacilitator } from './cascade';
 export { fluxa, fluxaFacilitator } from './fluxa';
 export { figment, figmentFacilitator } from './figment';
+export { bridgenode, bridgenodeFacilitator } from './bridgenode';

--- a/packages/external/facilitators/src/lists/all.ts
+++ b/packages/external/facilitators/src/lists/all.ts
@@ -30,6 +30,7 @@ import {
   cascadeFacilitator,
   fluxaFacilitator,
   figmentFacilitator,
+  bridgenodeFacilitator,
 } from '../facilitators';
 
 import { validateUniqueFacilitators } from './validate';
@@ -68,6 +69,7 @@ const FACILITATORS = validateUniqueFacilitators([
   cascadeFacilitator,
   fluxaFacilitator,
   figmentFacilitator,
+  bridgenodeFacilitator,
 ]);
 
 export const allFacilitators: Facilitator[] =


### PR DESCRIPTION
Add BridgeNode as a self-facilitated x402 facilitator.

**Details:**
- Service: https://bridgenode.cc — pay-per-request AI chat completions via x402 (exact scheme)
- Network: Solana
- Asset: USDC (EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v)
- Wallet: `BHMDv3ri3LBEZjEzJgDZeUiguVX7LmsCstTXbM3dL8rN`
- First transaction: 2026-07-25

All changes are additive (new facilitator entry registered in the existing lists).