### PR TITLE
fix: unbreak Ethereum sign-in (missing issuedAt on SIWE message)

### DIFF
--- a/apps/scan/src/auth/providers/siwe/sign-in.test.ts
+++ b/apps/scan/src/auth/providers/siwe/sign-in.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+
+import { SiweMessage } from '@signinwithethereum/siwe';
+import { privateKeyToAccount } from 'viem/accounts';
+
+import { buildSiweMessage } from './sign-in';
+import { SIWE_STATEMENT } from './constants';
+
+const account = privateKeyToAccount(
+  '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d'
+);
+
+const params = {
+  domain: 'www.x402scan.com',
+  uri: 'https://www.x402scan.com',
+  address: account.address,
+  chainId: 8453,
+  nonce: 'abcdef1234567890',
+};
+
+describe('buildSiweMessage', () => {
+  it('constructs a message without throwing', () => {
+    expect(() => buildSiweMessage(params)).not.toThrow();
+  });
+
+  it('sets issuedAt, which the SiweMessage constructor requires', () => {
+    // Regression: omitting issuedAt threw "Unable to parse the message."
+    // before the wallet was ever prompted, breaking all EVM sign-in.
+    const message = buildSiweMessage(params);
+    expect(message.issuedAt).toBeDefined();
+    expect(new Date(message.issuedAt!).toString()).not.toBe('Invalid Date');
+  });
+
+  it('expires after issuedAt', () => {
+    const message = buildSiweMessage(params);
+    expect(new Date(message.expirationTime!).getTime()).toBeGreaterThan(
+      new Date(message.issuedAt!).getTime()
+    );
+  });
+
+  it('survives the JSON round trip the provider does on the wire', () => {
+    const message = buildSiweMessage(params);
+    const parsed = JSON.parse(JSON.stringify(message)) as SiweMessage;
+    expect(() => new SiweMessage(parsed)).not.toThrow();
+  });
+
+  it('produces a message the server can verify', async () => {
+    const message = buildSiweMessage(params);
+    const signature = await account.signMessage({
+      message: message.prepareMessage(),
+    });
+
+    // Mirrors verifySignature in the provider.
+    const onTheWire = JSON.parse(JSON.stringify(message)) as SiweMessage;
+    const siwe = new SiweMessage(onTheWire);
+    const result = await siwe.verify({
+      signature,
+      domain: siwe.domain,
+      nonce: onTheWire.nonce,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data.address).toBe(account.address);
+    expect(result.data.statement).toBe(SIWE_STATEMENT);
+    expect(new Date(result.data.expirationTime!).getTime()).toBeGreaterThan(
+      Date.now()
+    );
+  });
+});

--- a/apps/scan/src/auth/providers/siwe/sign-in.ts
+++ b/apps/scan/src/auth/providers/siwe/sign-in.ts
@@ -10,6 +10,48 @@ interface SignInWithEthereumOptions {
   redirectTo?: string;
 }
 
+const MESSAGE_LIFETIME_MS = 2 * 60 * 60 * 1000;
+
+interface BuildSiweMessageOptions {
+  domain: string;
+  uri: string;
+  address: string;
+  chainId: number;
+  nonce: string;
+  issuedAt?: Date;
+}
+
+/**
+ * Build the message the user is asked to sign.
+ *
+ * Split out from the sign-in flow so the field set stays under test: the
+ * SiweMessage object constructor validates eagerly and rejects a message
+ * without an `issuedAt` rather than defaulting it, which throws before the
+ * wallet is ever prompted.
+ */
+export function buildSiweMessage({
+  domain,
+  uri,
+  address,
+  chainId,
+  nonce,
+  issuedAt = new Date(),
+}: BuildSiweMessageOptions) {
+  return new SiweMessage({
+    domain,
+    uri,
+    version: '1',
+    address,
+    statement: SIWE_STATEMENT,
+    nonce,
+    chainId,
+    issuedAt: issuedAt.toISOString(),
+    expirationTime: new Date(
+      issuedAt.getTime() + MESSAGE_LIFETIME_MS
+    ).toISOString(),
+  });
+}
+
 export async function signInWithEthereum({
   address,
   chainId,
@@ -17,15 +59,12 @@ export async function signInWithEthereum({
   email,
   redirectTo,
 }: SignInWithEthereumOptions) {
-  const message = new SiweMessage({
+  const message = buildSiweMessage({
     domain: window.location.host,
     uri: window.location.origin,
-    version: '1',
     address,
-    statement: SIWE_STATEMENT,
-    nonce: await getCsrfToken(),
     chainId,
-    expirationTime: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
+    nonce: await getCsrfToken(),
   });
   // Build options in statements: the sign-in body is form-encoded, so keys
   // must be present only when they have a value.


### PR DESCRIPTION
## Ethereum sign-in has been broken in production since 2026-05-11

Clicking "Verify wallet" fails with `SiweError: Unable to parse the message.` thrown in the browser, before the wallet is ever prompted to sign.

The `SiweMessage` object constructor validates eagerly and throws when `issuedAt` is absent. `signInWithEthereum` never set it.

### Evidence

Last account created per provider, from prod:

| provider | last successful sign-in |
|---|---|
| `siwe-csrf` (Ethereum) | **2026-05-09** |
| `siws-csrf` (Solana) | 2026-08-17 |

`8c502b22` — "chore: migrate to `@signinwithethereum/siwe`" — landed **2026-05-11**, two days after the last successful Ethereum sign-in. New `siwe-csrf` accounts per month: 247 (Mar), 80 (Apr), 17 (May), then **zero** in Jun/Jul/Aug. Solana sign-in uses a different library and kept working throughout.

## Why nothing caught it

The library's own types disagree with its runtime behavior:

```ts
constructor(param: string | Partial<SiweMessage>);
issuedAt?: string;   // "ISO 8601 datetime string of the current time."
```

`issuedAt` is declared **optional** and the constructor takes a **`Partial`**, so omitting it type-checks cleanly. The throw is runtime-only, in a client component, on user interaction — so `types:check`, `oxlint`, `knip` and the production build all pass, and the server never sees a failed request to log. No test covered the sign-in path.

## The fix

Set `issuedAt`, and derive `expirationTime` from it so the two stay consistent.

Message construction is extracted into `buildSiweMessage` so the field set is testable without `window` or `next-auth/react`.

## Tests

New `sign-in.test.ts` covers construction, `issuedAt` presence, expiry ordering, the JSON round trip the provider does on the wire, and a full **sign-and-verify round trip** through the same calls `verifySignature` makes.

Confirmed the tests actually catch the regression: removing the `issuedAt` line again fails all 5 with the exact production error.

## Checks

- `pnpm check` — pass, 57/57
- `pnpm --filter @x402scan/app test -- --run` — pass, 205 tests / 19 files

## Note

Found while investigating a 403 on `/admin/composer-balances`. That 403 was a symptom, not a permissions problem: with Ethereum sign-in broken, no session could be established, so `auth()` returned null and the admin layout called `forbidden()`.

Two follow-ups worth considering separately, not included here:

1. Unauthenticated users hitting `/admin/*` get a bare 403 rather than a redirect to sign-in, which made this look like a permissions issue.
2. A three-month auth outage with no alert suggests sign-in success rate is worth monitoring.