### PR TITLE
fix(mcp): make tokenStringToNumber safe against decimal float strings and invalid amounts

### DIFF
--- a/packages/external/mcp/src/shared/token.ts
+++ b/packages/external/mcp/src/shared/token.ts
@@ -1,5 +1,15 @@
 import { formatUnits } from 'viem';
 
-export const tokenStringToNumber = (amount: string, decimals = 6) => {
-  return Number(formatUnits(BigInt(amount), decimals));
+export const tokenStringToNumber = (amount: string, decimals = 6): number => {
+  if (!amount) return 0;
+  if (amount.includes('.')) {
+    const parsed = parseFloat(amount);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  }
+  try {
+    return Number(formatUnits(BigInt(amount), decimals));
+  } catch {
+    const parsed = parseFloat(amount);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  }
 };

--- a/packages/external/mcp/test/token.test.ts
+++ b/packages/external/mcp/test/token.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { tokenStringToNumber } from '../src/shared/token';
+
+describe('tokenStringToNumber', () => {
+  it('converts atomic base unit string to number (6 decimals USDC)', () => {
+    expect(tokenStringToNumber('50000', 6)).toBe(0.05);
+    expect(tokenStringToNumber('1000000', 6)).toBe(1);
+    expect(tokenStringToNumber('1500000', 6)).toBe(1.5);
+  });
+
+  it('handles already-formatted decimal strings without throwing SyntaxError', () => {
+    expect(tokenStringToNumber('0.05', 6)).toBe(0.05);
+    expect(tokenStringToNumber('1.5', 6)).toBe(1.5);
+  });
+
+  it('handles empty or invalid strings gracefully', () => {
+    expect(tokenStringToNumber('')).toBe(0);
+    expect(tokenStringToNumber('invalid')).toBe(0);
+  });
+});


### PR DESCRIPTION
Updated tokenStringToNumber in @x402scan/mcp to gracefully parse both atomic base unit integer strings (e.g. "50000") and pre-formatted decimal float strings (e.g. "0.05"). Previously, calling BigInt("0.05") threw an unhandled SyntaxError: Cannot convert 0.05 to a BigInt which crashed MCP tool executions. Added unit test coverage.