### PR TITLE
feat: add BridgeNode to ecosystem page

### DIFF
--- a/apps/scan/src/lib/ecosystem/default.ts
+++ b/apps/scan/src/lib/ecosystem/default.ts
@@ -2,6 +2,14 @@ import type { EcosystemItem } from './schema';
 
 export const defaultEcosystemItems: EcosystemItem[] = [
   {
+    name: 'BridgeNode',
+    description:
+      'Pay-per-request AI chat completions (LLM inference) via x402 on Solana — no API keys, no accounts, pay with USDC.',
+    logoUrl: 'https://www.x402.org/logos/bridgenode.jpg',
+    websiteUrl: 'https://bridgenode.cc',
+    category: 'Services/Endpoints',
+  },
+  {
     name: 'awesome-x402',
     description: 'A curated list of resources for the x402 ecosystem.',
     logoUrl: 'https://www.merit.systems/logo/dark.svg',


### PR DESCRIPTION
## What

Adds [BridgeNode](https://bridgenode.cc) to the ecosystem page (`default.ts`).

## Why

BridgeNode is a pay-per-request AI inference bridge using x402 on Solana (USDC) — no API keys, no accounts, agent-friendly. Listed in the same way as other ecosystem entries (e.g. InsumerAPI PR #1047).

## Details

- Name: BridgeNode
- Category: Services/Endpoints
- Website: https://bridgenode.cc
- Logo: `https://www.x402.org/logos/bridgenode.jpg` (file submitted in coinbase/x402 PR #276)

## Test plan

- [ ] Ecosystem page renders BridgeNode card with logo and category badge