### PR TITLE
Align collection page usage shells

### DIFF
--- a/apps/scan/src/app/(app)/(home)/(discover)/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/(discover)/page.tsx
@@ -5,7 +5,7 @@ import { ErrorBoundary } from "react-error-boundary";
 import { OverallStatsContent } from "./_components/stats";
 import { DiscoverHeading } from "./_components/heading";
 import { ServiceViewToggle } from "./_components/service-view-toggle";
-import { UsageTimeframeSelect } from "./_components/usage-timeframe-select";
+import { TimeframeSelect } from "@/components/timeframe-select";
 
 import { api, HydrateClient } from "@/trpc/server";
 
@@ -19,7 +19,6 @@ import { UsageSection } from "@/components/usage-section";
 import { Separator } from "@/components/ui/separator";
 import {
   parseDiscoverPage,
-  parseDiscoverTimeframe,
   parseServiceView,
   SERVICES_PAGE_SIZE,
 } from "@/lib/discover/filters";
@@ -28,6 +27,7 @@ import {
   DEFAULT_SELLERS_SORTING,
   SELLERS_SORT_IDS,
 } from "@/lib/table-sort-options";
+import { parseUsageTimeframe } from "@/lib/timeframe";
 
 export default async function DiscoverPage({ searchParams }: PageProps<"/">) {
   const resolvedParams = await searchParams;
@@ -37,7 +37,7 @@ export default async function DiscoverPage({ searchParams }: PageProps<"/">) {
     SELLERS_SORT_IDS,
     DEFAULT_SELLERS_SORTING
   );
-  const timeframe = parseDiscoverTimeframe(resolvedParams.d);
+  const timeframe = parseUsageTimeframe(resolvedParams.d);
   const view = parseServiceView(resolvedParams.v);
   const page = parseDiscoverPage(resolvedParams.p);
 
@@ -68,7 +68,7 @@ export default async function DiscoverPage({ searchParams }: PageProps<"/">) {
             <div className="flex flex-wrap items-center gap-0 sm:gap-2">
               <ServiceViewToggle view={view} />
               <Separator orientation="vertical" className="hidden sm:block" />
-              <UsageTimeframeSelect timeframe={timeframe} />
+              <TimeframeSelect timeframe={timeframe} />
             </div>
           }
         >

--- a/apps/scan/src/app/(app)/(home)/facilitators/_components/chart.tsx
+++ b/apps/scan/src/app/(app)/(home)/facilitators/_components/chart.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useChain } from "@/app/(app)/_contexts/chain/hook";
-import { useTimeRangeContext } from "@/app/(app)/_contexts/time-range/hook";
 import type { ChartData } from "@/components/ui/charts/chart/types";
 import { LoadingMultiCharts, MultiCharts } from "@/components/ui/charts/multi";
 import { facilitators } from "@/lib/facilitators";
@@ -10,12 +8,18 @@ import { formatTokenAmount } from "@/lib/token";
 import { createTab } from "@/lib/charts";
 import { api } from "@/trpc/client";
 
+import type { Chain } from "@/types/chain";
+import type { ActivityTimeframe } from "@/types/timeframes";
+
 type FacilitatorKey = `${string}-${"transactions" | "amount"}`;
 
-export const FacilitatorsChart = () => {
-  const { chain } = useChain();
-  const { timeframe } = useTimeRangeContext();
-
+export const FacilitatorsChart = ({
+  chain,
+  timeframe,
+}: {
+  chain?: Chain;
+  timeframe: ActivityTimeframe;
+}) => {
   const [bucketedFacilitatorData] =
     api.public.facilitators.bucketedStatistics.useSuspenseQuery({
       numBuckets: 48,

--- a/apps/scan/src/app/(app)/(home)/facilitators/_components/facilitators/index.tsx
+++ b/apps/scan/src/app/(app)/(home)/facilitators/_components/facilitators/index.tsx
@@ -5,17 +5,19 @@ import { api } from "@/trpc/client";
 import { DataTable, DataTableLoading } from "@/components/ui/data-table";
 
 import { columns } from "./columns";
-import { useTimeRangeContext } from "@/app/(app)/_contexts/time-range/hook";
-import { useChain } from "@/app/(app)/_contexts/chain/hook";
 import { useUrlTableSorting } from "@/hooks/use-url-table-sorting";
 import { FACILITATORS_SORT_IDS } from "@/lib/table-sort-options";
 
 import type { FacilitatorsSortId } from "@/lib/table-sort-options";
 import type { TableSorting } from "@/lib/table-state";
+import type { Chain } from "@/types/chain";
+import type { ActivityTimeframe } from "@/types/timeframes";
 
 interface Props {
+  chain?: Chain;
   pageSize: number;
   sorting: TableSorting<FacilitatorsSortId>;
+  timeframe: ActivityTimeframe;
 }
 
 interface LoadingProps {
@@ -23,9 +25,12 @@ interface LoadingProps {
   sorting?: TableSorting<FacilitatorsSortId>;
 }
 
-export const FacilitatorsTable: React.FC<Props> = ({ pageSize, sorting }) => {
-  const { timeframe } = useTimeRangeContext();
-  const { chain } = useChain();
+export const FacilitatorsTable: React.FC<Props> = ({
+  chain,
+  pageSize,
+  sorting,
+  timeframe,
+}) => {
   const tableSorting = useUrlTableSorting({
     sorting,
     sortIds: FACILITATORS_SORT_IDS,

--- a/apps/scan/src/app/(app)/(home)/facilitators/loading.tsx
+++ b/apps/scan/src/app/(app)/(home)/facilitators/loading.tsx
@@ -1,25 +1,22 @@
-import { Body, Heading } from "@/app/_components/layout/page-utils";
-
 import { Card } from "@/components/ui/card";
+import { PageHeading } from "@/components/page-heading";
+import { UsageSection } from "@/components/usage-section";
 
 import { LoadingFacilitatorsChart } from "./_components/chart";
 import { LoadingFacilitatorsTable } from "./_components/facilitators";
-import { RangeSelector } from "@/app/(app)/_contexts/time-range/component";
-
 export default function LoadingFacilitatorsPage() {
   return (
-    <div>
-      <Heading
+    <main className="mx-auto flex w-full max-w-5xl flex-1 flex-col gap-12 px-4 pt-6 pb-8 md:pt-4">
+      <PageHeading
         title="Facilitators"
         description="Top facilitators processing x402 transactions"
-        actions={<RangeSelector />}
       />
-      <Body>
+      <UsageSection aria-busy="true">
         <Card className="overflow-hidden">
           <LoadingFacilitatorsChart />
         </Card>
         <LoadingFacilitatorsTable pageSize={10} />
-      </Body>
-    </div>
+      </UsageSection>
+    </main>
   );
 }

--- a/apps/scan/src/app/(app)/(home)/facilitators/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/facilitators/page.tsx
@@ -1,8 +1,9 @@
 import { Suspense } from "react";
 
 import { Card } from "@/components/ui/card";
-
-import { Body, Heading } from "@/app/_components/layout/page-utils";
+import { PageHeading } from "@/components/page-heading";
+import { TimeframeSelect } from "@/components/timeframe-select";
+import { UsageSection } from "@/components/usage-section";
 
 import {
   FacilitatorsChart,
@@ -13,19 +14,16 @@ import {
   LoadingFacilitatorsTable,
 } from "./_components/facilitators";
 
-import { RangeSelector } from "@/app/(app)/_contexts/time-range/component";
-import { TimeRangeProvider } from "@/app/(app)/_contexts/time-range/provider";
-
 import { api, HydrateClient } from "@/trpc/server";
 
 import { getChainForPage } from "@/app/(app)/_lib/chain/page";
 
-import { ActivityTimeframe } from "@/types/timeframes";
 import { parseTableSorting } from "@/lib/table-state";
 import {
   DEFAULT_FACILITATORS_SORTING,
   FACILITATORS_SORT_IDS,
 } from "@/lib/table-sort-options";
+import { parseUsageTimeframe } from "@/lib/timeframe";
 
 import type { Metadata } from "next";
 
@@ -41,6 +39,7 @@ export default async function FacilitatorsPage({
 }: PageProps<"/facilitators">) {
   const resolvedSearchParams = await searchParams;
   const chain = await getChainForPage(resolvedSearchParams);
+  const timeframe = parseUsageTimeframe(resolvedSearchParams.d);
   const sorting = parseTableSorting(
     resolvedSearchParams,
     FACILITATORS_SORT_IDS,
@@ -49,11 +48,11 @@ export default async function FacilitatorsPage({
 
   void api.public.facilitators.bucketedStatistics.prefetch({
     numBuckets: 48,
-    timeframe: ActivityTimeframe.OneDay,
+    timeframe,
     chain,
   });
   void api.public.stats.overall.prefetch({
-    timeframe: ActivityTimeframe.OneDay,
+    timeframe,
     chain,
   });
   void api.public.facilitators.list.prefetch({
@@ -61,26 +60,29 @@ export default async function FacilitatorsPage({
       page_size: PAGE_SIZE,
     },
     sorting,
-    timeframe: ActivityTimeframe.OneDay,
+    timeframe,
     chain,
   });
 
   return (
     <HydrateClient>
-      <TimeRangeProvider initialTimeframe={ActivityTimeframe.OneDay}>
-        <Heading
+      <main className="mx-auto flex w-full max-w-5xl flex-1 flex-col gap-12 px-4 pt-6 pb-8 md:pt-4">
+        <PageHeading
           title="Facilitators"
           description="Top facilitators processing x402 transactions"
-          actions={<RangeSelector />}
         />
-        <Body>
+        <UsageSection controls={<TimeframeSelect timeframe={timeframe} />}>
           {/* <FacilitatorPackageBanner /> */}
           <Card className="overflow-hidden">
-            <Suspense fallback={<LoadingFacilitatorsChart />}>
-              <FacilitatorsChart />
+            <Suspense
+              key={`chart:${chain ?? "all"}:${timeframe}`}
+              fallback={<LoadingFacilitatorsChart />}
+            >
+              <FacilitatorsChart chain={chain} timeframe={timeframe} />
             </Suspense>
           </Card>
           <Suspense
+            key={`table:${chain ?? "all"}:${timeframe}:${sorting.id}:${sorting.desc}`}
             fallback={
               <LoadingFacilitatorsTable
                 pageSize={PAGE_SIZE}
@@ -88,10 +90,15 @@ export default async function FacilitatorsPage({
               />
             }
           >
-            <FacilitatorsTable pageSize={PAGE_SIZE} sorting={sorting} />
+            <FacilitatorsTable
+              chain={chain}
+              pageSize={PAGE_SIZE}
+              sorting={sorting}
+              timeframe={timeframe}
+            />
           </Suspense>
-        </Body>
-      </TimeRangeProvider>
+        </UsageSection>
+      </main>
     </HydrateClient>
   );
 }

--- a/apps/scan/src/app/(app)/(home)/networks/_components/chart.tsx
+++ b/apps/scan/src/app/(app)/(home)/networks/_components/chart.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useChain } from "@/app/(app)/_contexts/chain/hook";
-import { useTimeRangeContext } from "@/app/(app)/_contexts/time-range/hook";
 import type { ChartData } from "@/components/ui/charts/chart/types";
 import { LoadingMultiCharts, MultiCharts } from "@/components/ui/charts/multi";
 import type { Chain } from "@/types/chain";
@@ -9,13 +7,17 @@ import type { Chain } from "@/types/chain";
 import { formatTokenAmount } from "@/lib/token";
 import { createTab, networks } from "@/lib/charts";
 import { api } from "@/trpc/client";
+import type { ActivityTimeframe } from "@/types/timeframes";
 
 type NetworkKey = `${Chain}-${"transactions" | "amount"}`;
 
-export const NetworksChart = () => {
-  const { chain } = useChain();
-  const { timeframe } = useTimeRangeContext();
-
+export const NetworksChart = ({
+  chain,
+  timeframe,
+}: {
+  chain?: Chain;
+  timeframe: ActivityTimeframe;
+}) => {
   const [bucketedNetworkData] =
     api.networks.bucketedStatistics.useSuspenseQuery({
       numBuckets: 48,

--- a/apps/scan/src/app/(app)/(home)/networks/_components/networks/index.tsx
+++ b/apps/scan/src/app/(app)/(home)/networks/_components/networks/index.tsx
@@ -5,21 +5,23 @@ import { api } from "@/trpc/client";
 import { DataTable, DataTableLoading } from "@/components/ui/data-table";
 
 import { columns } from "./columns";
-import { useTimeRangeContext } from "@/app/(app)/_contexts/time-range/hook";
-import { useChain } from "@/app/(app)/_contexts/chain/hook";
 import { useUrlTableSorting } from "@/hooks/use-url-table-sorting";
 import { NETWORKS_SORT_IDS } from "@/lib/table-sort-options";
 
 import type { NetworksSortId } from "@/lib/table-sort-options";
 import type { TableSorting } from "@/lib/table-state";
+import type { Chain } from "@/types/chain";
+import type { ActivityTimeframe } from "@/types/timeframes";
 
 export const NetworksTable = ({
+  chain,
   sorting,
+  timeframe,
 }: {
+  chain?: Chain;
   sorting: TableSorting<NetworksSortId>;
+  timeframe: ActivityTimeframe;
 }) => {
-  const { timeframe } = useTimeRangeContext();
-  const { chain } = useChain();
   const tableSorting = useUrlTableSorting({
     sorting,
     sortIds: NETWORKS_SORT_IDS,

--- a/apps/scan/src/app/(app)/(home)/networks/loading.tsx
+++ b/apps/scan/src/app/(app)/(home)/networks/loading.tsx
@@ -1,23 +1,22 @@
-import { Body, Heading } from "@/app/_components/layout/page-utils";
 import { Card } from "@/components/ui/card";
-import { RangeSelector } from "@/app/(app)/_contexts/time-range/component";
+import { PageHeading } from "@/components/page-heading";
+import { UsageSection } from "@/components/usage-section";
 import { LoadingNetworksChart } from "./_components/chart";
 import { LoadingNetworksTable } from "./_components/networks";
 
 export default function LoadingNetworksPage() {
   return (
-    <>
-      <Heading
+    <main className="mx-auto flex w-full max-w-5xl flex-1 flex-col gap-12 px-4 pt-6 pb-8 md:pt-4">
+      <PageHeading
         title="Networks"
         description="Top networks processing x402 transactions"
-        actions={<RangeSelector />}
       />
-      <Body>
+      <UsageSection aria-busy="true">
         <Card className="overflow-hidden">
           <LoadingNetworksChart />
         </Card>
         <LoadingNetworksTable />
-      </Body>
-    </>
+      </UsageSection>
+    </main>
   );
 }

--- a/apps/scan/src/app/(app)/(home)/networks/page.tsx
+++ b/apps/scan/src/app/(app)/(home)/networks/page.tsx
@@ -1,24 +1,23 @@
 import { Suspense } from "react";
 
 import { Card } from "@/components/ui/card";
-
-import { Body, Heading } from "@/app/_components/layout/page-utils";
+import { PageHeading } from "@/components/page-heading";
+import { TimeframeSelect } from "@/components/timeframe-select";
+import { UsageSection } from "@/components/usage-section";
 
 import { NetworksChart, LoadingNetworksChart } from "./_components/chart";
 import { NetworksTable, LoadingNetworksTable } from "./_components/networks";
 
-import { RangeSelector } from "@/app/(app)/_contexts/time-range/component";
-import { TimeRangeProvider } from "@/app/(app)/_contexts/time-range/provider";
 import { api, HydrateClient } from "@/trpc/server";
 
 import { getChainForPage } from "@/app/(app)/_lib/chain/page";
 
-import { ActivityTimeframe } from "@/types/timeframes";
 import { parseTableSorting } from "@/lib/table-state";
 import {
   DEFAULT_NETWORKS_SORTING,
   NETWORKS_SORT_IDS,
 } from "@/lib/table-sort-options";
+import { parseUsageTimeframe } from "@/lib/timeframe";
 
 import type { Metadata } from "next";
 
@@ -32,6 +31,7 @@ export default async function NetworksPage({
 }: PageProps<"/networks">) {
   const resolvedSearchParams = await searchParams;
   const chain = await getChainForPage(resolvedSearchParams);
+  const timeframe = parseUsageTimeframe(resolvedSearchParams.d);
   const sorting = parseTableSorting(
     resolvedSearchParams,
     NETWORKS_SORT_IDS,
@@ -40,38 +40,47 @@ export default async function NetworksPage({
 
   void api.networks.bucketedStatistics.prefetch({
     numBuckets: 48,
-    timeframe: ActivityTimeframe.OneDay,
+    timeframe,
     chain,
   });
   void api.public.stats.overall.prefetch({
-    timeframe: ActivityTimeframe.OneDay,
+    timeframe,
     chain,
   });
   void api.networks.list.prefetch({
     sorting,
-    timeframe: ActivityTimeframe.OneDay,
+    timeframe,
     chain,
   });
 
   return (
     <HydrateClient>
-      <TimeRangeProvider initialTimeframe={ActivityTimeframe.OneDay}>
-        <Heading
+      <main className="mx-auto flex w-full max-w-5xl flex-1 flex-col gap-12 px-4 pt-6 pb-8 md:pt-4">
+        <PageHeading
           title="Networks"
           description="Top networks processing x402 transactions"
-          actions={<RangeSelector />}
         />
-        <Body>
+        <UsageSection controls={<TimeframeSelect timeframe={timeframe} />}>
           <Card className="overflow-hidden">
-            <Suspense fallback={<LoadingNetworksChart />}>
-              <NetworksChart />
+            <Suspense
+              key={`chart:${chain ?? "all"}:${timeframe}`}
+              fallback={<LoadingNetworksChart />}
+            >
+              <NetworksChart chain={chain} timeframe={timeframe} />
             </Suspense>
           </Card>
-          <Suspense fallback={<LoadingNetworksTable sorting={sorting} />}>
-            <NetworksTable sorting={sorting} />
+          <Suspense
+            key={`table:${chain ?? "all"}:${timeframe}:${sorting.id}:${sorting.desc}`}
+            fallback={<LoadingNetworksTable sorting={sorting} />}
+          >
+            <NetworksTable
+              chain={chain}
+              sorting={sorting}
+              timeframe={timeframe}
+            />
           </Suspense>
-        </Body>
-      </TimeRangeProvider>
+        </UsageSection>
+      </main>
     </HydrateClient>
   );
 }

--- a/apps/scan/src/app/(app)/_components/layout/navbar/chain-selector.tsx
+++ b/apps/scan/src/app/(app)/_components/layout/navbar/chain-selector.tsx
@@ -17,6 +17,8 @@ import {
 import { Globe } from "lucide-react";
 import { useState } from "react";
 
+const URL_BACKED_CHAIN_ROUTES = new Set(["/", "/facilitators", "/networks"]);
+
 export const ChainSelector = () => {
   const { chain, setChain } = useChain();
   const pathname = usePathname();
@@ -27,7 +29,7 @@ export const ChainSelector = () => {
   const handleSelectChain = (chain: Chain | undefined) => {
     setChain(chain);
 
-    if (pathname === "/") {
+    if (URL_BACKED_CHAIN_ROUTES.has(pathname)) {
       replaceSearchParams((params) => {
         if (chain) {
           params.set("chain", chain);

--- a/apps/scan/src/components/page-heading.tsx
+++ b/apps/scan/src/components/page-heading.tsx
@@ -1,0 +1,13 @@
+interface PageHeadingProps {
+  title: string;
+  description: string;
+}
+
+export function PageHeading({ title, description }: PageHeadingProps) {
+  return (
+    <div className="flex flex-col gap-2">
+      <h1 className="type-page-title">{title}</h1>
+      <p className="text-muted-foreground">{description}</p>
+    </div>
+  );
+}

--- a/apps/scan/src/components/timeframe-select.tsx
+++ b/apps/scan/src/components/timeframe-select.tsx
@@ -13,13 +13,13 @@ import {
 } from "@/components/ui/select";
 import { useReplaceSearchParams } from "@/hooks/use-replace-search-params";
 import {
-  DEFAULT_DISCOVER_TIMEFRAME,
-  DISCOVER_TIMEFRAME_OPTIONS,
-} from "@/lib/discover/filters";
+  DEFAULT_USAGE_TIMEFRAME,
+  USAGE_TIMEFRAME_OPTIONS,
+} from "@/lib/timeframe";
 
 import type { ActivityTimeframe } from "@/types/timeframes";
 
-export function UsageTimeframeSelect({
+export function TimeframeSelect({
   timeframe,
 }: {
   timeframe: ActivityTimeframe;
@@ -30,7 +30,7 @@ export function UsageTimeframeSelect({
     if (nextTimeframe === timeframe) return;
 
     replaceSearchParams((params) => {
-      if (nextTimeframe === DEFAULT_DISCOVER_TIMEFRAME) {
+      if (nextTimeframe === DEFAULT_USAGE_TIMEFRAME) {
         params.delete("d");
       } else {
         params.set("d", nextTimeframe.toString());
@@ -45,7 +45,7 @@ export function UsageTimeframeSelect({
       <Select
         value={timeframe.toString()}
         onValueChange={(value) => {
-          const option = DISCOVER_TIMEFRAME_OPTIONS.find(
+          const option = USAGE_TIMEFRAME_OPTIONS.find(
             (candidate) => candidate.value.toString() === value
           );
           if (option) setTimeframe(option.value);
@@ -59,14 +59,14 @@ export function UsageTimeframeSelect({
         >
           <SelectValue>
             {(value: string | null) =>
-              DISCOVER_TIMEFRAME_OPTIONS.find(
+              USAGE_TIMEFRAME_OPTIONS.find(
                 (option) => option.value.toString() === value
               )?.label ?? "Timeframe"
             }
           </SelectValue>
         </SelectTrigger>
         <SelectContent>
-          {DISCOVER_TIMEFRAME_OPTIONS.map((option) => (
+          {USAGE_TIMEFRAME_OPTIONS.map((option) => (
             <SelectItem key={option.value} value={option.value.toString()}>
               {option.label}
             </SelectItem>
@@ -78,14 +78,14 @@ export function UsageTimeframeSelect({
         aria-label="Usage timeframe"
         value={timeframe.toString()}
         onValueChange={(value) => {
-          const option = DISCOVER_TIMEFRAME_OPTIONS.find(
+          const option = USAGE_TIMEFRAME_OPTIONS.find(
             (candidate) => candidate.value.toString() === value
           );
           if (option) setTimeframe(option.value);
         }}
         className="hidden sm:inline-flex"
       >
-        {DISCOVER_TIMEFRAME_OPTIONS.map((option) => (
+        {USAGE_TIMEFRAME_OPTIONS.map((option) => (
           <MotionToggleItem key={option.value} value={option.value.toString()}>
             {option.label}
           </MotionToggleItem>

--- a/apps/scan/src/lib/discover/filters.test.ts
+++ b/apps/scan/src/lib/discover/filters.test.ts
@@ -1,33 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  DEFAULT_DISCOVER_TIMEFRAME,
   DEFAULT_SERVICE_VIEW,
   formatDiscoverPage,
   parseDiscoverPage,
-  parseDiscoverTimeframe,
   parseServiceView,
 } from "./filters";
-import { ActivityTimeframe } from "@/types/timeframes";
-
-describe("parseDiscoverTimeframe", () => {
-  it.each([
-    ["0", ActivityTimeframe.AllTime],
-    ["1", ActivityTimeframe.OneDay],
-    ["7", ActivityTimeframe.SevenDays],
-    ["14", ActivityTimeframe.FourteenDays],
-    ["30", ActivityTimeframe.ThirtyDays],
-  ])("parses %s", (raw, expected) => {
-    expect(parseDiscoverTimeframe(raw)).toBe(expected);
-  });
-
-  it.each([undefined, "", "2", "thirty", ["7"]])(
-    "uses the default for %j",
-    (raw) => {
-      expect(parseDiscoverTimeframe(raw)).toBe(DEFAULT_DISCOVER_TIMEFRAME);
-    }
-  );
-});
 
 describe("parseServiceView", () => {
   it.each(["featured", "all"] as const)("parses %s", (view) => {

--- a/apps/scan/src/lib/discover/filters.ts
+++ b/apps/scan/src/lib/discover/filters.ts
@@ -1,22 +1,6 @@
 import { z } from "zod";
 
-import { ActivityTimeframe } from "@/types/timeframes";
-
 type SearchParamValue = string | string[] | undefined;
-
-const timeframeSchema = z.union([
-  z.literal(ActivityTimeframe.AllTime),
-  z.literal(ActivityTimeframe.OneDay),
-  z.literal(ActivityTimeframe.SevenDays),
-  z.literal(ActivityTimeframe.FourteenDays),
-  z.literal(ActivityTimeframe.ThirtyDays),
-]);
-const timeframeParamSchema = z
-  .string()
-  .trim()
-  .min(1)
-  .transform(Number)
-  .pipe(timeframeSchema);
 const pageParamSchema = z
   .string()
   .trim()
@@ -24,27 +8,11 @@ const pageParamSchema = z
   .transform(Number)
   .pipe(z.number().int().positive());
 
-export const DEFAULT_DISCOVER_TIMEFRAME = ActivityTimeframe.ThirtyDays;
 export const SERVICES_PAGE_SIZE = 15;
-
-export const DISCOVER_TIMEFRAME_OPTIONS = [
-  { label: "24h", value: ActivityTimeframe.OneDay },
-  { label: "7d", value: ActivityTimeframe.SevenDays },
-  { label: "14d", value: ActivityTimeframe.FourteenDays },
-  { label: "30d", value: ActivityTimeframe.ThirtyDays },
-  { label: "All", value: ActivityTimeframe.AllTime },
-] as const;
 
 const serviceViewSchema = z.enum(["featured", "all"]);
 export type ServiceView = z.infer<typeof serviceViewSchema>;
 export const DEFAULT_SERVICE_VIEW: ServiceView = "featured";
-
-export function parseDiscoverTimeframe(
-  raw: SearchParamValue
-): ActivityTimeframe {
-  const parsed = timeframeParamSchema.safeParse(raw);
-  return parsed.success ? parsed.data : DEFAULT_DISCOVER_TIMEFRAME;
-}
 
 export function parseServiceView(raw: SearchParamValue): ServiceView {
   const parsed = serviceViewSchema.safeParse(raw);

--- a/apps/scan/src/lib/timeframe.test.ts
+++ b/apps/scan/src/lib/timeframe.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { ActivityTimeframe } from "@/types/timeframes";
+
+import { DEFAULT_USAGE_TIMEFRAME, parseUsageTimeframe } from "./timeframe";
+
+describe("parseUsageTimeframe", () => {
+  it.each([
+    ["0", ActivityTimeframe.AllTime],
+    ["1", ActivityTimeframe.OneDay],
+    ["7", ActivityTimeframe.SevenDays],
+    ["14", ActivityTimeframe.FourteenDays],
+    ["30", ActivityTimeframe.ThirtyDays],
+  ])("parses %s", (raw, expected) => {
+    expect(parseUsageTimeframe(raw)).toBe(expected);
+  });
+
+  it.each([undefined, "", "2", "thirty", ["7"]])(
+    "uses the default for %j",
+    (raw) => {
+      expect(parseUsageTimeframe(raw)).toBe(DEFAULT_USAGE_TIMEFRAME);
+    }
+  );
+});

--- a/apps/scan/src/lib/timeframe.ts
+++ b/apps/scan/src/lib/timeframe.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+import { ActivityTimeframe } from "@/types/timeframes";
+
+type SearchParamValue = string | string[] | undefined;
+
+const timeframeSchema = z.union([
+  z.literal(ActivityTimeframe.AllTime),
+  z.literal(ActivityTimeframe.OneDay),
+  z.literal(ActivityTimeframe.SevenDays),
+  z.literal(ActivityTimeframe.FourteenDays),
+  z.literal(ActivityTimeframe.ThirtyDays),
+]);
+
+const timeframeParamSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .transform(Number)
+  .pipe(timeframeSchema);
+
+export const DEFAULT_USAGE_TIMEFRAME = ActivityTimeframe.ThirtyDays;
+
+export const USAGE_TIMEFRAME_OPTIONS = [
+  { label: "24h", value: ActivityTimeframe.OneDay },
+  { label: "7d", value: ActivityTimeframe.SevenDays },
+  { label: "14d", value: ActivityTimeframe.FourteenDays },
+  { label: "30d", value: ActivityTimeframe.ThirtyDays },
+  { label: "All", value: ActivityTimeframe.AllTime },
+] as const;
+
+export function parseUsageTimeframe(raw: SearchParamValue): ActivityTimeframe {
+  const parsed = timeframeParamSchema.safeParse(raw);
+  return parsed.success ? parsed.data : DEFAULT_USAGE_TIMEFRAME;
+}


### PR DESCRIPTION
## Summary

- align the Facilitators and Networks pages with the same public shell, semantic heading, and Usage section used by Discover
- promote the timeframe parser and responsive selector into shared modules, backed by the `d` query parameter
- drive chart and table queries from the same server-derived timeframe and chain inputs while leaving Transactions/Amount as chart-local tabs
- URL-sync navbar chain selection across Discover, Facilitators, and Networks
- align resolved and loading layouts across both collection pages

## Validation

- `pnpm check`
- 239 scan tests
- Foundation UI check and UI integrity check
- independent review and clean remediation re-review
- Playwright desktop/mobile light/dark visual checks
- Playwright verified `/networks?d=7` -> `/networks?d=7&chain=base` updates both chart and table data

## Stack

Depends on #1142.