### PR TITLE
feat: Composer wallet balances admin page (server + embedded wallets)

### DIFF
--- a/apps/scan/src/app/(app)/@breadcrumbs/admin/composer-balances/page.tsx
+++ b/apps/scan/src/app/(app)/@breadcrumbs/admin/composer-balances/page.tsx
@@ -1,0 +1,3 @@
+export default function ComposerBalancesBreadcrumbs() {
+  return null;
+}

--- a/apps/scan/src/app/(app)/admin/composer-balances/_components/columns.tsx
+++ b/apps/scan/src/app/(app)/admin/composer-balances/_components/columns.tsx
@@ -46,6 +46,28 @@ export const columns: ExtendedColumnDef<BalanceRow>[] = [
     loading: () => <Skeleton className="h-4 w-full" />,
   },
   {
+    accessorKey: 'source',
+    header: () => <span className="text-xs font-medium">Wallet Type</span>,
+    cell: ({ row }) =>
+      row.original.source === 'server' ? (
+        <span
+          className="inline-flex items-center px-2 py-0.5 rounded-md bg-blue-500/10 text-blue-600 text-xs"
+          title="CDP server wallet — we hold the keys and can sweep it"
+        >
+          Server
+        </span>
+      ) : (
+        <span
+          className="inline-flex items-center px-2 py-0.5 rounded-md bg-purple-500/10 text-purple-600 text-xs"
+          title="CDP embedded wallet — non-custodial, only the user can withdraw"
+        >
+          Embedded
+        </span>
+      ),
+    size: 120,
+    loading: () => <Skeleton className="h-4 w-full" />,
+  },
+  {
     accessorKey: 'email',
     header: () => (
       <div className="flex items-center gap-2">

--- a/apps/scan/src/app/(app)/admin/composer-balances/_components/columns.tsx
+++ b/apps/scan/src/app/(app)/admin/composer-balances/_components/columns.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { Mail, Wallet, Coins, KeyRound } from 'lucide-react';
+
+import { Copyable } from '@/components/ui/copyable';
+import { Skeleton } from '@/components/ui/skeleton';
+
+import { CHAIN_LABELS } from '@/types/chain';
+import { formatCurrency } from '@/lib/utils';
+
+import type { ExtendedColumnDef } from '@/components/ui/data-table';
+import type { RouterOutputs } from '@/trpc/client';
+
+type BalanceRow =
+  RouterOutputs['admin']['composerBalances']['report']['rows'][number];
+
+const truncateAddress = (address: string) =>
+  `${address.slice(0, 6)}…${address.slice(-4)}`;
+
+export const columns: ExtendedColumnDef<BalanceRow>[] = [
+  {
+    accessorKey: 'usdc',
+    header: () => (
+      <div className="flex items-center gap-2">
+        <Coins className="size-4" />
+        <span className="text-xs font-medium">Balance</span>
+      </div>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs font-mono font-medium tabular-nums">
+        {formatCurrency(row.original.usdc)}
+      </span>
+    ),
+    size: 110,
+    loading: () => <Skeleton className="h-4 w-full" />,
+  },
+  {
+    accessorKey: 'chain',
+    header: () => <span className="text-xs font-medium">Chain</span>,
+    cell: ({ row }) => (
+      <span className="inline-flex items-center px-2 py-0.5 rounded-md bg-primary/10 text-primary text-xs">
+        {CHAIN_LABELS[row.original.chain]}
+      </span>
+    ),
+    size: 100,
+    loading: () => <Skeleton className="h-4 w-full" />,
+  },
+  {
+    accessorKey: 'email',
+    header: () => (
+      <div className="flex items-center gap-2">
+        <Mail className="size-4" />
+        <span className="text-xs font-medium">Email</span>
+      </div>
+    ),
+    cell: ({ row }) => {
+      const { email } = row.original;
+      if (!email) {
+        return <span className="text-xs text-muted-foreground">—</span>;
+      }
+      return (
+        <Copyable
+          value={email}
+          toastMessage="Email copied"
+          className="text-xs truncate max-w-[220px] block"
+        >
+          {email}
+        </Copyable>
+      );
+    },
+    size: 240,
+    loading: () => <Skeleton className="h-4 w-full" />,
+  },
+  {
+    accessorKey: 'loginAddresses',
+    header: () => (
+      <div className="flex items-center gap-2">
+        <KeyRound className="size-4" />
+        <span className="text-xs font-medium">Signed in with</span>
+      </div>
+    ),
+    cell: ({ row }) => {
+      const { loginAddresses } = row.original;
+      if (loginAddresses.length === 0) {
+        return <span className="text-xs text-muted-foreground">—</span>;
+      }
+      return (
+        <div className="flex flex-col gap-1">
+          {loginAddresses.map(loginAddress => (
+            <Copyable
+              key={loginAddress}
+              value={loginAddress}
+              toastMessage="Address copied"
+              className="text-xs font-mono block"
+            >
+              {truncateAddress(loginAddress)}
+            </Copyable>
+          ))}
+        </div>
+      );
+    },
+    size: 180,
+    loading: () => <Skeleton className="h-4 w-full" />,
+  },
+  {
+    accessorKey: 'address',
+    header: () => (
+      <div className="flex items-center gap-2">
+        <Wallet className="size-4" />
+        <span className="text-xs font-medium">Composer Wallet</span>
+      </div>
+    ),
+    cell: ({ row }) => (
+      <Copyable
+        value={row.original.address}
+        toastMessage="Address copied"
+        className="text-xs font-mono block"
+      >
+        {truncateAddress(row.original.address)}
+      </Copyable>
+    ),
+    size: 180,
+    loading: () => <Skeleton className="h-4 w-full" />,
+  },
+  {
+    accessorKey: 'userId',
+    header: () => <span className="text-xs font-medium">User</span>,
+    cell: ({ row }) => {
+      const { userId } = row.original;
+      if (!userId) {
+        return (
+          <span className="inline-flex items-center px-2 py-0.5 rounded-md bg-amber-500/10 text-amber-600 text-xs">
+            Orphaned
+          </span>
+        );
+      }
+      return (
+        <Copyable
+          value={userId}
+          toastMessage="User ID copied"
+          className="text-xs font-mono truncate max-w-[160px] block"
+        >
+          {userId}
+        </Copyable>
+      );
+    },
+    size: 180,
+    loading: () => <Skeleton className="h-4 w-full" />,
+  },
+];

--- a/apps/scan/src/app/(app)/admin/composer-balances/_components/table.tsx
+++ b/apps/scan/src/app/(app)/admin/composer-balances/_components/table.tsx
@@ -18,6 +18,7 @@ type Report = RouterOutputs['admin']['composerBalances']['report'];
 const CSV_HEADERS = [
   'usdc',
   'chain',
+  'walletType',
   'email',
   'loginAddresses',
   'composerWalletAddress',
@@ -34,6 +35,7 @@ const toCsv = (rows: Report['rows']): string => {
       [
         row.usdc.toString(),
         CHAIN_LABELS[row.chain],
+        row.source,
         row.email ?? '',
         row.loginAddresses.join('; '),
         row.address,
@@ -83,14 +85,19 @@ export const ComposerBalancesTable = () => {
     });
 
   const totals = data?.totals;
+  const bySource = data?.bySource;
 
   return (
     <div className="space-y-4">
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <Stat
-          label="Users with a balance"
-          value={totals ? totals.userCount.toLocaleString() : '—'}
-          hint={totals ? `${totals.walletCount} wallets` : undefined}
+          label="People with a balance"
+          value={totals ? totals.peopleCount.toLocaleString() : '—'}
+          hint={
+            totals
+              ? `${totals.walletCount} wallets · ${totals.userCount} CDP identities`
+              : undefined
+          }
         />
         <Stat
           label="Total outstanding"
@@ -110,6 +117,27 @@ export const ComposerBalancesTable = () => {
           label="Orphaned wallets"
           value={totals ? totals.orphaned.toLocaleString() : '—'}
           hint="No ServerWallet row — user deleted"
+        />
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <Stat
+          label="Server wallets"
+          value={bySource ? formatCurrency(bySource.server.totalUsdc) : '—'}
+          hint={
+            bySource
+              ? `${bySource.server.walletCount} wallets · ${bySource.server.userCount} users · we can sweep these`
+              : undefined
+          }
+        />
+        <Stat
+          label="Embedded wallets"
+          value={bySource ? formatCurrency(bySource.embedded.totalUsdc) : '—'}
+          hint={
+            bySource
+              ? `${bySource.embedded.walletCount} wallets · ${bySource.embedded.userCount} users · non-custodial, user must withdraw`
+              : undefined
+          }
         />
       </div>
 

--- a/apps/scan/src/app/(app)/admin/composer-balances/_components/table.tsx
+++ b/apps/scan/src/app/(app)/admin/composer-balances/_components/table.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import { Download, RefreshCw } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { DataTable } from '@/components/ui/data-table';
+
+import { api } from '@/trpc/client';
+import { formatCurrency } from '@/lib/utils';
+import { CHAIN_LABELS } from '@/types/chain';
+
+import { columns } from './columns';
+
+import type { RouterOutputs } from '@/trpc/client';
+
+type Report = RouterOutputs['admin']['composerBalances']['report'];
+
+const CSV_HEADERS = [
+  'usdc',
+  'chain',
+  'email',
+  'loginAddresses',
+  'composerWalletAddress',
+  'walletName',
+  'userId',
+] as const;
+
+const toCsv = (rows: Report['rows']): string => {
+  const escape = (value: string) => `"${value.replace(/"/g, '""')}"`;
+
+  return [
+    CSV_HEADERS.join(','),
+    ...rows.map(row =>
+      [
+        row.usdc.toString(),
+        CHAIN_LABELS[row.chain],
+        row.email ?? '',
+        row.loginAddresses.join('; '),
+        row.address,
+        row.walletName,
+        row.userId ?? '',
+      ]
+        .map(escape)
+        .join(',')
+    ),
+  ].join('\n');
+};
+
+const downloadCsv = (csv: string) => {
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.setAttribute('href', url);
+  link.setAttribute(
+    'download',
+    `composer-balances-${new Date().toISOString().replace(/[:.]/g, '-')}.csv`
+  );
+  link.style.visibility = 'hidden';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+};
+
+const Stat: React.FC<{ label: string; value: string; hint?: string }> = ({
+  label,
+  value,
+  hint,
+}) => (
+  <div className="flex flex-col gap-1 rounded-md border p-4">
+    <span className="text-xs text-muted-foreground">{label}</span>
+    <span className="text-2xl font-medium tabular-nums">{value}</span>
+    {hint ? (
+      <span className="text-xs text-muted-foreground">{hint}</span>
+    ) : null}
+  </div>
+);
+
+export const ComposerBalancesTable = () => {
+  const { data, isLoading, isFetching, refetch } =
+    api.admin.composerBalances.report.useQuery(undefined, {
+      refetchOnWindowFocus: false,
+    });
+
+  const totals = data?.totals;
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <Stat
+          label="Users with a balance"
+          value={totals ? totals.userCount.toLocaleString() : '—'}
+          hint={totals ? `${totals.walletCount} wallets` : undefined}
+        />
+        <Stat
+          label="Total outstanding"
+          value={totals ? formatCurrency(totals.totalUsdc) : '—'}
+          hint="USDC on Base + Solana"
+        />
+        <Stat
+          label="Reachable by email"
+          value={totals ? totals.withEmail.toLocaleString() : '—'}
+          hint={
+            totals
+              ? `${totals.withLoginAddress} have a login address`
+              : undefined
+          }
+        />
+        <Stat
+          label="Orphaned wallets"
+          value={totals ? totals.orphaned.toLocaleString() : '—'}
+          hint="No ServerWallet row — user deleted"
+        />
+      </div>
+
+      {data && data.systemWallets.length > 0 ? (
+        <div className="rounded-md border p-4 space-y-2">
+          <div className="text-xs font-medium text-muted-foreground">
+            App wallets (not user funds)
+          </div>
+          <div className="flex flex-wrap gap-4">
+            {data.systemWallets.map(wallet => (
+              <div
+                key={`${wallet.name}-${wallet.chain}`}
+                className="text-xs font-mono"
+              >
+                <span className="text-muted-foreground">
+                  {wallet.name} · {CHAIN_LABELS[wallet.chain]}
+                </span>{' '}
+                <span className="font-medium">
+                  {formatCurrency(wallet.usdc)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      <div className="flex justify-between items-center">
+        <div className="text-sm text-muted-foreground">
+          {data
+            ? `${data.rows.length} wallets holding a balance`
+            : 'Scanning wallets…'}
+        </div>
+        <div className="flex gap-2">
+          <Button
+            onClick={() => void refetch()}
+            disabled={isFetching}
+            variant="outline"
+            size="sm"
+          >
+            <RefreshCw
+              className={`size-4 mr-2 ${isFetching ? 'animate-spin' : ''}`}
+            />
+            Refresh
+          </Button>
+          <Button
+            onClick={() => data && downloadCsv(toCsv(data.rows))}
+            disabled={!data || data.rows.length === 0}
+            variant="outline"
+            size="sm"
+          >
+            <Download className="size-4 mr-2" />
+            Download CSV
+          </Button>
+        </div>
+      </div>
+
+      <DataTable
+        columns={columns}
+        data={data?.rows ?? []}
+        isLoading={isLoading}
+        getRowId={(row, index) =>
+          row ? `${row.walletName}-${row.chain}` : `loading-${index}`
+        }
+      />
+    </div>
+  );
+};

--- a/apps/scan/src/app/(app)/admin/composer-balances/page.tsx
+++ b/apps/scan/src/app/(app)/admin/composer-balances/page.tsx
@@ -1,0 +1,25 @@
+import { forbidden } from 'next/navigation';
+
+import { Body, Heading } from '@/app/_components/layout/page-utils';
+import { auth } from '@/auth';
+
+import { ComposerBalancesTable } from './_components/table';
+
+export default async function ComposerBalancesPage() {
+  const session = await auth();
+  if (session?.user.role !== 'admin') {
+    forbidden();
+  }
+
+  return (
+    <div>
+      <Heading
+        title="Composer Wallet Balances"
+        description="Users still holding USDC in a Composer wallet, with whatever identity we hold for them."
+      />
+      <Body>
+        <ComposerBalancesTable />
+      </Body>
+    </div>
+  );
+}

--- a/apps/scan/src/app/(app)/admin/composer-balances/page.tsx
+++ b/apps/scan/src/app/(app)/admin/composer-balances/page.tsx
@@ -15,7 +15,7 @@ export default async function ComposerBalancesPage() {
     <div>
       <Heading
         title="Composer Wallet Balances"
-        description="Users still holding USDC in a Composer wallet, with whatever identity we hold for them."
+        description="Users still holding USDC in a Composer wallet — both CDP server wallets and the earlier embedded wallets — with whatever identity we hold for them."
       />
       <Body>
         <ComposerBalancesTable />

--- a/apps/scan/src/app/(app)/admin/layout.tsx
+++ b/apps/scan/src/app/(app)/admin/layout.tsx
@@ -44,6 +44,10 @@ export default async function AdminLayout({ children }: LayoutProps<'/admin'>) {
             label: 'Invite Codes',
             href: '/admin/invite-codes',
           },
+          {
+            label: 'Composer Balances',
+            href: '/admin/composer-balances',
+          },
         ]}
       />
       <div className="flex flex-col py-6 md:py-8 flex-1">{children}</div>

--- a/apps/scan/src/services/cdp/server-wallet/list-accounts.ts
+++ b/apps/scan/src/services/cdp/server-wallet/list-accounts.ts
@@ -36,3 +36,32 @@ export const generateAccountsCsv = (accounts: ServerAccount[]): string => {
     .join('\n');
   return header + rows;
 };
+
+interface SolanaServerAccount {
+  address: string;
+  name?: string;
+}
+
+export const listAllSolanaServerAccounts = async (): Promise<
+  SolanaServerAccount[]
+> => {
+  const allAccounts: SolanaServerAccount[] = [];
+  let response = await cdpClient.solana.listAccounts();
+
+  while (true) {
+    for (const account of response.accounts) {
+      allAccounts.push({
+        address: account.address,
+        name: account.name,
+      });
+    }
+
+    if (!response.nextPageToken) break;
+
+    response = await cdpClient.solana.listAccounts({
+      pageToken: response.nextPageToken,
+    });
+  }
+
+  return allAccounts;
+};

--- a/apps/scan/src/services/composer-balances/index.ts
+++ b/apps/scan/src/services/composer-balances/index.ts
@@ -1,11 +1,37 @@
 import 'server-only';
 
-import { scanComposerWalletBalances } from './scan';
+import { getBaseUsdcBalances, getSolanaUsdcBalances } from './scan';
+import {
+  listAllServerAccounts,
+  listAllSolanaServerAccounts,
+} from '@/services/cdp/server-wallet/list-accounts';
+import { listAllEndUsers } from '@/services/cdp/end-users/list';
 import { getOwnersByWalletName } from '@/services/db/composer-balances/owners';
 
-import type { Chain } from '@/types/chain';
+import { Chain } from '@/types/chain';
+
+/**
+ * Composer funds live in two generations of CDP wallet:
+ *
+ * - `server` — CDP server wallets named with the `ServerWallet.walletName`
+ *   UUID. We hold the keys, so these can be swept.
+ * - `embedded` — CDP end-user (embedded) wallets from the earlier email/OAuth
+ *   login. These are non-custodial: the user controls the keys and we can only
+ *   ask them to withdraw.
+ */
+export type WalletSource = 'server' | 'embedded';
+
+/**
+ * Server wallets are named with the `ServerWallet.walletName` UUID. Anything
+ * else in the CDP project (`free-tier`, the invite wallets) is app treasury
+ * rather than a user balance, so it is reported separately.
+ */
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export interface ComposerWalletBalanceRow {
+  source: WalletSource;
+  /** CDP account name for server wallets, CDP end user id for embedded ones. */
   walletName: string;
   address: string;
   chain: Chain.BASE | Chain.SOLANA;
@@ -15,70 +41,191 @@ export interface ComposerWalletBalanceRow {
   loginAddresses: string[];
 }
 
+interface SystemWalletRow {
+  name: string;
+  address: string;
+  chain: Chain.BASE | Chain.SOLANA;
+  usdc: number;
+}
+
+/**
+ * One human can hold balances under several CDP identities — signing in with
+ * both email and Google creates two end users — so collapse on email where we
+ * have one before counting people.
+ */
+const personKey = (row: ComposerWalletBalanceRow): string =>
+  row.email?.toLowerCase() ?? row.userId ?? `orphan:${row.walletName}`;
+
+interface SourceTotals {
+  userCount: number;
+  walletCount: number;
+  totalUsdc: number;
+  withEmail: number;
+}
+
 export interface ComposerBalancesReport {
   rows: ComposerWalletBalanceRow[];
-  systemWallets: {
-    name: string;
-    address: string;
-    chain: Chain.BASE | Chain.SOLANA;
-    usdc: number;
-  }[];
+  systemWallets: SystemWalletRow[];
   totals: {
-    /** Distinct users holding a balance, not distinct wallets. */
+    /** Distinct people, collapsing the CDP identities that share an email. */
+    peopleCount: number;
+    /** Distinct CDP identities holding a balance, not distinct wallets. */
     userCount: number;
     walletCount: number;
     totalUsdc: number;
     withEmail: number;
     withLoginAddress: number;
-    /** Wallets whose owning `ServerWallet` row no longer exists. */
+    /** Server wallets whose owning `ServerWallet` row no longer exists. */
     orphaned: number;
   };
+  bySource: Record<WalletSource, SourceTotals>;
 }
+
+interface CandidateWallet {
+  source: WalletSource;
+  walletName: string;
+  address: string;
+  chain: Chain.BASE | Chain.SOLANA;
+  /** Present for embedded wallets, which carry their own identity from CDP. */
+  email?: string | null;
+}
+
+/** CDP server wallets — the current generation, custodied by us. */
+const collectServerWallets = async (): Promise<CandidateWallet[]> => {
+  const [evm, svm] = await Promise.all([
+    listAllServerAccounts(),
+    listAllSolanaServerAccounts(),
+  ]);
+
+  return [
+    ...evm.map(a => ({ chain: Chain.BASE as const, ...a })),
+    ...svm.map(a => ({ chain: Chain.SOLANA as const, ...a })),
+  ].flatMap(({ name, address, chain }) =>
+    name
+      ? [{ source: 'server' as const, walletName: name, address, chain }]
+      : []
+  );
+};
+
+/**
+ * CDP end-user embedded wallets — the earlier generation. Unlike server
+ * wallets these always carry an email, since sign-in was email or OAuth.
+ */
+const collectEmbeddedWallets = async (): Promise<CandidateWallet[]> => {
+  const endUsers = await listAllEndUsers();
+
+  return endUsers.flatMap(user => {
+    const email =
+      user.authenticationMethods.find(method => method.email)?.email ?? null;
+
+    const evm = [...user.evmAccounts, ...user.evmSmartAccounts].map(
+      address => ({ address, chain: Chain.BASE as const })
+    );
+    const svm = user.solanaAccounts.map(address => ({
+      address,
+      chain: Chain.SOLANA as const,
+    }));
+
+    return [...evm, ...svm].map(({ address, chain }) => ({
+      source: 'embedded' as const,
+      walletName: user.userId,
+      address,
+      chain,
+      email,
+    }));
+  });
+};
+
+const summarise = (rows: ComposerWalletBalanceRow[]): SourceTotals => ({
+  userCount: new Set(rows.map(personKey)).size,
+  walletCount: rows.length,
+  totalUsdc: rows.reduce((sum, r) => sum + r.usdc, 0),
+  withEmail: rows.filter(r => r.email).length,
+});
 
 export const getComposerBalancesReport =
   async (): Promise<ComposerBalancesReport> => {
-    const { userWallets, systemWallets } = await scanComposerWalletBalances();
+    const [serverWallets, embeddedWallets] = await Promise.all([
+      collectServerWallets(),
+      collectEmbeddedWallets(),
+    ]);
+    const candidates = [...serverWallets, ...embeddedWallets];
 
-    const owners = await getOwnersByWalletName([
-      ...new Set(userWallets.map(w => w.name)),
+    const [baseBalances, solanaBalances] = await Promise.all([
+      getBaseUsdcBalances(
+        candidates.filter(c => c.chain === Chain.BASE).map(c => c.address)
+      ),
+      getSolanaUsdcBalances(
+        candidates.filter(c => c.chain === Chain.SOLANA).map(c => c.address)
+      ),
     ]);
 
-    const rows: ComposerWalletBalanceRow[] = userWallets
+    const funded = candidates.flatMap(candidate => {
+      const usdc =
+        candidate.chain === Chain.BASE
+          ? baseBalances.get(candidate.address.toLowerCase())
+          : solanaBalances.get(candidate.address);
+      return usdc ? [{ ...candidate, usdc }] : [];
+    });
+
+    // Only server wallets map back to a local user; embedded wallets carry
+    // their identity from CDP itself.
+    const owners = await getOwnersByWalletName([
+      ...new Set(
+        funded
+          .filter(w => w.source === 'server' && UUID_RE.test(w.walletName))
+          .map(w => w.walletName)
+      ),
+    ]);
+
+    const rows: ComposerWalletBalanceRow[] = funded
+      .filter(w => w.source === 'embedded' || UUID_RE.test(w.walletName))
       .map(wallet => {
-        const owner = owners.get(wallet.name);
+        const owner = owners.get(wallet.walletName);
         return {
-          walletName: wallet.name,
+          source: wallet.source,
+          walletName: wallet.walletName,
           address: wallet.address,
           chain: wallet.chain,
           usdc: wallet.usdc,
-          userId: owner?.userId ?? null,
-          email: owner?.email ?? null,
+          userId:
+            owner?.userId ??
+            (wallet.source === 'embedded' ? wallet.walletName : null),
+          email: owner?.email ?? wallet.email ?? null,
           loginAddresses: owner?.loginAddresses ?? [],
         };
       })
       .sort((a, b) => b.usdc - a.usdc);
 
-    const distinctUsers = new Set(
-      rows.map(r => r.userId ?? `orphan:${r.walletName}`)
-    );
+    const systemWallets: SystemWalletRow[] = funded
+      .filter(w => w.source === 'server' && !UUID_RE.test(w.walletName))
+      .map(w => ({
+        name: w.walletName,
+        address: w.address,
+        chain: w.chain,
+        usdc: w.usdc,
+      }))
+      .sort((a, b) => b.usdc - a.usdc);
+
+    const serverRows = rows.filter(r => r.source === 'server');
+    const embeddedRows = rows.filter(r => r.source === 'embedded');
 
     return {
       rows,
-      systemWallets: systemWallets
-        .map(w => ({
-          name: w.name,
-          address: w.address,
-          chain: w.chain,
-          usdc: w.usdc,
-        }))
-        .sort((a, b) => b.usdc - a.usdc),
+      systemWallets,
       totals: {
-        userCount: distinctUsers.size,
+        peopleCount: new Set(rows.map(personKey)).size,
+        userCount: new Set(rows.map(r => r.userId ?? `orphan:${r.walletName}`))
+          .size,
         walletCount: rows.length,
         totalUsdc: rows.reduce((sum, r) => sum + r.usdc, 0),
         withEmail: rows.filter(r => r.email).length,
         withLoginAddress: rows.filter(r => r.loginAddresses.length > 0).length,
-        orphaned: rows.filter(r => !r.userId).length,
+        orphaned: serverRows.filter(r => !r.userId).length,
+      },
+      bySource: {
+        server: summarise(serverRows),
+        embedded: summarise(embeddedRows),
       },
     };
   };

--- a/apps/scan/src/services/composer-balances/index.ts
+++ b/apps/scan/src/services/composer-balances/index.ts
@@ -19,7 +19,7 @@ import { Chain } from '@/types/chain';
  *   login. These are non-custodial: the user controls the keys and we can only
  *   ask them to withdraw.
  */
-export type WalletSource = 'server' | 'embedded';
+type WalletSource = 'server' | 'embedded';
 
 /**
  * Server wallets are named with the `ServerWallet.walletName` UUID. Anything
@@ -29,7 +29,7 @@ export type WalletSource = 'server' | 'embedded';
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-export interface ComposerWalletBalanceRow {
+interface ComposerWalletBalanceRow {
   source: WalletSource;
   /** CDP account name for server wallets, CDP end user id for embedded ones. */
   walletName: string;
@@ -63,7 +63,7 @@ interface SourceTotals {
   withEmail: number;
 }
 
-export interface ComposerBalancesReport {
+interface ComposerBalancesReport {
   rows: ComposerWalletBalanceRow[];
   systemWallets: SystemWalletRow[];
   totals: {

--- a/apps/scan/src/services/composer-balances/index.ts
+++ b/apps/scan/src/services/composer-balances/index.ts
@@ -1,0 +1,84 @@
+import 'server-only';
+
+import { scanComposerWalletBalances } from './scan';
+import { getOwnersByWalletName } from '@/services/db/composer-balances/owners';
+
+import type { Chain } from '@/types/chain';
+
+export interface ComposerWalletBalanceRow {
+  walletName: string;
+  address: string;
+  chain: Chain.BASE | Chain.SOLANA;
+  usdc: number;
+  userId: string | null;
+  email: string | null;
+  loginAddresses: string[];
+}
+
+export interface ComposerBalancesReport {
+  rows: ComposerWalletBalanceRow[];
+  systemWallets: {
+    name: string;
+    address: string;
+    chain: Chain.BASE | Chain.SOLANA;
+    usdc: number;
+  }[];
+  totals: {
+    /** Distinct users holding a balance, not distinct wallets. */
+    userCount: number;
+    walletCount: number;
+    totalUsdc: number;
+    withEmail: number;
+    withLoginAddress: number;
+    /** Wallets whose owning `ServerWallet` row no longer exists. */
+    orphaned: number;
+  };
+}
+
+export const getComposerBalancesReport =
+  async (): Promise<ComposerBalancesReport> => {
+    const { userWallets, systemWallets } = await scanComposerWalletBalances();
+
+    const owners = await getOwnersByWalletName([
+      ...new Set(userWallets.map(w => w.name)),
+    ]);
+
+    const rows: ComposerWalletBalanceRow[] = userWallets
+      .map(wallet => {
+        const owner = owners.get(wallet.name);
+        return {
+          walletName: wallet.name,
+          address: wallet.address,
+          chain: wallet.chain,
+          usdc: wallet.usdc,
+          userId: owner?.userId ?? null,
+          email: owner?.email ?? null,
+          loginAddresses: owner?.loginAddresses ?? [],
+        };
+      })
+      .sort((a, b) => b.usdc - a.usdc);
+
+    const distinctUsers = new Set(
+      rows.map(r => r.userId ?? `orphan:${r.walletName}`)
+    );
+
+    return {
+      rows,
+      systemWallets: systemWallets
+        .map(w => ({
+          name: w.name,
+          address: w.address,
+          chain: w.chain,
+          usdc: w.usdc,
+        }))
+        .sort((a, b) => b.usdc - a.usdc),
+      totals: {
+        userCount: distinctUsers.size,
+        walletCount: rows.length,
+        totalUsdc: rows.reduce((sum, r) => sum + r.usdc, 0),
+        withEmail: rows.filter(r => r.email).length,
+        withLoginAddress: rows.filter(r => r.loginAddresses.length > 0).length,
+        orphaned: rows.filter(r => !r.userId).length,
+      },
+    };
+  };

--- a/apps/scan/src/services/composer-balances/scan.ts
+++ b/apps/scan/src/services/composer-balances/scan.ts
@@ -1,0 +1,161 @@
+import 'server-only';
+
+import { erc20Abi } from 'viem';
+import { address as toSolanaAddress } from '@solana/kit';
+import {
+  findAssociatedTokenPda,
+  TOKEN_PROGRAM_ADDRESS,
+} from '@solana-program/token';
+
+import {
+  listAllServerAccounts,
+  listAllSolanaServerAccounts,
+} from '@/services/cdp/server-wallet/list-accounts';
+import { baseRpc } from '@/services/rpc/base';
+import { solanaRpc } from '@/services/rpc/solana';
+
+import { convertTokenAmount } from '@/lib/token';
+import { USDC_ADDRESS } from '@/lib/utils';
+import { Chain } from '@/types/chain';
+
+import type { Address } from 'viem';
+
+/**
+ * Composer server wallets are named with the `ServerWallet.walletName` UUID.
+ * Anything else in the CDP project (`sponsored`, the invite wallets) is app
+ * treasury rather than a user balance, so it is reported separately.
+ */
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Multicall3 handles far larger batches, but this keeps single payloads sane. */
+const EVM_BATCH_SIZE = 500;
+/** `getMultipleAccounts` is capped at 100 addresses per request. */
+const SVM_BATCH_SIZE = 100;
+
+const chunk = <T>(items: T[], size: number): T[][] => {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    out.push(items.slice(i, i + size));
+  }
+  return out;
+};
+
+export interface WalletBalance {
+  /** CDP account name — the `ServerWallet.walletName` for user wallets. */
+  name: string;
+  address: string;
+  chain: Chain.BASE | Chain.SOLANA;
+  usdc: number;
+}
+
+/**
+ * USDC balances for every Base composer wallet, read in multicall batches.
+ * A per-account CDP `listTokenBalances` sweep would be thousands of rate
+ * limited round trips; this is a handful of RPC calls.
+ */
+const scanBaseBalances = async (): Promise<WalletBalance[]> => {
+  const accounts = (await listAllServerAccounts()).filter(a => a.name);
+  const usdcAddress = USDC_ADDRESS[Chain.BASE] as Address;
+
+  const balances: WalletBalance[] = [];
+
+  for (const batch of chunk(accounts, EVM_BATCH_SIZE)) {
+    const results = await baseRpc.multicall({
+      allowFailure: true,
+      contracts: batch.map(account => ({
+        abi: erc20Abi,
+        address: usdcAddress,
+        functionName: 'balanceOf' as const,
+        args: [account.address as Address],
+      })),
+    });
+
+    results.forEach((result, index) => {
+      const account = batch[index];
+      if (!account?.name || result.status !== 'success') return;
+      const usdc = convertTokenAmount(result.result);
+      if (usdc > 0) {
+        balances.push({
+          name: account.name,
+          address: account.address,
+          chain: Chain.BASE,
+          usdc,
+        });
+      }
+    });
+  }
+
+  return balances;
+};
+
+/** SPL token account layout: `amount` is a u64 LE at byte offset 64. */
+const AMOUNT_OFFSET = 64;
+
+const readSplAmount = (base64Data: string): bigint => {
+  const raw = Buffer.from(base64Data, 'base64');
+  if (raw.length < AMOUNT_OFFSET + 8) return 0n;
+  return raw.readBigUInt64LE(AMOUNT_OFFSET);
+};
+
+/**
+ * USDC balances for every Solana composer wallet. Reads the associated token
+ * accounts directly so wallets that never held USDC (no ATA on chain) simply
+ * come back null instead of throwing per-account.
+ */
+const scanSolanaBalances = async (): Promise<WalletBalance[]> => {
+  const accounts = (await listAllSolanaServerAccounts()).filter(a => a.name);
+  const mint = toSolanaAddress(USDC_ADDRESS[Chain.SOLANA]);
+
+  const withAta = await Promise.all(
+    accounts.map(async account => {
+      const [ata] = await findAssociatedTokenPda({
+        mint,
+        owner: toSolanaAddress(account.address),
+        tokenProgram: TOKEN_PROGRAM_ADDRESS,
+      });
+      return { account, ata };
+    })
+  );
+
+  const balances: WalletBalance[] = [];
+
+  for (const batch of chunk(withAta, SVM_BATCH_SIZE)) {
+    const { value } = await solanaRpc
+      .getMultipleAccounts(
+        batch.map(entry => entry.ata),
+        { encoding: 'base64' }
+      )
+      .send();
+
+    value.forEach((account, index) => {
+      const entry = batch[index];
+      if (!entry?.account.name || !account) return;
+      const usdc = convertTokenAmount(readSplAmount(account.data[0]));
+      if (usdc > 0) {
+        balances.push({
+          name: entry.account.name,
+          address: entry.account.address,
+          chain: Chain.SOLANA,
+          usdc,
+        });
+      }
+    });
+  }
+
+  return balances;
+};
+
+export const scanComposerWalletBalances = async () => {
+  const [base, solana] = await Promise.all([
+    scanBaseBalances(),
+    scanSolanaBalances(),
+  ]);
+
+  const all = [...base, ...solana];
+
+  return {
+    userWallets: all.filter(b => UUID_RE.test(b.name)),
+    systemWallets: all.filter(b => !UUID_RE.test(b.name)),
+  };
+};

--- a/apps/scan/src/services/composer-balances/scan.ts
+++ b/apps/scan/src/services/composer-balances/scan.ts
@@ -7,10 +7,6 @@ import {
   TOKEN_PROGRAM_ADDRESS,
 } from '@solana-program/token';
 
-import {
-  listAllServerAccounts,
-  listAllSolanaServerAccounts,
-} from '@/services/cdp/server-wallet/list-accounts';
 import { baseRpc } from '@/services/rpc/base';
 import { solanaRpc } from '@/services/rpc/solana';
 
@@ -19,14 +15,6 @@ import { USDC_ADDRESS } from '@/lib/utils';
 import { Chain } from '@/types/chain';
 
 import type { Address } from 'viem';
-
-/**
- * Composer server wallets are named with the `ServerWallet.walletName` UUID.
- * Anything else in the CDP project (`sponsored`, the invite wallets) is app
- * treasury rather than a user balance, so it is reported separately.
- */
-const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /** Multicall3 handles far larger batches, but this keeps single payloads sane. */
 const EVM_BATCH_SIZE = 500;
@@ -41,48 +29,36 @@ const chunk = <T>(items: T[], size: number): T[][] => {
   return out;
 };
 
-export interface WalletBalance {
-  /** CDP account name — the `ServerWallet.walletName` for user wallets. */
-  name: string;
-  address: string;
-  chain: Chain.BASE | Chain.SOLANA;
-  usdc: number;
-}
-
 /**
- * USDC balances for every Base composer wallet, read in multicall batches.
- * A per-account CDP `listTokenBalances` sweep would be thousands of rate
- * limited round trips; this is a handful of RPC calls.
+ * USDC balances for Base addresses, read in multicall batches. A per-account
+ * CDP `listTokenBalances` sweep would be thousands of rate limited round
+ * trips; this is a handful of RPC calls.
+ *
+ * Returns only non-zero balances, keyed by lowercased address.
  */
-const scanBaseBalances = async (): Promise<WalletBalance[]> => {
-  const accounts = (await listAllServerAccounts()).filter(a => a.name);
+export const getBaseUsdcBalances = async (
+  addresses: string[]
+): Promise<Map<string, number>> => {
+  const unique = [...new Set(addresses.map(a => a.toLowerCase()))];
   const usdcAddress = USDC_ADDRESS[Chain.BASE] as Address;
+  const balances = new Map<string, number>();
 
-  const balances: WalletBalance[] = [];
-
-  for (const batch of chunk(accounts, EVM_BATCH_SIZE)) {
+  for (const batch of chunk(unique, EVM_BATCH_SIZE)) {
     const results = await baseRpc.multicall({
       allowFailure: true,
-      contracts: batch.map(account => ({
+      contracts: batch.map(owner => ({
         abi: erc20Abi,
         address: usdcAddress,
         functionName: 'balanceOf' as const,
-        args: [account.address as Address],
+        args: [owner as Address],
       })),
     });
 
     results.forEach((result, index) => {
-      const account = batch[index];
-      if (!account?.name || result.status !== 'success') return;
+      const owner = batch[index];
+      if (!owner || result.status !== 'success') return;
       const usdc = convertTokenAmount(result.result);
-      if (usdc > 0) {
-        balances.push({
-          name: account.name,
-          address: account.address,
-          chain: Chain.BASE,
-          usdc,
-        });
-      }
+      if (usdc > 0) balances.set(owner, usdc);
     });
   }
 
@@ -99,26 +75,29 @@ const readSplAmount = (base64Data: string): bigint => {
 };
 
 /**
- * USDC balances for every Solana composer wallet. Reads the associated token
- * accounts directly so wallets that never held USDC (no ATA on chain) simply
- * come back null instead of throwing per-account.
+ * USDC balances for Solana addresses. Reads the associated token accounts
+ * directly, so wallets that never held USDC (no ATA on chain) come back null
+ * rather than throwing per-account.
+ *
+ * Returns only non-zero balances, keyed by address.
  */
-const scanSolanaBalances = async (): Promise<WalletBalance[]> => {
-  const accounts = (await listAllSolanaServerAccounts()).filter(a => a.name);
+export const getSolanaUsdcBalances = async (
+  addresses: string[]
+): Promise<Map<string, number>> => {
+  const unique = [...new Set(addresses)];
   const mint = toSolanaAddress(USDC_ADDRESS[Chain.SOLANA]);
+  const balances = new Map<string, number>();
 
   const withAta = await Promise.all(
-    accounts.map(async account => {
+    unique.map(async owner => {
       const [ata] = await findAssociatedTokenPda({
         mint,
-        owner: toSolanaAddress(account.address),
+        owner: toSolanaAddress(owner),
         tokenProgram: TOKEN_PROGRAM_ADDRESS,
       });
-      return { account, ata };
+      return { owner, ata };
     })
   );
-
-  const balances: WalletBalance[] = [];
 
   for (const batch of chunk(withAta, SVM_BATCH_SIZE)) {
     const { value } = await solanaRpc
@@ -130,32 +109,11 @@ const scanSolanaBalances = async (): Promise<WalletBalance[]> => {
 
     value.forEach((account, index) => {
       const entry = batch[index];
-      if (!entry?.account.name || !account) return;
+      if (!entry || !account) return;
       const usdc = convertTokenAmount(readSplAmount(account.data[0]));
-      if (usdc > 0) {
-        balances.push({
-          name: entry.account.name,
-          address: entry.account.address,
-          chain: Chain.SOLANA,
-          usdc,
-        });
-      }
+      if (usdc > 0) balances.set(entry.owner, usdc);
     });
   }
 
   return balances;
-};
-
-export const scanComposerWalletBalances = async () => {
-  const [base, solana] = await Promise.all([
-    scanBaseBalances(),
-    scanSolanaBalances(),
-  ]);
-
-  const all = [...base, ...solana];
-
-  return {
-    userWallets: all.filter(b => UUID_RE.test(b.name)),
-    systemWallets: all.filter(b => !UUID_RE.test(b.name)),
-  };
 };

--- a/apps/scan/src/services/db/composer-balances/owners.ts
+++ b/apps/scan/src/services/db/composer-balances/owners.ts
@@ -1,6 +1,6 @@
 import { scanDb } from '@x402scan/scan-db';
 
-export interface WalletOwner {
+interface WalletOwner {
   userId: string;
   email: string | null;
   /**

--- a/apps/scan/src/services/db/composer-balances/owners.ts
+++ b/apps/scan/src/services/db/composer-balances/owners.ts
@@ -1,0 +1,47 @@
+import { scanDb } from '@x402scan/scan-db';
+
+export interface WalletOwner {
+  userId: string;
+  email: string | null;
+  /**
+   * The address the user signed in with (SIWE/SIWS). Almost all composer users
+   * authenticated by wallet rather than email, so this is usually the only
+   * identity we hold — and the address funds would be returned to.
+   */
+  loginAddresses: string[];
+}
+
+/**
+ * Resolve `ServerWallet.walletName` -> owning user, for the handful of wallets
+ * that actually hold a balance. Keyed by wallet name.
+ */
+export const getOwnersByWalletName = async (
+  walletNames: string[]
+): Promise<Map<string, WalletOwner>> => {
+  if (walletNames.length === 0) return new Map();
+
+  const wallets = await scanDb.serverWallet.findMany({
+    where: { walletName: { in: walletNames } },
+    select: {
+      walletName: true,
+      user: {
+        select: {
+          id: true,
+          email: true,
+          accounts: { select: { providerAccountId: true } },
+        },
+      },
+    },
+  });
+
+  return new Map(
+    wallets.map(wallet => [
+      wallet.walletName,
+      {
+        userId: wallet.user.id,
+        email: wallet.user.email,
+        loginAddresses: wallet.user.accounts.map(a => a.providerAccountId),
+      },
+    ])
+  );
+};

--- a/apps/scan/src/trpc/routers/admin/composer-balances.ts
+++ b/apps/scan/src/trpc/routers/admin/composer-balances.ts
@@ -1,0 +1,8 @@
+import { adminProcedure, createTRPCRouter } from '../../trpc';
+import { getComposerBalancesReport } from '@/services/composer-balances';
+
+export const adminComposerBalancesRouter = createTRPCRouter({
+  report: adminProcedure.query(async () => {
+    return await getComposerBalancesReport();
+  }),
+});

--- a/apps/scan/src/trpc/routers/admin/index.ts
+++ b/apps/scan/src/trpc/routers/admin/index.ts
@@ -6,6 +6,7 @@ import { adminFreeTierRouter } from './free-tier';
 import { adminEndUsersRouter } from './end-users';
 import { adminInviteCodesRouter } from './invite-codes';
 import { adminPartnersRouter } from './partners';
+import { adminComposerBalancesRouter } from './composer-balances';
 
 export const adminRouter = createTRPCRouter({
   resources: adminResourcesRouter,
@@ -14,4 +15,5 @@ export const adminRouter = createTRPCRouter({
   endUsers: adminEndUsersRouter,
   inviteCodes: adminInviteCodesRouter,
   partners: adminPartnersRouter,
+  composerBalances: adminComposerBalancesRouter,
 });


### PR DESCRIPTION
## Summary

Adds `/admin/composer-balances` — who still holds USDC in a Composer wallet, how much, and whatever identity we have for them. Covers **both generations of CDP wallet**: the current server wallets and the earlier end-user embedded wallets. Intended as the input for winding the Composer down.

## Why

The Composer is no longer linked anywhere, but wallets across both generations may still hold user funds. There was no way to see how much or whose.

Worth noting: **dev and prod are separate CDP projects** (`Dev` vs `Prod` keys, different `NEXT_PUBLIC_CDP_PROJECT_ID`) that **share one Neon database**. A local scan therefore reports dev balances against prod user rows and is not a usable prod number. Deploying this page is the practical way to read prod, since the prod CDP credentials only exist there.

## The two wallet generations differ in ways that matter

|  | Server wallets | Embedded wallets |
|---|---|---|
| Custody | We hold the keys — **can be swept** | Non-custodial — **only the user can withdraw** |
| Identity | SIWE/SIWS address; email on ~1% | **Always** an email (email/OAuth sign-in) |
| Source | `ServerWallet.walletName` → local user | CDP end-user record |

Rows are tagged by type and totals are broken out per generation, since the recovery path is completely different for each.

## Approach

**Batched reads, not per-account.** Per-account CDP `listTokenBalances` is thousands of rate-limited round trips (it hit rate limits at 545 accounts in dev). Instead:

- Base — Multicall3 `balanceOf` in batches of 500
- Solana — `getMultipleAccounts` over derived ATAs, 100 per call

Both generations flow through the same two readers. Full report runs in **~2.7s**.

**Counting people, not records.** Signing in with both email and Google creates two CDP end users for one person — visible in the dev data. The headline stat collapses identities on email and reports people; the CDP identity count is kept as a secondary hint.

**Scope.** USDC on Base and Solana only — what the Composer transacted in. Native ETH/SOL dust and airdropped tokens are not counted.

## Verification

`pnpm types:check` clean · oxlint clean · formatted.

The batched scan was cross-checked against an independent per-account `listTokenBalances` sweep of the same project. Both agree to six decimals. Server-wallet totals were also confirmed unchanged across the refactor that added embedded support, as a regression check.

Live report against the **dev** project:

| | wallets | users | USDC |
|---|---|---|---|
| Server | 10 | 9 | 19.435047 |
| Embedded | 7 | 4 | 13.649003 |
| **Total** | **17** | **13 people** (14 CDP identities) | **33.084050** |

App treasury, reported separately and excluded from the above: `free-tier` holds 19.472283 (Base) + 9.950001 (Solana).

Of the server-wallet rows, 5 are orphaned — no surviving `ServerWallet` row, so the owning user was deleted. All 7 embedded rows carry an email; 0 server rows do.

These are **dev** figures. Prod is expected to be materially larger.

## Test plan

- [ ] Deploy, open `/admin/composer-balances` as an admin, confirm prod numbers load
- [ ] Confirm both Server and Embedded rows appear and the per-generation totals split correctly
- [ ] Confirm non-admins get `forbidden()`
- [ ] Spot-check a couple of balances of each type on Basescan / Solscan
- [ ] Check the CSV export

## Notes

The repo PR template is facilitator-specific and does not apply here, so it has been replaced per its own instruction.

No Composer code is removed in this PR — it only adds the reporting needed to decide how to handle the remaining funds.