### PR TITLE
PayAI: un-deprecate CjNFTjvB… — it is settling again on Solana

### DIFF
--- a/packages/external/facilitators/src/facilitators/payai.ts
+++ b/packages/external/facilitators/src/facilitators/payai.ts
@@ -30,7 +30,6 @@ export const payaiFacilitator = {
       },
       {
         address: 'CjNFTjvBhbJJd2B5ePPMHRLx1ELZpa8dwQgGL727eKww',
-        deprecated: true,
         tokens: [USDC_SOLANA_TOKEN],
         dateOfFirstTransaction: new Date('2025-12-08'),
       },


### PR DESCRIPTION
One line: removes `deprecated: true` from PayAI's Solana address `CjNFTjvBhbJJd2B5ePPMHRLx1ELZpa8dwQgGL727eKww`.

### Why

It was deprecated in ec3d87b (2026-07-14), *"Deprecate inactive facilitator addresses to skip transfer sync"* — correct at the time. It has since gone back into production:

- **~100 transactions in a single minute**, 2026-08-29 18:32 UTC
- Most recent transaction is an SPL `transferChecked` of USDC (`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`), fee-paid by that address — an x402 settlement
- Sample signature: `JNCZ4Jj1SiN6Qbo9c3dMDyom6sspbxv4hgWNC7sgzuCPbh3YirLCEHaFVwpWSYAvYyZTTS1hbD7TuXSJyXGTn7Q`

PayAI appears to run this settler alongside `2wKupLR9q6wXYppw8Gr2NvWxKBUqm4PPJKkQfoxHDBg4`; both were busy in the same minute.

### Effect

`sync.ts` skips any address where `enabled` is false:

```ts
for (const facilitatorConfig of facilitator.addresses[...]) {
  if (!facilitatorConfig.enabled) {
    continue;
  }
```

So while the flag is set, every payment PayAI settles through this address is missing from merchant and facilitator stats. I noticed because my own resource shows 0 transactions on its x402scan page while its treasury is receiving settlements fee-paid by this address.

### Caveat

I cannot see from outside *why* PayAI runs two settlers, so if you would rather confirm with them before merging, that is fair. Either way the current data is incomplete. The other deprecated entries in this file are untouched — I did not check them.

Happy to add the same evidence for any other address if useful.