### PR TITLE
fix: exclude deprecated resources from origin verification status

### DIFF
--- a/apps/scan/src/services/verification/accepts-verification.ts
+++ b/apps/scan/src/services/verification/accepts-verification.ts
@@ -173,6 +173,7 @@ export async function getOriginVerificationStatus(originId: string) {
     where: {
       resourceRel: {
         originId,
+        deprecatedAt: null,
       },
     },
     select: {


### PR DESCRIPTION
## Problem

`getOriginVerificationStatus()` (`apps/scan/src/services/verification/accepts-verification.ts`) counts `accepts` on **deprecated resources** — the `resourceRel` query has no `deprecatedAt: null` filter.

This causes wrong `partiallyVerified` / `total` results for origins that previously registered resources which were later deprecated (e.g. old endpoints, re-registrations). Example: an origin with 3 active verified resources + 1 deprecated resource with an accept shows `verified: 1, total: 4, partiallyVerified: true` instead of `1/1 allVerified`.

## Fix

One-line change: add `deprecatedAt: null` to the `resourceRel` filter, consistent with the rest of the codebase (e.g. `accepts.ts`, `origin.ts` already filter deprecated resources).

## Test plan

- [ ] Existing verification tests still pass
- [ ] Origin with deprecated resources shows correct counts