### PR TITLE
Unify discover server rows

### DIFF
--- a/apps/scan/src/app/(app)/(home)/(discover)/_components/discover-origins.tsx
+++ b/apps/scan/src/app/(app)/(home)/(discover)/_components/discover-origins.tsx
@@ -1,8 +1,14 @@
 "use client";
 
 import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
 
-import { ServiceSummary, serviceColumns as columns } from "./service-columns";
+import {
+  LoadingServiceSummary,
+  ServiceSummary,
+  serviceColumns as columns,
+} from "./service-columns";
 import {
   ResponsiveCollection,
   ResponsiveCollectionLoading,
@@ -23,6 +29,7 @@ import {
 
 import type { ServiceItem } from "./service-columns";
 import type { DataListItem } from "@/components/ui/data-list";
+import type { Route } from "next";
 import type { SellerSortId } from "@/lib/table-sort-options";
 import type { TableSorting } from "@/lib/table-state";
 import type { Chain } from "@/types/chain";
@@ -145,6 +152,7 @@ function ServicesCollection({
   };
   sorting: TableSorting<SellerSortId>;
 }) {
+  const router = useRouter();
   const replaceSearchParams = useReplaceSearchParams();
   const tableSorting = useUrlTableSorting({
     sorting,
@@ -169,7 +177,12 @@ function ServicesCollection({
         list={{ item: serviceListItem }}
         table={{
           columns,
+          getRowHref: getServiceHref,
+          getRowLabel: (item) => `Open ${getServiceName(item)}`,
           manualSorting: true,
+          onRowMouseEnter: (item) => {
+            router.prefetch(getServiceHref(item));
+          },
           sorting: tableSorting.tableSorting,
           onSortingChange: tableSorting.onSortingChange,
           pageSize: PAGE_SIZE,
@@ -261,8 +274,12 @@ const serviceListItem: DataListItem<ServiceItem> = {
     }
 
     return (
-      <div className="flex flex-col gap-3 py-4">
-        <ServiceSummary item={item} />
+      <Link href={getServiceHref(item)} className="flex flex-col gap-2 py-4">
+        <ServiceSummary
+          item={item}
+          descriptionPlacement="below"
+          nameVariant="card-title"
+        />
         <dl className="grid grid-cols-4 gap-2">
           <Metric
             label="Volume"
@@ -291,7 +308,7 @@ const serviceListItem: DataListItem<ServiceItem> = {
             }
           />
         </dl>
-      </div>
+      </Link>
     );
   },
   renderLoadingItem: () => <LoadingServiceItem />,
@@ -309,14 +326,7 @@ function Metric({ label, value }: { label: string; value: string }) {
 function LoadingServiceItem() {
   return (
     <div className="flex flex-col gap-3 py-4">
-      <div className="flex items-start gap-3">
-        <Skeleton className="size-6 rounded-full" />
-        <div className="flex flex-1 flex-col gap-1.5">
-          <Skeleton className="h-4 w-32" />
-          <Skeleton className="h-3 w-4/5" />
-        </div>
-        <Skeleton className="h-7 w-16" />
-      </div>
+      <LoadingServiceSummary />
       <div className="grid grid-cols-4 gap-2">
         {Array.from({ length: 4 }, (_, metricIndex) => (
           <div key={metricIndex} className="flex flex-col gap-1">
@@ -327,4 +337,29 @@ function LoadingServiceItem() {
       </div>
     </div>
   );
+}
+
+function getServiceHref(item: ServiceItem): Route {
+  const origin = item.origins[0];
+
+  if (!origin) {
+    throw new Error("A service row must have at least one origin");
+  }
+
+  return `/server/${origin.id}` as Route;
+}
+
+function getServiceName(item: ServiceItem) {
+  const origin = item.origins[0];
+
+  if (!origin) {
+    return "server";
+  }
+
+  const title = origin.title?.trim();
+  if (title) {
+    return title;
+  }
+
+  return new URL(origin.origin).hostname;
 }

--- a/apps/scan/src/app/(app)/(home)/(discover)/_components/service-columns.tsx
+++ b/apps/scan/src/app/(app)/(home)/(discover)/_components/service-columns.tsx
@@ -1,12 +1,16 @@
 "use client";
 
-import Link from "next/link";
-
 import { Skeleton } from "@/components/ui/skeleton";
 import { DataTableColumnHeader } from "@/components/ui/data-table";
+import {
+  OriginSummary,
+  OriginSummaryAvatar,
+  OriginSummaryDescription,
+  OriginSummaryHeader,
+  OriginSummaryName,
+  OriginSummaryTrailing,
+} from "@/components/ui/origin-summary";
 import { Sparkline, SparklineLoading } from "@/components/ui/sparkline";
-
-import { Favicon } from "@/app/(app)/_components/favicon";
 
 import {
   cn,
@@ -17,6 +21,10 @@ import {
 import { formatTokenAmount } from "@/lib/token";
 
 import type { DataTableColumnDef } from "@/components/ui/data-table";
+import type {
+  OriginSummaryNameProps,
+  OriginSummaryProps,
+} from "@/components/ui/origin-summary";
 import type { RouterOutputs } from "@/trpc/client";
 import { Chains } from "@/app/(app)/_components/chains";
 
@@ -33,22 +41,18 @@ export const serviceColumns: DataTableColumnDef<ServiceItem>[] = [
       <DataTableColumnHeader
         column={column}
         title="Server"
-        className="flex justify-start type-caption"
+        className="justify-start"
       />
     ),
     enableSorting: false,
-    cell: ({ row }) => <ServiceSummary item={row.original} />,
-    size: 280,
+    cell: ({ row }) => (
+      <div className="flex h-13 items-center pr-4">
+        <ServiceSummary item={row.original} />
+      </div>
+    ),
+    size: 400,
     meta: {
-      loadingCell: (
-        <div className="flex items-start gap-2.5">
-          <Skeleton className="mt-0.5 size-6 shrink-0 rounded-full" />
-          <div className="flex-1 space-y-1.5 py-0.5">
-            <Skeleton className="h-3.5 w-32" />
-            <Skeleton className="h-3 w-44" />
-          </div>
-        </div>
-      ),
+      loadingCell: <LoadingServiceSummary className="h-13 pr-4" />,
     },
   },
   {
@@ -154,7 +158,7 @@ export const serviceColumns: DataTableColumnDef<ServiceItem>[] = [
       <DataTableColumnHeader
         column={column}
         title="Chain"
-        className="flex justify-center type-caption"
+        className="justify-center"
       />
     ),
     enableSorting: false,
@@ -182,14 +186,12 @@ const Cell = ({
   );
 };
 
-/**
- * Server cell — title (curated) + description on top, hostname tucked
- * underneath in mono. Falls back to hostname-as-title when no curated title
- * exists.
- */
 export const ServiceSummary: React.FC<{
   item: ServiceItem;
-}> = ({ item }) => {
+  className?: string;
+  descriptionPlacement?: OriginSummaryProps["descriptionPlacement"];
+  nameVariant?: OriginSummaryNameProps["variant"];
+}> = ({ item, className, descriptionPlacement, nameVariant }) => {
   const origin = item.origins[0];
   if (!origin) return null;
 
@@ -201,36 +203,47 @@ export const ServiceSummary: React.FC<{
   const description = rawDescription ? cleanExternalText(rawDescription) : null;
   const otherOrigins = item.origins.slice(1);
 
-  const innerContent = (
-    <>
-      <Favicon url={origin.favicon} className="mt-0.5 size-6 shrink-0" />
-      <div className="min-w-0 flex-1">
-        <div className="flex min-w-0 items-center gap-1.5">
-          <span className="truncate type-label transition-colors group-hover:text-primary">
-            {title}
-          </span>
-          {otherOrigins.length > 0 ? (
-            <span className="shrink-0 type-caption text-muted-foreground">
+  return (
+    <OriginSummary
+      className={cn("max-w-full overflow-hidden", className)}
+      descriptionPlacement={descriptionPlacement}
+    >
+      <OriginSummaryAvatar origin={origin.origin} src={origin.favicon} />
+      <OriginSummaryHeader>
+        <OriginSummaryName variant={nameVariant}>{title}</OriginSummaryName>
+        {otherOrigins.length > 0 ? (
+          <OriginSummaryTrailing>
+            <span className="type-caption text-muted-foreground">
               +{otherOrigins.length}
             </span>
-          ) : null}
-        </div>
-        <div className="mt-0.5 truncate type-caption text-muted-foreground">
-          {description ?? "No description available."}
-        </div>
-        <span className="type-compact-code mt-0.5 block truncate text-muted-foreground/70">
-          {hostname}
-        </span>
-      </div>
-    </>
-  );
-
-  return (
-    <Link
-      href={`/server/${origin.id}`}
-      className="group flex min-w-0 items-start gap-2.5 py-0.5"
-    >
-      {innerContent}
-    </Link>
+          </OriginSummaryTrailing>
+        ) : null}
+      </OriginSummaryHeader>
+      {description ? (
+        <OriginSummaryDescription lines={2}>
+          {description}
+        </OriginSummaryDescription>
+      ) : null}
+    </OriginSummary>
   );
 };
+
+export function LoadingServiceSummary({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        "flex max-w-full min-w-0 items-center gap-3 overflow-hidden",
+        className
+      )}
+    >
+      <Skeleton className="size-6 rounded-md" />
+      <div className="flex max-w-full min-w-0 flex-1 flex-col gap-0.5 overflow-hidden">
+        <Skeleton className="my-[3px] h-[14px] w-32" />
+        <div className="flex flex-col gap-px">
+          <Skeleton className="my-[2px] h-[10px] w-5/6" />
+          <Skeleton className="my-[2px] h-[10px] w-1/4" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/scan/src/components/ui/origin-avatar.tsx
+++ b/apps/scan/src/components/ui/origin-avatar.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { GlobeIcon } from "lucide-react";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+
+import type { ComponentProps, ReactNode } from "react";
+
+type AvatarProps = Omit<ComponentProps<typeof Avatar>, "children">;
+
+interface OriginAvatarProps extends AvatarProps {
+  fallback?: ReactNode;
+  fallbackClassName?: string;
+  imageClassName?: string;
+  origin?: string;
+  src?: string | null;
+}
+
+function getOriginFaviconUrls(origin: string) {
+  try {
+    const { origin: baseOrigin } = new URL(origin);
+
+    return [
+      new URL("/favicon.svg", baseOrigin).toString(),
+      new URL("/favicon.png", baseOrigin).toString(),
+      new URL("/favicon.ico", baseOrigin).toString(),
+    ];
+  } catch {
+    return [];
+  }
+}
+
+function OriginAvatar({
+  className,
+  fallback,
+  fallbackClassName,
+  imageClassName,
+  origin,
+  size = "sm",
+  src,
+  ...props
+}: OriginAvatarProps) {
+  const faviconUrls = useMemo(() => {
+    const urls: string[] = [];
+    const trimmedSrc = src?.trim();
+
+    if (trimmedSrc) {
+      urls.push(trimmedSrc);
+    }
+
+    if (origin) {
+      for (const url of getOriginFaviconUrls(origin)) {
+        if (!urls.includes(url)) {
+          urls.push(url);
+        }
+      }
+    }
+
+    return urls;
+  }, [origin, src]);
+  const faviconKey = JSON.stringify(faviconUrls);
+  const [faviconState, setFaviconState] = useState({
+    index: 0,
+    key: faviconKey,
+  });
+  const faviconIndex = faviconState.key === faviconKey ? faviconState.index : 0;
+  const faviconUrl = faviconUrls[faviconIndex];
+
+  return (
+    <Avatar className={className} variant="tile" size={size} {...props}>
+      {faviconUrl ? (
+        <AvatarImage
+          alt=""
+          className={imageClassName}
+          src={faviconUrl}
+          onLoadingStatusChange={(status) => {
+            if (status === "error") {
+              setFaviconState({ index: faviconIndex + 1, key: faviconKey });
+            }
+          }}
+        />
+      ) : null}
+      <AvatarFallback className={fallbackClassName}>
+        {fallback ?? <GlobeIcon className="size-full text-primary/80" />}
+      </AvatarFallback>
+    </Avatar>
+  );
+}
+
+export { OriginAvatar };
+export type { OriginAvatarProps };

--- a/apps/scan/src/components/ui/origin-avatar.tsx
+++ b/apps/scan/src/components/ui/origin-avatar.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useMemo, useState } from "react";
 import { GlobeIcon } from "lucide-react";
+
+import { useMemo, useState } from "react";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 

--- a/apps/scan/src/components/ui/origin-summary.tsx
+++ b/apps/scan/src/components/ui/origin-summary.tsx
@@ -1,0 +1,182 @@
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { OriginAvatar } from "@/components/ui/origin-avatar";
+import { cn } from "@/lib/utils";
+
+import type { OriginAvatarProps } from "@/components/ui/origin-avatar";
+import type { ComponentProps, ReactNode } from "react";
+
+const originSummaryVariants = cva(
+  "grid w-full min-w-0 max-w-full grid-cols-[auto_minmax(0,1fr)] items-center gap-x-3",
+  {
+    variants: {
+      descriptionPlacement: {
+        beside:
+          "[&>[data-slot=origin-summary-avatar]]:row-start-1 has-data-[slot=origin-summary-description]:[&>[data-slot=origin-summary-avatar]]:row-span-2 has-data-[slot=origin-summary-metadata]:[&>[data-slot=origin-summary-avatar]]:row-span-2 has-data-[slot=origin-summary-description]:has-data-[slot=origin-summary-metadata]:[&>[data-slot=origin-summary-avatar]]:row-span-3",
+        below:
+          "gap-y-1 [&>[data-slot=origin-summary-avatar]]:row-start-1 [&>[data-slot=origin-summary-description]]:col-span-2 [&>[data-slot=origin-summary-description]]:col-start-1",
+      },
+    },
+    defaultVariants: {
+      descriptionPlacement: "beside",
+    },
+  }
+);
+
+const originSummaryNameVariants = cva("min-w-0", {
+  variants: {
+    variant: {
+      "card-title": "type-card-title",
+      label: "type-label",
+      "page-title": "type-page-title",
+      "section-title": "type-section-title",
+    },
+  },
+  defaultVariants: {
+    variant: "label",
+  },
+});
+
+const textOverflowClassNames = {
+  1: "truncate",
+  2: "line-clamp-2 wrap-break-word whitespace-normal",
+  none: "wrap-break-word whitespace-normal",
+} as const;
+
+interface OriginSummaryProps
+  extends
+    Omit<ComponentProps<"div">, "children">,
+    VariantProps<typeof originSummaryVariants> {
+  children: ReactNode;
+}
+
+type OriginSummaryNameProps = ComponentProps<"div"> &
+  VariantProps<typeof originSummaryNameVariants> & {
+    lines?: keyof typeof textOverflowClassNames;
+  };
+
+type OriginSummaryTextProps = ComponentProps<"div"> & {
+  lines?: keyof typeof textOverflowClassNames;
+};
+
+function OriginSummary({
+  children,
+  className,
+  descriptionPlacement = "beside",
+  ...props
+}: OriginSummaryProps) {
+  return (
+    <div
+      {...props}
+      className={cn(originSummaryVariants({ descriptionPlacement }), className)}
+      data-description-placement={descriptionPlacement}
+      data-slot="origin-summary"
+    >
+      {children}
+    </div>
+  );
+}
+
+function OriginSummaryAvatar({ className, ...props }: OriginAvatarProps) {
+  return (
+    <div
+      className="col-start-1 shrink-0 self-center"
+      data-slot="origin-summary-avatar"
+    >
+      <OriginAvatar className={className} {...props} />
+    </div>
+  );
+}
+
+function OriginSummaryHeader({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="origin-summary-header"
+      className={cn(
+        "col-start-2 row-start-1 flex min-w-0 items-center gap-1.5",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function OriginSummaryName({
+  className,
+  lines = 1,
+  variant = "label",
+  ...props
+}: OriginSummaryNameProps) {
+  return (
+    <div
+      data-slot="origin-summary-name"
+      className={cn(
+        originSummaryNameVariants({ variant }),
+        textOverflowClassNames[lines],
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function OriginSummaryTrailing({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="origin-summary-trailing"
+      className={cn("shrink-0", className)}
+      {...props}
+    />
+  );
+}
+
+function OriginSummaryDescription({
+  className,
+  lines = 1,
+  ...props
+}: OriginSummaryTextProps) {
+  return (
+    <div
+      data-slot="origin-summary-description"
+      className={cn(
+        "col-start-2 type-caption text-muted-foreground",
+        textOverflowClassNames[lines],
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function OriginSummaryMetadata({
+  className,
+  lines = 1,
+  ...props
+}: OriginSummaryTextProps) {
+  return (
+    <div
+      data-slot="origin-summary-metadata"
+      className={cn(
+        "col-start-2 type-caption text-muted-foreground/70",
+        textOverflowClassNames[lines],
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  OriginSummary,
+  OriginSummaryAvatar,
+  OriginSummaryDescription,
+  OriginSummaryHeader,
+  OriginSummaryMetadata,
+  OriginSummaryName,
+  OriginSummaryTrailing,
+};
+export type {
+  OriginSummaryNameProps,
+  OriginSummaryProps,
+  OriginSummaryTextProps,
+};

--- a/apps/scan/src/components/ui/origin-summary.tsx
+++ b/apps/scan/src/components/ui/origin-summary.tsx
@@ -1,10 +1,14 @@
-import { cva, type VariantProps } from "class-variance-authority";
+import { cva } from "class-variance-authority";
 
 import { OriginAvatar } from "@/components/ui/origin-avatar";
+
 import { cn } from "@/lib/utils";
 
-import type { OriginAvatarProps } from "@/components/ui/origin-avatar";
 import type { ComponentProps, ReactNode } from "react";
+
+import type { VariantProps } from "class-variance-authority";
+
+import type { OriginAvatarProps } from "@/components/ui/origin-avatar";
 
 const originSummaryVariants = cva(
   "grid w-full min-w-0 max-w-full grid-cols-[auto_minmax(0,1fr)] items-center gap-x-3",

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -79,7 +79,7 @@ const config: KnipConfig = {
   ],
   // Registry-owned components intentionally expose the complete Foundation API.
   ignoreIssues: {
-    "apps/scan/src/components/ui/{accordion,alert-dialog,avatar,badge,button,card,collapsible,command,copy-button,data-list,data-table,dialog,dropdown-menu,field,input-group,input,interactive-row,label,motion-tabs,responsive-view,select,separator,sheet,sidebar,skeleton,sonner,spinner,table,tabs,textarea,tooltip}.tsx":
+    "apps/scan/src/components/ui/{accordion,alert-dialog,avatar,badge,button,card,collapsible,command,copy-button,data-list,data-table,dialog,dropdown-menu,field,input-group,input,interactive-row,label,motion-tabs,origin-avatar,origin-summary,responsive-view,select,separator,sheet,sidebar,skeleton,sonner,spinner,table,tabs,textarea,tooltip}.tsx":
       ["exports", "types"],
     "apps/scan/src/components/responsive-collection.tsx": ["types"],
   },


### PR DESCRIPTION
## Summary

- adopt the Foundation `origin-summary` registry component for discover server rows
- align desktop and mobile row structure with MPPscan, including whole-row navigation and hover behavior
- remove the redundant hostname line while preserving x402-specific alternate-origin counts
- let the shared data-table header component own column-header typography

## Validation

- `pnpm check`
- `pnpm build`
- light and dark browser smoke tests

## Review note

The local browser dataset contained no server rows, so populated-row behavior was verified through source review and automated checks rather than live local data.
