### PR TITLE
chore: clean up mechanical lint findings

### DIFF
--- a/apps/proxy/src/routes/proxy.ts
+++ b/apps/proxy/src/routes/proxy.ts
@@ -11,7 +11,7 @@ const REQUEST_HEADER_BLOCKLIST = new Set(["host", "content-length"]);
 const extractRequestBody = async (request: Request) => {
   const contentType = request.headers.get("content-type") ?? "";
   if (contentType.includes("application/json")) {
-    return (await request.json()) as unknown;
+    return request.json();
   } else if (contentType.includes("application/x-www-form-urlencoded")) {
     const formData = await request.formData();
     return Object.fromEntries(formData.entries());
@@ -19,7 +19,7 @@ const extractRequestBody = async (request: Request) => {
     const formData = await request.formData();
     return Object.fromEntries(formData.entries());
   } else if (contentType.includes("text/")) {
-    return await request.text();
+    return request.text();
   }
   return null;
 };
@@ -70,7 +70,7 @@ const extractResponseBody = async (
 
   if (contentType.includes("application/json")) {
     try {
-      const result = (await response.json()) as unknown;
+      const result = await response.json();
       console.log("[extractResponseBody] Successfully parsed JSON");
       return { kind: "json", body: result };
     } catch (error) {
@@ -304,8 +304,7 @@ async function proxyHandler(c: Context) {
       void (async () => {
         try {
           if (clonedUpstreamResponse.status === 402) {
-            const upstreamX402Response =
-              (await clonedUpstreamResponse.json()) as unknown;
+            const upstreamX402Response = await clonedUpstreamResponse.json();
             console.log("[402 Response]", {
               url: targetUrl.toString(),
               data: upstreamX402Response,
@@ -320,7 +319,8 @@ async function proxyHandler(c: Context) {
             let requestBody: unknown = undefined;
             let requestHeaders: Record<string, string> | undefined = undefined;
             let responseBody: unknown = undefined;
-            let responseHeaders: Record<string, string> | undefined = undefined;
+            let capturedResponseHeaders: Record<string, string> | undefined =
+              undefined;
 
             try {
               requestBody = await extractRequestBody(clonedRequest);
@@ -369,7 +369,7 @@ async function proxyHandler(c: Context) {
             }
 
             try {
-              responseHeaders = Object.fromEntries(
+              capturedResponseHeaders = Object.fromEntries(
                 clonedUpstreamResponse.headers
               );
             } catch (error) {
@@ -392,7 +392,7 @@ async function proxyHandler(c: Context) {
               requestBody,
               requestHeaders,
               responseBody,
-              responseHeaders,
+              responseHeaders: capturedResponseHeaders,
             };
             console.log("[Proxy Data]", { cleanedTargetUrl, data });
           }

--- a/apps/scan/src/app/(app)/(home)/(discover)/layout.tsx
+++ b/apps/scan/src/app/(app)/(home)/(discover)/layout.tsx
@@ -6,10 +6,6 @@ export const metadata: Metadata = {
   },
 };
 
-export default function DiscoverLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function DiscoverLayout({ children }: LayoutProps<"/">) {
   return children;
 }

--- a/apps/scan/src/app/(app)/(home)/agentic-commerce/layout.tsx
+++ b/apps/scan/src/app/(app)/(home)/agentic-commerce/layout.tsx
@@ -2,8 +2,6 @@ import { DocumentationPage } from "@/components/documentation-page";
 
 export default function AgenticCommerceLayout({
   children,
-}: {
-  children: React.ReactNode;
-}) {
+}: LayoutProps<"/agentic-commerce">) {
   return <DocumentationPage>{children}</DocumentationPage>;
 }

--- a/apps/scan/src/app/(app)/(home)/discovery/layout.tsx
+++ b/apps/scan/src/app/(app)/(home)/discovery/layout.tsx
@@ -2,8 +2,6 @@ import { DocumentationPage } from "@/components/documentation-page";
 
 export default function DiscoveryLayout({
   children,
-}: {
-  children: React.ReactNode;
-}) {
+}: LayoutProps<"/discovery">) {
   return <DocumentationPage>{children}</DocumentationPage>;
 }

--- a/apps/scan/src/app/(app)/(home)/discovery/quickstart/_components/prompt-card.tsx
+++ b/apps/scan/src/app/(app)/(home)/discovery/quickstart/_components/prompt-card.tsx
@@ -21,7 +21,9 @@ export function QuickstartPromptCard() {
         "overflow-hidden cursor-pointer transition-colors hover:border-foreground/20",
         expanded && "border-foreground/20"
       )}
-      onClick={() => setExpanded(!expanded)}
+      onClick={() => {
+        setExpanded(!expanded);
+      }}
     >
       <div className="flex items-center justify-between gap-4 p-4">
         <div className="type-supporting-body flex items-center gap-2.5 text-muted-foreground">

--- a/apps/scan/src/app/(app)/(home)/facilitators/_components/chart.tsx
+++ b/apps/scan/src/app/(app)/(home)/facilitators/_components/chart.tsx
@@ -48,7 +48,7 @@ export const FacilitatorsChart = ({
     totalTransactions: totals?.[facilitator.id]?.totalTransactions ?? 0,
   }));
 
-  const facilitatorsByTransactions = [...facilitatorTotals].sort(
+  const facilitatorsByTransactions = [...facilitatorTotals].toSorted(
     (a, b) => b.totalTransactions - a.totalTransactions
   );
 

--- a/apps/scan/src/app/(app)/(home)/integration-spec/agent-prompt-preview.tsx
+++ b/apps/scan/src/app/(app)/(home)/integration-spec/agent-prompt-preview.tsx
@@ -49,14 +49,16 @@ export function AgentPromptPreview({
           </pre>
         </motion.div>
         {!expanded && (
-          <div className="pointer-events-none absolute inset-x-0 bottom-0 h-10 rounded-b-md bg-gradient-to-t from-muted via-muted/95 to-transparent" />
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 h-10 rounded-b-md bg-linear-to-t from-muted via-muted/95 to-transparent" />
         )}
       </div>
       <div className="flex justify-end">
         <Button
           variant="quiet"
           size="none"
-          onClick={() => setExpanded((prev) => !prev)}
+          onClick={() => {
+            setExpanded((prev) => !prev);
+          }}
         >
           {expanded ? "Show less" : "Show full prompt"}
         </Button>

--- a/apps/scan/src/app/(app)/(home)/integration-spec/layout.tsx
+++ b/apps/scan/src/app/(app)/(home)/integration-spec/layout.tsx
@@ -2,8 +2,6 @@ import { DocumentationPage } from "@/components/documentation-page";
 
 export default function IntegrationSpecLayout({
   children,
-}: {
-  children: React.ReactNode;
-}) {
+}: LayoutProps<"/integration-spec">) {
   return <DocumentationPage>{children}</DocumentationPage>;
 }

--- a/apps/scan/src/app/(app)/(home)/layout.tsx
+++ b/apps/scan/src/app/(app)/(home)/layout.tsx
@@ -1,8 +1,4 @@
-export default function HomeLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function HomeLayout({ children }: LayoutProps<"/">) {
   return (
     <div className="flex flex-1 flex-col">
       <div className="flex flex-1 flex-col py-6 md:py-8">{children}</div>

--- a/apps/scan/src/app/(app)/(home)/networks/_components/chart.tsx
+++ b/apps/scan/src/app/(app)/(home)/networks/_components/chart.tsx
@@ -55,7 +55,7 @@ export const NetworksChart = ({
         0
       ),
     }))
-    .sort((a, b) => b.totalTransactions - a.totalTransactions)
+    .toSorted((a, b) => b.totalTransactions - a.totalTransactions)
     .map((item) => item.network);
 
   const chart = createUsageBarChartModel({

--- a/apps/scan/src/app/(app)/(home)/resources/register/_components/expandable-link.tsx
+++ b/apps/scan/src/app/(app)/(home)/resources/register/_components/expandable-link.tsx
@@ -22,21 +22,29 @@ export function ExpandableLink({
       }
     }
     document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
   }, [open]);
 
   return (
     <span
       ref={ref}
       className="relative inline-flex flex-col items-center"
-      onMouseEnter={() => setOpen(true)}
-      onMouseLeave={() => setOpen(false)}
+      onMouseEnter={() => {
+        setOpen(true);
+      }}
+      onMouseLeave={() => {
+        setOpen(false);
+      }}
     >
       <Button
         type="button"
         variant="quiet"
         size="none"
-        onClick={() => setOpen((prev) => !prev)}
+        onClick={() => {
+          setOpen((prev) => !prev);
+        }}
       >
         {label}
       </Button>

--- a/apps/scan/src/app/(app)/(home)/x402/layout.tsx
+++ b/apps/scan/src/app/(app)/(home)/x402/layout.tsx
@@ -1,9 +1,5 @@
 import { DocumentationPage } from "@/components/documentation-page";
 
-export default function X402Layout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function X402Layout({ children }: LayoutProps<"/x402">) {
   return <DocumentationPage>{children}</DocumentationPage>;
 }

--- a/apps/scan/src/app/(app)/_components/layout/header/theme-toggle.tsx
+++ b/apps/scan/src/app/(app)/_components/layout/header/theme-toggle.tsx
@@ -14,7 +14,9 @@ export function ThemeToggle() {
       variant="quiet"
       size="icon"
       aria-label="Toggle color theme"
-      onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
+      onClick={() => {
+        setTheme(resolvedTheme === "dark" ? "light" : "dark");
+      }}
     >
       <Sun className="size-4 dark:hidden" />
       <Moon className="hidden size-4 dark:block" />

--- a/apps/scan/src/app/(app)/_components/layout/navbar/chain-selector.tsx
+++ b/apps/scan/src/app/(app)/_components/layout/navbar/chain-selector.tsx
@@ -26,13 +26,13 @@ export const ChainSelector = () => {
 
   const [isOpen, setIsOpen] = useState(false);
 
-  const handleSelectChain = (chain: Chain | undefined) => {
-    setChain(chain);
+  const handleSelectChain = (selectedChain: Chain | undefined) => {
+    setChain(selectedChain);
 
     if (URL_BACKED_CHAIN_ROUTES.has(pathname)) {
       replaceSearchParams((params) => {
-        if (chain) {
-          params.set("chain", chain);
+        if (selectedChain) {
+          params.set("chain", selectedChain);
         } else {
           params.delete("chain");
         }

--- a/apps/scan/src/app/(app)/_components/layout/navbar/search.tsx
+++ b/apps/scan/src/app/(app)/_components/layout/navbar/search.tsx
@@ -16,7 +16,9 @@ export const NavbarSearchButton = () => {
       variant="outline"
       aria-label="Search x402scan"
       className="text-muted-foreground lg:w-48 lg:justify-between lg:px-2 lg:pr-1"
-      onClick={() => setIsOpen(true)}
+      onClick={() => {
+        setIsOpen(true);
+      }}
     >
       <div className="flex items-center gap-2">
         <Search className="size-4" />

--- a/apps/scan/src/app/(app)/_contexts/chain/provider.tsx
+++ b/apps/scan/src/app/(app)/_contexts/chain/provider.tsx
@@ -23,9 +23,9 @@ export const ChainProvider: React.FC<Props> = ({ children }) => {
   );
   const chain = urlChain ?? storedChain;
 
-  const setChain = (chain: Chain | undefined) => {
-    setDataChainCookieClient(chain);
-    setStoredChain(chain);
+  const setChain = (selectedChain: Chain | undefined) => {
+    setDataChainCookieClient(selectedChain);
+    setStoredChain(selectedChain);
   };
 
   return (

--- a/apps/scan/src/app/(app)/_contexts/search/provider.tsx
+++ b/apps/scan/src/app/(app)/_contexts/search/provider.tsx
@@ -34,11 +34,13 @@ export const SearchProvider = ({ children }: { children: React.ReactNode }) => {
     const down = (e: KeyboardEvent) => {
       if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
-        setIsOpen((isOpen) => !isOpen);
+        setIsOpen((wasOpen) => !wasOpen);
       }
     };
     document.addEventListener("keydown", down);
-    return () => document.removeEventListener("keydown", down);
+    return () => {
+      document.removeEventListener("keydown", down);
+    };
   }, []);
 
   const input = {
@@ -99,7 +101,9 @@ export const SearchProvider = ({ children }: { children: React.ReactNode }) => {
                   <CommandItem
                     key={origin.id}
                     value={origin.origin}
-                    onSelect={() => handleSelect(`/server/${origin.id}`)}
+                    onSelect={() => {
+                      handleSelect(`/server/${origin.id}`);
+                    }}
                   >
                     <Origin
                       origin={origin}
@@ -121,9 +125,9 @@ export const SearchProvider = ({ children }: { children: React.ReactNode }) => {
                   <CommandItem
                     key={resource.id}
                     value={resource.resource}
-                    onSelect={() =>
-                      handleSelect(`/server/${resource.origin.id}`)
-                    }
+                    onSelect={() => {
+                      handleSelect(`/server/${resource.origin.id}`);
+                    }}
                   >
                     <Resource resource={resource} />
                   </CommandItem>

--- a/apps/scan/src/app/(app)/_lib/chain/page.ts
+++ b/apps/scan/src/app/(app)/_lib/chain/page.ts
@@ -14,5 +14,5 @@ export const getChainForPage = async (
       return parsedChain;
     }
   }
-  return await getDataChainCookieServer();
+  return getDataChainCookieServer();
 };

--- a/apps/scan/src/app/_contexts/solana/provider.tsx
+++ b/apps/scan/src/app/_contexts/solana/provider.tsx
@@ -42,15 +42,16 @@ export function SolanaWalletProvider({ children }: Props) {
 
   useEffect(() => {
     if (ready && cdpWallet) {
-      const wallet = wallets.find(
-        (wallet) =>
-          wallet.features.includes("cdp:") &&
-          wallet.accounts[0]?.address === cdpWallet.accounts[0]?.address
+      const matchingWallet = wallets.find(
+        (candidateWallet) =>
+          candidateWallet.features.includes("cdp:") &&
+          candidateWallet.accounts[0]?.address ===
+            cdpWallet.accounts[0]?.address
       );
-      if (wallet) {
+      if (matchingWallet) {
         setConnectedWallet({
-          account: wallet.accounts[0]!,
-          wallet: wallet,
+          account: matchingWallet.accounts[0]!,
+          wallet: matchingWallet,
         });
       }
     }

--- a/apps/scan/src/app/api/chat/[id]/stream/route.ts
+++ b/apps/scan/src/app/api/chat/[id]/stream/route.ts
@@ -6,7 +6,7 @@ import { createResumableStreamContext } from "resumable-stream";
 
 export async function GET(
   _: Request,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: RouteContext<"/api/chat/[id]/stream">
 ) {
   const { id } = await params;
 

--- a/apps/scan/src/app/api/chat/execute-tool/route.ts
+++ b/apps/scan/src/app/api/chat/execute-tool/route.ts
@@ -139,7 +139,9 @@ export const POST = async (request: NextRequest) => {
     );
   }
 
-  const accept = resource.accepts?.find((accept) => accept.network === chain);
+  const accept = resource.accepts?.find(
+    (candidateAccept) => candidateAccept.network === chain
+  );
 
   if (!accept) {
     return NextResponse.json(
@@ -226,8 +228,8 @@ export const POST = async (request: NextRequest) => {
     requestInit.headers = mergedHeaders;
   }
 
-  const supportedAccepts = resource.accepts.filter((accept) =>
-    SUPPORTED_CHAINS.includes(accept.network as SupportedChain)
+  const supportedAccepts = resource.accepts.filter((candidateAccept) =>
+    SUPPORTED_CHAINS.includes(candidateAccept.network as SupportedChain)
   );
 
   if (supportedAccepts.length === 0) {

--- a/apps/scan/src/auth/providers/siwe/provider.ts
+++ b/apps/scan/src/auth/providers/siwe/provider.ts
@@ -97,7 +97,7 @@ function SiweProvider(options?: Partial<CredentialsConfig>) {
 
         // no user, create a user and an account
         if (!user) {
-          return await scanDb.user.create({
+          return scanDb.user.create({
             data: {
               email,
               accounts: {

--- a/apps/scan/src/auth/providers/siws/provider.ts
+++ b/apps/scan/src/auth/providers/siws/provider.ts
@@ -102,7 +102,7 @@ function SiwsProvider(options?: Partial<CredentialsConfig>) {
 
         // no user, create a user and an account
         if (!user) {
-          return await scanDb.user.create({
+          return scanDb.user.create({
             data: {
               email,
               accounts: {

--- a/apps/scan/src/components/ai-elements/json-viewer.tsx
+++ b/apps/scan/src/components/ai-elements/json-viewer.tsx
@@ -90,8 +90,10 @@ const JsonNode = ({
         <div className="flex items-start gap-1">
           {!isEmpty && (
             <button
-              onClick={() => setIsCollapsed(!isCollapsed)}
-              className="mt-0.5 flex-shrink-0 rounded p-0.5 transition-colors hover:bg-accent"
+              onClick={() => {
+                setIsCollapsed(!isCollapsed);
+              }}
+              className="mt-0.5 shrink-0 rounded p-0.5 transition-colors hover:bg-accent"
               aria-label={isCollapsed ? "Expand" : "Collapse"}
             >
               {isCollapsed ? (

--- a/apps/scan/src/components/ai-elements/message.tsx
+++ b/apps/scan/src/components/ai-elements/message.tsx
@@ -13,7 +13,7 @@ const Message = ({
     className={cn(
       "group flex flex-col w-full items-end gap-4 py-2 md:py-4",
       from === "user" ? "is-user" : "is-assistant items-start",
-      "[&>div]:max-w-[100%] md:[&>div]:max-w-[80%]",
+      "[&>div]:max-w-full md:[&>div]:max-w-[80%]",
       className
     )}
     {...props}

--- a/apps/scan/src/components/ai-elements/reasoning.tsx
+++ b/apps/scan/src/components/ai-elements/reasoning.tsx
@@ -85,7 +85,9 @@ export const Reasoning = memo(
           setHasAutoClosed(true);
         }, AUTO_CLOSE_DELAY);
 
-        return () => clearTimeout(timer);
+        return () => {
+          clearTimeout(timer);
+        };
       }
     }, [isStreaming, isOpen, defaultOpen, setIsOpen, hasAutoClosed]);
 

--- a/apps/scan/src/components/ai-elements/sources.tsx
+++ b/apps/scan/src/components/ai-elements/sources.tsx
@@ -31,7 +31,7 @@ const SourcesTrigger = ({
     {children ?? (
       <>
         <p className="font-medium">Used {count} sources</p>
-        <ChevronDownIcon className="h-4 w-4" />
+        <ChevronDownIcon className="size-4" />
       </>
     )}
   </CollapsibleTrigger>
@@ -61,7 +61,7 @@ const Source = ({ href, title, children, ...props }: ComponentProps<"a">) => (
   >
     {children ?? (
       <>
-        <BookIcon className="h-4 w-4" />
+        <BookIcon className="size-4" />
         <span className="block font-medium">{title}</span>
       </>
     )}

--- a/apps/scan/src/components/ai-elements/tool.tsx
+++ b/apps/scan/src/components/ai-elements/tool.tsx
@@ -62,9 +62,9 @@ const ToolHeader = ({
         <Loading
           value={resource}
           isLoading={isResourceLoading ?? state === "input-streaming"}
-          component={(resource) => (
+          component={(loadedResource) => (
             <Favicon
-              url={resource.origin.favicon ?? null}
+              url={loadedResource.origin.favicon ?? null}
               className="size-6 rounded-md md:size-8"
             />
           )}
@@ -74,10 +74,10 @@ const ToolHeader = ({
           <Loading
             value={resource}
             isLoading={isResourceLoading ?? state === "input-streaming"}
-            component={(resource) => (
+            component={(loadedResource) => (
               <div className="flex w-full items-center gap-2 overflow-hidden">
                 <span className="truncate text-left font-mono text-xs font-semibold md:text-sm">
-                  {resource.resource}
+                  {loadedResource.resource}
                 </span>
                 {state === "input-streaming" ? (
                   <Loader2 className="size-3 shrink-0 animate-spin" />
@@ -96,10 +96,10 @@ const ToolHeader = ({
           <Loading
             value={resource}
             isLoading={isResourceLoading ?? state === "input-streaming"}
-            component={(resource) => (
+            component={(loadedResource) => (
               <span className="text-left text-[10px] text-muted-foreground md:text-xs">
                 {cleanExternalText(
-                  resource.accepts.find((accept) => accept.description)
+                  loadedResource.accepts.find((accept) => accept.description)
                     ?.description ?? ""
                 )}
               </span>
@@ -166,22 +166,22 @@ const ToolOutput = ({
     return null;
   }
 
-  const parseOutput = (output: ReactNode) => {
-    const text = z.string().safeParse(output);
+  const parseOutput = (value: ReactNode) => {
+    const text = z.string().safeParse(value);
     if (!text.success) {
-      return { raw: output, parsed: null };
+      return { raw: value, parsed: null };
     }
 
     const trimmed = text.data.trim();
     if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
       try {
-        return { raw: output, parsed: JSON.parse(trimmed) as JsonValue };
+        return { raw: value, parsed: JSON.parse(trimmed) as JsonValue };
       } catch {
-        return { raw: output, parsed: null };
+        return { raw: value, parsed: null };
       }
     }
 
-    return { raw: output, parsed: null };
+    return { raw: value, parsed: null };
   };
 
   const result = output ? parseOutput(output) : { raw: null, parsed: null };

--- a/apps/scan/src/components/magicui/animated-shiny-text.tsx
+++ b/apps/scan/src/components/magicui/animated-shiny-text.tsx
@@ -30,7 +30,7 @@ export const AnimatedShinyText: FC<AnimatedShinyTextProps> = ({
         "animate-shiny-text [background-size:var(--shiny-width)_100%] bg-clip-text [background-position:0_0] bg-no-repeat [transition:background-position_1s_cubic-bezier(.6,.6,0,1)_infinite]",
 
         // Shine gradient
-        "bg-gradient-to-r from-transparent via-black/80 via-50% to-transparent dark:via-white/80",
+        "bg-linear-to-r from-transparent via-black/80 via-50% to-transparent dark:via-white/80",
 
         className
       )}

--- a/apps/scan/src/components/ui/charts/chart/area/index.tsx
+++ b/apps/scan/src/components/ui/charts/chart/area/index.tsx
@@ -36,8 +36,8 @@ export const BaseAreaChart = <
       <defs>
         {areas.map(({ dataKey, color }) => (
           <linearGradient
-            key={dataKey as string}
-            id={`${dataKey as string}-gradient`}
+            key={dataKey}
+            id={`${dataKey}-gradient`}
             x1="0"
             y1="0"
             x2="0"
@@ -51,11 +51,11 @@ export const BaseAreaChart = <
       {areas.map(({ dataKey, color, ...areaProps }, index) => {
         return (
           <Area<ChartData<T>, number>
-            key={dataKey as string}
+            key={dataKey}
             isAnimationActive={index === areas.length - 1}
             dataKey={dataKey}
             stackId="1"
-            fill={`url(#${dataKey as string}-gradient)`}
+            fill={`url(#${dataKey}-gradient)`}
             stroke={color}
             strokeWidth={1}
             type="monotone"

--- a/apps/scan/src/components/ui/charts/chart/bar/index.tsx
+++ b/apps/scan/src/components/ui/charts/chart/bar/index.tsx
@@ -40,8 +40,8 @@ export const BaseBarChart = <
         <defs>
           {bars.map(({ dataKey, color }) => (
             <linearGradient
-              key={dataKey as string}
-              id={`${dataKey as string}-gradient`}
+              key={dataKey}
+              id={`${dataKey}-gradient`}
               x1="0"
               y1="0"
               x2="0"
@@ -57,11 +57,11 @@ export const BaseBarChart = <
       {bars.map(({ dataKey, color, ...barProps }, index) => {
         return (
           <Bar<ChartData<T>, number>
-            key={dataKey as string}
+            key={dataKey}
             isAnimationActive={index === bars.length - 1}
             dataKey={dataKey}
             stackId={stacked ? "1" : index.toString()}
-            fill={solid ? color : `url(#${dataKey as string}-gradient)`}
+            fill={solid ? color : `url(#${dataKey}-gradient)`}
             fillOpacity={solid ? 0.2 : undefined}
             stroke={color}
             strokeWidth={0.5}

--- a/apps/scan/src/components/ui/charts/chart/composed/index.tsx
+++ b/apps/scan/src/components/ui/charts/chart/composed/index.tsx
@@ -35,8 +35,8 @@ export const BaseComposedChart = <
       <defs>
         {bars.map(({ dataKey, color }) => (
           <linearGradient
-            key={dataKey as string}
-            id={`${dataKey as string}-gradient`}
+            key={dataKey}
+            id={`${dataKey}-gradient`}
             x1="0"
             y1="0"
             x2="0"
@@ -50,7 +50,7 @@ export const BaseComposedChart = <
       {bars.map(({ dataKey, color, ...barProps }, index) => {
         return (
           <Bar<ChartData<T>, number>
-            key={dataKey as string}
+            key={dataKey}
             isAnimationActive={index === bars.length - 1}
             dataKey={dataKey}
             stackId={index.toString()}
@@ -64,8 +64,8 @@ export const BaseComposedChart = <
       <defs>
         {areas.map(({ dataKey, color }) => (
           <linearGradient
-            key={dataKey as string}
-            id={`${dataKey as string}-gradient`}
+            key={dataKey}
+            id={`${dataKey}-gradient`}
             x1="0"
             y1="0"
             x2="0"
@@ -79,7 +79,7 @@ export const BaseComposedChart = <
       {areas.map(({ dataKey, color, ...areaProps }, index) => {
         return (
           <Area<ChartData<T>, number>
-            key={dataKey as string}
+            key={dataKey}
             isAnimationActive={index === areas.length - 1}
             dataKey={dataKey}
             stackId="1"
@@ -93,7 +93,7 @@ export const BaseComposedChart = <
       {lines.map(({ dataKey, color, ...lineProps }, index) => {
         return (
           <Line<ChartData<T>, number>
-            key={dataKey as string}
+            key={dataKey}
             isAnimationActive={index === lines.length - 1}
             dataKey={dataKey}
             fill={`color-mix(in oklab, ${color} 40%, transparent)`}

--- a/apps/scan/src/components/ui/charts/chart/line/index.tsx
+++ b/apps/scan/src/components/ui/charts/chart/line/index.tsx
@@ -30,7 +30,7 @@ export const BaseLineChart = <
       {lines.map(({ dataKey, color, ...lineProps }, index) => {
         return (
           <Line<ChartData<T>, number>
-            key={dataKey as string}
+            key={dataKey}
             isAnimationActive={index === lines.length - 1}
             dataKey={dataKey}
             fill={`color-mix(in oklab, ${color} 40%, transparent)`}

--- a/apps/scan/src/components/ui/charts/chart/tooltip.tsx
+++ b/apps/scan/src/components/ui/charts/chart/tooltip.tsx
@@ -17,7 +17,7 @@ export const TooltipContent = <T extends Record<string, number>>({
 }: Props<T>) => {
   const sortedRows = rows
     .filter((row) => row.key in data)
-    .sort((a, b) => data[b.key]! - data[a.key]!);
+    .toSorted((a, b) => data[b.key]! - data[a.key]!);
 
   return (
     <Card className="min-w-32 overflow-hidden">

--- a/apps/scan/src/components/ui/stepper.tsx
+++ b/apps/scan/src/components/ui/stepper.tsx
@@ -44,7 +44,9 @@ export const Stepper: React.FC<Props> = ({
               activeClassName={activeStepClassName}
               onClick={
                 setCurrentStep && index < currentStep
-                  ? () => setCurrentStep(index)
+                  ? () => {
+                      setCurrentStep(index);
+                    }
                   : undefined
               }
               {...step}

--- a/apps/scan/src/hooks/use-copy-to-clipboard.ts
+++ b/apps/scan/src/hooks/use-copy-to-clipboard.ts
@@ -7,7 +7,9 @@ export const useCopyToClipboard = (onCopy?: () => void) => {
     async (text: string) => {
       await navigator.clipboard.writeText(text);
       setIsCopied(true);
-      setTimeout(() => setIsCopied(false), 2000);
+      setTimeout(() => {
+        setIsCopied(false);
+      }, 2000);
       onCopy?.();
     },
     [onCopy]

--- a/apps/scan/src/hooks/use-is-mobile.ts
+++ b/apps/scan/src/hooks/use-is-mobile.ts
@@ -21,7 +21,9 @@ export function useIsMobile(defaultValue = false) {
     mql.addEventListener("change", onChange);
 
     // Cleanup
-    return () => mql.removeEventListener("change", onChange);
+    return () => {
+      mql.removeEventListener("change", onChange);
+    };
   }, []);
 
   return isMobile;

--- a/apps/scan/src/lib/cache.ts
+++ b/apps/scan/src/lib/cache.ts
@@ -142,7 +142,7 @@ async function withRedisCache<T>(
     console.log(
       `[Cache] NO REDIS: Executing query directly for ${fullCacheKey}`
     );
-    return await queryFn();
+    return queryFn();
   }
 
   const lockKey = `${fullCacheKey}:lock`;
@@ -262,7 +262,7 @@ const createCachedQueryBase = <TInput extends unknown[], TOutput>(config: {
         : rawKey;
     const ttl = config.revalidate ?? CACHE_TTL_SECONDS;
 
-    return await withRedisCache(
+    return withRedisCache(
       fullCacheKey,
       async () => {
         const data = await config.queryFn(...args);
@@ -412,7 +412,7 @@ const normalizeCacheKeyValue = (
     // elements stringifying to '[object Object]' matches the previous
     // default-sort behavior, so existing cache keys are preserved.
     /* oxlint-disable typescript/no-base-to-string */
-    return [...value].sort((a, b) =>
+    return [...value].toSorted((a, b) =>
       String(a) < String(b) ? -1 : String(a) > String(b) ? 1 : 0
     );
     /* oxlint-enable typescript/no-base-to-string */
@@ -454,7 +454,7 @@ export const createStandardCacheKey = <T extends object>(params: T): string => {
   return JSON.stringify(
     Object.fromEntries(
       Object.keys(normalized)
-        .sort()
+        .toSorted()
         .map((key) => [key, normalized[key]])
     )
   );

--- a/apps/scan/src/lib/discover/origins.test.ts
+++ b/apps/scan/src/lib/discover/origins.test.ts
@@ -27,7 +27,7 @@ describe("fetchUsedOriginsFromAgentCash", () => {
   });
 
   it("returns origins from a successful response and calls the right URL", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(
         JSON.stringify({
           protocol: "x402",

--- a/apps/scan/src/lib/discovery/probe.ts
+++ b/apps/scan/src/lib/discovery/probe.ts
@@ -60,7 +60,9 @@ function directProbe402(
         });
       }
     );
-    req.on("error", () => resolve(null));
+    req.on("error", () => {
+      resolve(null);
+    });
     req.on("timeout", () => {
       req.destroy();
       resolve(null);

--- a/apps/scan/src/lib/discovery/vercel-preview.test.ts
+++ b/apps/scan/src/lib/discovery/vercel-preview.test.ts
@@ -33,7 +33,7 @@ describe("isVercelPreviewDeployment", () => {
   });
 
   function stubFetch(impl: typeof fetch) {
-    const spy = vi.fn(impl);
+    const spy = vi.fn<typeof fetch>(impl);
     vi.stubGlobal("fetch", spy);
     return spy;
   }

--- a/apps/scan/src/services/cdp/lib/generate-jwt.ts
+++ b/apps/scan/src/services/cdp/lib/generate-jwt.ts
@@ -16,7 +16,7 @@ export const generateCdpJwt = async (
   const { requestMethod, requestHost, requestPath, expiresIn } =
     generateCdpJwtSchema.parse(input);
 
-  return await generateJwt({
+  return generateJwt({
     apiKeyId: env.CDP_API_KEY_ID,
     apiKeySecret: env.CDP_API_KEY_SECRET,
     requestMethod,

--- a/apps/scan/src/services/cdp/server-wallet/wallets/evm.ts
+++ b/apps/scan/src/services/cdp/server-wallet/wallets/evm.ts
@@ -18,7 +18,7 @@ export const evmServerWallet =
   <T extends EvmChain>(chain: T): NetworkServerWallet<EvmChain> =>
   (name: string) => {
     const getAccount = async () => {
-      return await cdpClient.evm.getOrCreateAccount({ name });
+      return cdpClient.evm.getOrCreateAccount({ name });
     };
 
     const getAddress = async () => (await getAccount()).address;

--- a/apps/scan/src/services/cdp/server-wallet/wallets/svm.ts
+++ b/apps/scan/src/services/cdp/server-wallet/wallets/svm.ts
@@ -57,9 +57,9 @@ export const svmServerWallet: NetworkServerWallet<Chain.SOLANA> = (
     getTokenBalance: ({ token }) =>
       cdpResultFromPromise(
         "getTokenBalance",
-        getAddress().then((address) =>
+        getAddress().then((walletAddress) =>
           getSolanaTokenBalance({
-            ownerAddress: address,
+            ownerAddress: walletAddress,
             tokenMint: token.address as SolanaAddress,
           })
         ),
@@ -72,9 +72,9 @@ export const svmServerWallet: NetworkServerWallet<Chain.SOLANA> = (
     export: () =>
       cdpResultFromPromise(
         "export",
-        getAddress().then((address) =>
+        getAddress().then((walletAddress) =>
           cdpClient.solana.exportAccount({
-            address,
+            address: walletAddress,
             name,
           })
         ),
@@ -84,7 +84,7 @@ export const svmServerWallet: NetworkServerWallet<Chain.SOLANA> = (
         })
       ),
     signer: async () => getModifyingSigner(await getAccount()),
-    sendTokens: ({ address, token, amount }) =>
+    sendTokens: ({ address: recipientAddress, token, amount }) =>
       cdpResultFromPromise(
         "sendTokens",
         (async () => {
@@ -103,14 +103,14 @@ export const svmServerWallet: NetworkServerWallet<Chain.SOLANA> = (
           // Find destination token account (recipient's ATA)
           const [destinationTokenAccount] = await findAssociatedTokenPda({
             mint,
-            owner: solanaAddress(address),
+            owner: solanaAddress(recipientAddress),
             tokenProgram: TOKEN_PROGRAM_ADDRESS,
           });
 
           const createAssociatedTokenInstruction =
             await getCreateAssociatedTokenIdempotentInstructionAsync({
               mint,
-              owner: solanaAddress(address),
+              owner: solanaAddress(recipientAddress),
               payer: signer,
             });
 

--- a/apps/scan/src/services/composer-balances/index.ts
+++ b/apps/scan/src/services/composer-balances/index.ts
@@ -195,7 +195,7 @@ export const getComposerBalancesReport =
           loginAddresses: owner?.loginAddresses ?? [],
         };
       })
-      .sort((a, b) => b.usdc - a.usdc);
+      .toSorted((a, b) => b.usdc - a.usdc);
 
     const systemWallets: SystemWalletRow[] = funded
       .filter((w) => w.source === "server" && !UUID_RE.test(w.walletName))
@@ -205,7 +205,7 @@ export const getComposerBalancesReport =
         chain: w.chain,
         usdc: w.usdc,
       }))
-      .sort((a, b) => b.usdc - a.usdc);
+      .toSorted((a, b) => b.usdc - a.usdc);
 
     const serverRows = rows.filter((r) => r.source === "server");
     const embeddedRows = rows.filter((r) => r.source === "embedded");

--- a/apps/scan/src/services/db/agent-config/mutate/index.ts
+++ b/apps/scan/src/services/db/agent-config/mutate/index.ts
@@ -11,7 +11,7 @@ export const createAgentConfiguration = async (
   input: z.infer<typeof agentConfigurationSchema>
 ) => {
   const { resourceIds, ...data } = input;
-  return await scanDb.agentConfiguration.create({
+  return scanDb.agentConfiguration.create({
     data: {
       ...data,
       owner: {
@@ -46,7 +46,7 @@ export const updateAgentConfiguration = async (
   updateData: z.infer<typeof updateAgentConfigurationSchema>
 ) => {
   const { id, resourceIds, ...data } = updateData;
-  return await scanDb.agentConfiguration.update({
+  return scanDb.agentConfiguration.update({
     where: { id, ownerId: userId },
     data: {
       ...data,
@@ -61,7 +61,7 @@ export const updateAgentConfiguration = async (
 };
 
 export const deleteAgentConfiguration = async (id: string, userId: string) => {
-  return await scanDb.agentConfiguration.delete({
+  return scanDb.agentConfiguration.delete({
     where: { id, ownerId: userId },
   });
 };

--- a/apps/scan/src/services/db/agent-config/user.ts
+++ b/apps/scan/src/services/db/agent-config/user.ts
@@ -1,7 +1,7 @@
 import { scanDb } from "@x402scan/scan-db";
 
 export const listUserAgentConfigurations = async (userId: string) => {
-  return await scanDb.agentConfigurationUser.findMany({
+  return scanDb.agentConfigurationUser.findMany({
     where: {
       userId,
     },

--- a/apps/scan/src/services/db/composer/chat.ts
+++ b/apps/scan/src/services/db/composer/chat.ts
@@ -5,7 +5,7 @@ import { scanDb } from "@x402scan/scan-db";
 import type { Prisma } from "@x402scan/scan-db";
 
 export const createChat = async (data: Prisma.ChatCreateInput) => {
-  return await scanDb.chat.create({
+  return scanDb.chat.create({
     data: data,
     include: {
       messages: true,
@@ -19,7 +19,7 @@ export const createChat = async (data: Prisma.ChatCreateInput) => {
 };
 
 export const getChat = async (id: string, userId?: string) => {
-  return await scanDb.chat.findFirst({
+  return scanDb.chat.findFirst({
     where: { id, OR: [{ userId }, { visibility: "public" }] },
     include: {
       messages: {
@@ -35,7 +35,7 @@ export const getChat = async (id: string, userId?: string) => {
 };
 
 export const getChatStreamId = async (id: string, userId?: string) => {
-  return await scanDb.chat.findFirst({
+  return scanDb.chat.findFirst({
     where: { id, OR: [{ userId }, { visibility: "public" }] },
     select: { activeStreamId: true },
   });
@@ -49,7 +49,7 @@ export const listChats = async (
   userId: string,
   { agentId }: z.infer<typeof listChatsSchema>
 ) => {
-  return await scanDb.chat.findMany({
+  return scanDb.chat.findMany({
     where: {
       userId,
       userAgentConfiguration: agentId
@@ -72,14 +72,14 @@ export const updateChat = async (
   chatId: string,
   updateChatData: Prisma.ChatUpdateInput
 ) => {
-  return await scanDb.chat.update({
+  return scanDb.chat.update({
     where: { id: chatId, userId },
     data: updateChatData,
   });
 };
 
 export const deleteChat = async (id: string, userId: string) => {
-  return await scanDb.chat.delete({
+  return scanDb.chat.delete({
     where: { id, userId },
   });
 };

--- a/apps/scan/src/services/db/composer/tool-call.ts
+++ b/apps/scan/src/services/db/composer/tool-call.ts
@@ -12,7 +12,7 @@ import {
 import { DEFAULT_TOOLS_SORTING, TOOL_SORT_IDS } from "@/lib/table-sort-options";
 
 export const createToolCall = async (data: Prisma.ToolCallCreateInput) => {
-  return await scanDb.toolCall.create({
+  return scanDb.toolCall.create({
     data,
   });
 };

--- a/apps/scan/src/services/db/invite-codes/redeem.ts
+++ b/apps/scan/src/services/db/invite-codes/redeem.ts
@@ -244,7 +244,7 @@ export const redeemInviteCode = async ({
   const walletAddressResult = await wallet.address();
 
   if (walletAddressResult.isErr()) {
-    return await handleRedemptionFailure({
+    return handleRedemptionFailure({
       redemptionId: redemption.id,
       inviteCodeId: inviteCode.id,
       error: walletAddressResult,
@@ -254,7 +254,7 @@ export const redeemInviteCode = async ({
   const walletBalanceResult = await wallet.getTokenBalance({ token });
 
   if (walletBalanceResult.isErr()) {
-    return await handleRedemptionFailure({
+    return handleRedemptionFailure({
       redemptionId: redemption.id,
       inviteCodeId: inviteCode.id,
       error: walletBalanceResult,
@@ -272,7 +272,7 @@ export const redeemInviteCode = async ({
   });
 
   if (sendTokensResult.isErr()) {
-    return await handleRedemptionFailure({
+    return handleRedemptionFailure({
       redemptionId: redemption.id,
       inviteCodeId: inviteCode.id,
       error: sendTokensResult,

--- a/apps/scan/src/services/db/resources/excludes.ts
+++ b/apps/scan/src/services/db/resources/excludes.ts
@@ -9,7 +9,7 @@ export const createExcludedResource = async (
   input: z.input<typeof createExcludedResourceSchema>
 ) => {
   const data = createExcludedResourceSchema.parse(input);
-  return await scanDb.excludedResource.create({
+  return scanDb.excludedResource.create({
     data,
     include: {
       resource: {
@@ -22,7 +22,7 @@ export const createExcludedResource = async (
 };
 
 export const getAllExcludedResources = async () => {
-  return await scanDb.excludedResource.findMany({
+  return scanDb.excludedResource.findMany({
     include: {
       resource: {
         include: {
@@ -46,13 +46,13 @@ export const getAllExcludedResources = async () => {
 export const deleteExcludedResourceByResourceId = async (
   resourceId: string
 ) => {
-  return await scanDb.excludedResource.delete({
+  return scanDb.excludedResource.delete({
     where: { resourceId },
   });
 };
 
 export const searchResourcesForExcludes = async (search?: string) => {
-  return await scanDb.resources.findMany({
+  return scanDb.resources.findMany({
     where: {
       ...(search
         ? {

--- a/apps/scan/src/services/db/resources/origin.ts
+++ b/apps/scan/src/services/db/resources/origin.ts
@@ -85,7 +85,7 @@ export const upsertOrigin = async (
   originInput: z.input<typeof originSchema>
 ) => {
   const origin = originSchema.parse(originInput);
-  return await scanDb.$transaction(async (tx) => {
+  return scanDb.$transaction(async (tx) => {
     const upsertedOrigin = await tx.resourceOrigin.upsert({
       where: { origin: origin.origin },
       update: {
@@ -281,7 +281,7 @@ export const searchOrigins = async (
 ) => {
   const { search, limit } = searchOriginsSchema.parse(input);
   const acceptsWhere = getDisplayableAcceptsWhere({});
-  return await scanDb.resourceOrigin.findMany({
+  return scanDb.resourceOrigin.findMany({
     where: {
       origin: {
         contains: search,
@@ -371,5 +371,5 @@ export const getOriginPayToAddresses = async (
     .filter((parsed) => parsed.success)
     .map((parsed) => parsed.data);
 
-  return [...new Set(addresses)].sort((a, b) => a.localeCompare(b));
+  return [...new Set(addresses)].toSorted((a, b) => a.localeCompare(b));
 };

--- a/apps/scan/src/services/db/resources/request-metadata.ts
+++ b/apps/scan/src/services/db/resources/request-metadata.ts
@@ -21,7 +21,7 @@ export const createResourceRequestMetadata = async (
   input: z.input<typeof createResourceRequestMetadataSchema>
 ) => {
   const data = createResourceRequestMetadataSchema.parse(input);
-  return await scanDb.resourceRequestMetadata.create({
+  return scanDb.resourceRequestMetadata.create({
     data,
     include: {
       resource: {
@@ -38,7 +38,7 @@ export const updateResourceRequestMetadata = async (
 ) => {
   const { id, ...updateData } =
     updateResourceRequestMetadataSchema.parse(input);
-  return await scanDb.resourceRequestMetadata.update({
+  return scanDb.resourceRequestMetadata.update({
     where: { id },
     data: updateData,
     include: {
@@ -52,7 +52,7 @@ export const updateResourceRequestMetadata = async (
 };
 
 export const getAllResourceRequestMetadata = async () => {
-  return await scanDb.resourceRequestMetadata.findMany({
+  return scanDb.resourceRequestMetadata.findMany({
     include: {
       resource: {
         include: {
@@ -69,13 +69,13 @@ export const getAllResourceRequestMetadata = async () => {
 };
 
 export const deleteResourceRequestMetadata = async (id: string) => {
-  return await scanDb.resourceRequestMetadata.delete({
+  return scanDb.resourceRequestMetadata.delete({
     where: { id },
   });
 };
 
 export const searchResourcesForMetadata = async (search?: string) => {
-  return await scanDb.resources.findMany({
+  return scanDb.resources.findMany({
     where: {
       ...(search
         ? {

--- a/apps/scan/src/services/db/resources/resource.ts
+++ b/apps/scan/src/services/db/resources/resource.ts
@@ -43,7 +43,7 @@ export const upsertResource = async (
   }
   const originStr = getOriginFromUrl(baseResource.resource);
 
-  return await scanDb.$transaction(async (tx) => {
+  return scanDb.$transaction(async (tx) => {
     await ensureOriginExists(tx, originStr);
 
     // Merge new metadata with existing to avoid clobbering fields set by a
@@ -161,7 +161,7 @@ export const upsertResource = async (
 };
 
 export const getResource = async (id: string) => {
-  return await scanDb.resources.findUnique({
+  return scanDb.resources.findUnique({
     where: {
       id,
     },
@@ -185,7 +185,7 @@ export const getResource = async (id: string) => {
 export const listResourcesUncached = async (
   where?: Prisma.ResourcesWhereInput
 ) => {
-  return await scanDb.resources.findMany({
+  return scanDb.resources.findMany({
     where: {
       ...where,
       // Exclude deprecated resources by default
@@ -305,7 +305,7 @@ const searchResourcesUncached = async (
   } = input;
   const acceptsFilter: Prisma.AcceptsWhereInput =
     chains !== undefined ? { network: { in: chains } } : {};
-  return await scanDb.resources.findMany({
+  return scanDb.resources.findMany({
     where: {
       // Include paid resources (with accepts) and free resources
       // (siwx/public/apiKey). When filtering by chain, free resources are
@@ -380,7 +380,7 @@ export const searchResources = createCachedArrayQuery({
 });
 
 export const listResourcesForTools = async (resourceIds: string[]) => {
-  return await scanDb.resources.findMany({
+  return scanDb.resources.findMany({
     where: {
       id: { in: resourceIds },
       excluded: { is: null },

--- a/apps/scan/src/services/db/resources/response.ts
+++ b/apps/scan/src/services/db/resources/response.ts
@@ -14,7 +14,7 @@ export const upsertResourceResponse = async (
   response: ParsedX402Response
 ) => {
   const responseJson = toPrismaJson(response);
-  return await scanDb.resourceResponse.upsert({
+  return scanDb.resourceResponse.upsert({
     where: {
       resourceId,
     },
@@ -30,7 +30,7 @@ export const upsertResourceResponse = async (
 };
 
 export const deleteResourceResponse = async (resourceId: string) => {
-  return await scanDb.resourceResponse.deleteMany({
+  return scanDb.resourceResponse.deleteMany({
     where: {
       resourceId,
     },

--- a/apps/scan/src/services/db/resources/tag.ts
+++ b/apps/scan/src/services/db/resources/tag.ts
@@ -8,7 +8,7 @@ export const createTagSchema = z.object({
 });
 
 export const createTag = async (data: z.infer<typeof createTagSchema>) => {
-  return await scanDb.tag.create({
+  return scanDb.tag.create({
     data,
   });
 };
@@ -18,7 +18,7 @@ export const listTagsSchema = z.object({
 });
 
 export const listTags = async (data: z.infer<typeof listTagsSchema>) => {
-  return await scanDb.tag.findMany({
+  return scanDb.tag.findMany({
     orderBy: {
       name: "asc",
     },
@@ -46,7 +46,7 @@ export const assignTagToResource = async (
   data: z.infer<typeof assignTagToResourceSchema>
 ) => {
   const { resourceId, tagId } = data;
-  return await scanDb.resourcesTags.upsert({
+  return scanDb.resourcesTags.upsert({
     where: {
       resourceId_tagId: {
         resourceId,
@@ -67,7 +67,7 @@ export const unassignTagFromResource = async (
   data: z.infer<typeof assignTagToResourceSchema>
 ) => {
   const { resourceId, tagId } = data;
-  return await scanDb.resourcesTags.delete({
+  return scanDb.resourcesTags.delete({
     where: {
       resourceId_tagId: {
         resourceId,
@@ -78,7 +78,7 @@ export const unassignTagFromResource = async (
 };
 
 export const listResourceTags = async (resourceId: string) => {
-  return await scanDb.resourcesTags.findMany({
+  return scanDb.resourcesTags.findMany({
     where: {
       resourceId,
     },
@@ -94,7 +94,7 @@ export const listResourceTags = async (resourceId: string) => {
 };
 
 export const unassignAllTagsFromResource = async (resourceId: string) => {
-  return await scanDb.resourcesTags.deleteMany({
+  return scanDb.resourcesTags.deleteMany({
     where: {
       resourceId,
     },
@@ -102,11 +102,11 @@ export const unassignAllTagsFromResource = async (resourceId: string) => {
 };
 
 export const unassignAllTagsFromAllResources = async () => {
-  return await scanDb.resourcesTags.deleteMany({});
+  return scanDb.resourcesTags.deleteMany({});
 };
 
 export const deleteResourceTag = async (tagId: string) => {
-  return await scanDb.tag.delete({
+  return scanDb.tag.delete({
     where: {
       id: tagId,
     },
@@ -130,7 +130,7 @@ export const removeSubTagsFromTag = async (tagId: string) => {
   const resourceIds = resourcesWithTag.map((rt) => rt.resourceId);
 
   // Delete all tag associations from these resources EXCEPT for the specified tag
-  return await scanDb.resourcesTags.deleteMany({
+  return scanDb.resourcesTags.deleteMany({
     where: {
       resourceId: {
         in: resourceIds,
@@ -146,7 +146,7 @@ export const unassignAllSubTags = async () => {
   const mainTagNames = Object.keys(MAIN_TAGS);
 
   // Delete all tags (and their assignments via cascade) that are NOT main categories
-  return await scanDb.tag.deleteMany({
+  return scanDb.tag.deleteMany({
     where: {
       name: {
         notIn: mainTagNames,

--- a/apps/scan/src/services/db/user/acknowledgements.ts
+++ b/apps/scan/src/services/db/user/acknowledgements.ts
@@ -11,7 +11,7 @@ export const hasUserAcknowledgedComposer = async (
 };
 
 export const upsertUserAcknowledgement = async (userId: string) => {
-  return await scanDb.userAcknowledgement.upsert({
+  return scanDb.userAcknowledgement.upsert({
     where: { userId },
     create: {
       userId,

--- a/apps/scan/src/services/resource-search/llm-refined-search.ts
+++ b/apps/scan/src/services/resource-search/llm-refined-search.ts
@@ -186,5 +186,5 @@ export async function applyLLMFilters(
   );
 
   // Sort by filter matches (highest first)
-  return evaluatedResults.sort((a, b) => b.filterMatches - a.filterMatches);
+  return evaluatedResults.toSorted((a, b) => b.filterMatches - a.filterMatches);
 }

--- a/apps/scan/src/services/resource-search/reranker-search.ts
+++ b/apps/scan/src/services/resource-search/reranker-search.ts
@@ -114,7 +114,7 @@ export async function rerankSearchResults(
   );
 
   // Sort by reranker score (highest first), then put unranked items at the end
-  return rerankedResults.sort((a, b) => {
+  return rerankedResults.toSorted((a, b) => {
     // Items with reranker scores come first
     if (a.rerankerScore !== null && b.rerankerScore === null) return -1;
     if (a.rerankerScore === null && b.rerankerScore !== null) return 1;

--- a/apps/scan/src/services/scraper/html.ts
+++ b/apps/scan/src/services/scraper/html.ts
@@ -8,7 +8,9 @@ const fetchWithTimeout = async (
   options: RequestInit = {}
 ): Promise<Response> => {
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  const timeoutId = setTimeout(() => {
+    controller.abort();
+  }, FETCH_TIMEOUT_MS);
 
   try {
     const response = await fetch(url, {

--- a/apps/scan/src/services/transfers/client.ts
+++ b/apps/scan/src/services/transfers/client.ts
@@ -12,9 +12,11 @@ const PRIMARY_TIMEOUT_MS = 15_000;
 function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   return Promise.race([
     promise,
-    new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error(`QUERY_TIMEOUT after ${ms}ms`)), ms)
-    ),
+    new Promise<never>((_, reject) => {
+      setTimeout(() => {
+        reject(new Error(`QUERY_TIMEOUT after ${ms}ms`));
+      }, ms);
+    }),
   ]);
 }
 

--- a/apps/scan/src/services/transfers/origins/stats/sparkline-values.ts
+++ b/apps/scan/src/services/transfers/origins/stats/sparkline-values.ts
@@ -33,7 +33,7 @@ export function buildOriginTransactionSparklines(
   );
   const buckets = [
     ...new Set(relevantRows.map((row) => row.bucket.getTime())),
-  ].sort((a, b) => a - b);
+  ].toSorted((a, b) => a - b);
   const indexByBucket = new Map(
     buckets.map((bucket, index) => [bucket, index])
   );

--- a/apps/scan/src/services/transfers/schemas.ts
+++ b/apps/scan/src/services/transfers/schemas.ts
@@ -10,7 +10,9 @@ import { timeframeSchema } from "@/lib/schemas";
 
 const addressArray = z
   .array(mixedAddressSchema)
-  .transform((addresses) => [...addresses].sort((a, b) => a.localeCompare(b)));
+  .transform((addresses) =>
+    [...addresses].toSorted((a, b) => a.localeCompare(b))
+  );
 
 const addressesSchema = z.object({
   include: addressArray.optional(),

--- a/apps/scan/src/trpc/routers/admin/composer-balances.ts
+++ b/apps/scan/src/trpc/routers/admin/composer-balances.ts
@@ -3,6 +3,6 @@ import { getComposerBalancesReport } from "@/services/composer-balances";
 
 export const adminComposerBalancesRouter = createTRPCRouter({
   report: adminProcedure.query(async () => {
-    return await getComposerBalancesReport();
+    return getComposerBalancesReport();
   }),
 });

--- a/apps/scan/src/trpc/routers/admin/end-users.ts
+++ b/apps/scan/src/trpc/routers/admin/end-users.ts
@@ -3,6 +3,6 @@ import { listAllEndUsers } from "@/services/cdp/end-users/list";
 
 export const adminEndUsersRouter = createTRPCRouter({
   list: adminProcedure.query(async () => {
-    return await listAllEndUsers();
+    return listAllEndUsers();
   }),
 });

--- a/apps/scan/src/trpc/routers/admin/resources.ts
+++ b/apps/scan/src/trpc/routers/admin/resources.ts
@@ -52,7 +52,7 @@ export const adminResourcesRouter = createTRPCRouter({
       })
     )
     .query(async ({ input }) => {
-      return await searchResourcesCombined(input.query, {
+      return searchResourcesCombined(input.query, {
         refinementMode: input.refinementMode,
         queryMode: input.queryMode,
       });
@@ -62,122 +62,122 @@ export const adminResourcesRouter = createTRPCRouter({
     create: adminProcedure
       .input(createTagSchema)
       .mutation(async ({ input }) => {
-        return await createTag(input);
+        return createTag(input);
       }),
 
     assign: adminProcedure
       .input(assignTagToResourceSchema)
       .mutation(async ({ input }) => {
-        return await assignTagToResource(input);
+        return assignTagToResource(input);
       }),
 
     unassign: adminProcedure
       .input(assignTagToResourceSchema)
       .mutation(async ({ input }) => {
-        return await unassignTagFromResource(input);
+        return unassignTagFromResource(input);
       }),
 
     unassignAll: adminProcedure
       .input(z.string().uuid())
       .mutation(async ({ input }) => {
-        return await unassignAllTagsFromResource(input);
+        return unassignAllTagsFromResource(input);
       }),
 
     unassignAllFromAll: adminProcedure.mutation(async () => {
-      return await unassignAllTagsFromAllResources();
+      return unassignAllTagsFromAllResources();
     }),
 
     delete: adminProcedure
       .input(z.string().uuid())
       .mutation(async ({ input }) => {
-        return await deleteResourceTag(input);
+        return deleteResourceTag(input);
       }),
 
     removeSubTags: adminProcedure
       .input(z.string().uuid())
       .mutation(async ({ input }) => {
-        return await removeSubTagsFromTag(input);
+        return removeSubTagsFromTag(input);
       }),
 
     unassignAllSubTags: adminProcedure.mutation(async () => {
-      return await unassignAllSubTags();
+      return unassignAllSubTags();
     }),
   },
   requestMetadata: {
     list: adminProcedure.query(async () => {
-      return await getAllResourceRequestMetadata();
+      return getAllResourceRequestMetadata();
     }),
 
     searchResources: adminProcedure
       .input(z.object({ search: z.string().optional() }))
       .query(async ({ input }) => {
-        return await searchResourcesForMetadata(input.search);
+        return searchResourcesForMetadata(input.search);
       }),
 
     create: adminProcedure
       .input(createResourceRequestMetadataSchema)
       .mutation(async ({ input }) => {
-        return await createResourceRequestMetadata(input);
+        return createResourceRequestMetadata(input);
       }),
 
     update: adminProcedure
       .input(updateResourceRequestMetadataSchema)
       .mutation(async ({ input }) => {
-        return await updateResourceRequestMetadata(input);
+        return updateResourceRequestMetadata(input);
       }),
 
     delete: adminProcedure
       .input(z.object({ id: z.uuid() }))
       .mutation(async ({ input }) => {
-        return await deleteResourceRequestMetadata(input.id);
+        return deleteResourceRequestMetadata(input.id);
       }),
   },
   excludes: {
     list: adminProcedure.query(async () => {
-      return await getAllExcludedResources();
+      return getAllExcludedResources();
     }),
 
     searchResources: adminProcedure
       .input(z.object({ search: z.string().optional() }))
       .query(async ({ input }) => {
-        return await searchResourcesForExcludes(input.search);
+        return searchResourcesForExcludes(input.search);
       }),
 
     create: adminProcedure
       .input(createExcludedResourceSchema)
       .mutation(async ({ input }) => {
-        return await createExcludedResource(input);
+        return createExcludedResource(input);
       }),
 
     deleteByResourceId: adminProcedure
       .input(z.object({ resourceId: z.uuid() }))
       .mutation(async ({ input }) => {
-        return await deleteExcludedResourceByResourceId(input.resourceId);
+        return deleteExcludedResourceByResourceId(input.resourceId);
       }),
   },
   stats: {
     creations: adminProcedure
       .input(resourceBucketedQuerySchema)
       .query(async ({ input }) => {
-        return await getBucketedResourceCreations(input);
+        return getBucketedResourceCreations(input);
       }),
 
     toolCalls: adminProcedure
       .input(resourceBucketedQuerySchema)
       .query(async ({ input }) => {
-        return await getBucketedToolCalls(input);
+        return getBucketedToolCalls(input);
       }),
 
     toolCallsByTags: adminProcedure
       .input(resourceBucketedQuerySchema)
       .query(async ({ input }) => {
-        return await getBucketedToolCallsByTags(input);
+        return getBucketedToolCallsByTags(input);
       }),
 
     toolCallsByResources: adminProcedure
       .input(resourceBucketedQuerySchema)
       .query(async ({ input }) => {
-        return await getBucketedToolCallsByResources(input);
+        return getBucketedToolCallsByResources(input);
       }),
   },
 });

--- a/apps/scan/src/trpc/routers/admin/spending.ts
+++ b/apps/scan/src/trpc/routers/admin/spending.ts
@@ -50,10 +50,7 @@ export const adminSpendingRouter = createTRPCRouter({
       })
     )
     .query(async ({ input }) => {
-      return await getSpendingByWallet(
-        { sorting: input.sorting },
-        input.pagination
-      );
+      return getSpendingByWallet({ sorting: input.sorting }, input.pagination);
     }),
 
   toolBreakdown: adminProcedure
@@ -74,7 +71,7 @@ export const adminSpendingRouter = createTRPCRouter({
       })
     )
     .query(async ({ input }) => {
-      return await getToolBreakdownByWallet(input.walletId, input.sorting);
+      return getToolBreakdownByWallet(input.walletId, input.sorting);
     }),
 
   byTool: adminProcedure
@@ -99,10 +96,7 @@ export const adminSpendingRouter = createTRPCRouter({
       })
     )
     .query(async ({ input }) => {
-      return await getSpendingByTool(
-        { sorting: input.sorting },
-        input.pagination
-      );
+      return getSpendingByTool({ sorting: input.sorting }, input.pagination);
     }),
 
   walletBreakdown: adminProcedure
@@ -124,19 +118,19 @@ export const adminSpendingRouter = createTRPCRouter({
       })
     )
     .query(async ({ input }) => {
-      return await getWalletBreakdownByTool(input.resourceId, input.sorting);
+      return getWalletBreakdownByTool(input.resourceId, input.sorting);
     }),
 
   getWalletAddress: adminProcedure
     .input(z.object({ walletName: z.string() }))
     .query(async ({ input }) => {
-      return await getWalletAddressFromName(input.walletName);
+      return getWalletAddressFromName(input.walletName);
     }),
 
   toolCallsOverTime: adminProcedure
     .input(toolCallsOverTimeQuerySchema)
     .query(async ({ input }) => {
-      return await getToolCallsOverTime(input);
+      return getToolCallsOverTime(input);
     }),
 
   getServerAccountsCsv: adminProcedure.query(async () => {

--- a/apps/scan/src/trpc/routers/networks.ts
+++ b/apps/scan/src/trpc/routers/networks.ts
@@ -12,12 +12,12 @@ export const networksRouter = createTRPCRouter({
   list: publicProcedure
     .input(listTopNetworksInputSchema)
     .query(async ({ input }) => {
-      return await listTopNetworks(input);
+      return listTopNetworks(input);
     }),
 
   bucketedStatistics: publicProcedure
     .input(bucketedNetworksStatisticsInputSchema)
     .query(async ({ input }) => {
-      return await getBucketedNetworksStatistics(input);
+      return getBucketedNetworksStatistics(input);
     }),
 });

--- a/apps/scan/src/trpc/routers/public/agent-configurations.ts
+++ b/apps/scan/src/trpc/routers/public/agent-configurations.ts
@@ -31,13 +31,13 @@ import { auth } from "@/auth";
 export const publicAgentConfigurationsRouter = createTRPCRouter({
   get: publicProcedure.input(z.uuid()).query(async ({ input }) => {
     const session = await auth();
-    return await getAgentConfiguration(input, session?.user?.id);
+    return getAgentConfiguration(input, session?.user?.id);
   }),
 
   list: paginatedProcedure
     .input(listTopAgentConfigurationsSchema)
     .query(async ({ input, ctx: { pagination } }) => {
-      return await listTopAgentConfigurations(input, pagination);
+      return listTopAgentConfigurations(input, pagination);
     }),
 
   activity: {
@@ -45,23 +45,23 @@ export const publicAgentConfigurationsRouter = createTRPCRouter({
       bucketed: publicProcedure
         .input(agentConfigBucketedActivityInputSchema)
         .query(async ({ input }) => {
-          return await getAgentConfigBucketedActivity(input);
+          return getAgentConfigBucketedActivity(input);
         }),
     },
     overall: publicProcedure
       .input(overallActivityInputSchema)
       .query(async ({ input }) => {
-        return await getOverallActivity(input);
+        return getOverallActivity(input);
       }),
     bucketed: publicProcedure
       .input(overallBucketedActivityInputSchema)
       .query(async ({ input }) => {
-        return await getOverallBucketedActivity(input);
+        return getOverallBucketedActivity(input);
       }),
     feed: paginatedProcedure
       .input(getAgentConfigFeedSchema)
       .query(async ({ input, ctx: { pagination } }) => {
-        return await getAgentConfigFeed(input, pagination);
+        return getAgentConfigFeed(input, pagination);
       }),
   },
 });

--- a/apps/scan/src/trpc/routers/public/chats.ts
+++ b/apps/scan/src/trpc/routers/public/chats.ts
@@ -9,6 +9,6 @@ import { createTRPCRouter, publicProcedure } from "@/trpc/trpc";
 export const publicChatsRouter = createTRPCRouter({
   get: publicProcedure.input(z.string()).query(async ({ input }) => {
     const session = await auth();
-    return await getChat(input, session?.user?.id);
+    return getChat(input, session?.user?.id);
   }),
 });

--- a/apps/scan/src/trpc/routers/public/facilitators.ts
+++ b/apps/scan/src/trpc/routers/public/facilitators.ts
@@ -16,12 +16,12 @@ export const facilitatorsRouter = createTRPCRouter({
   list: paginatedProcedure
     .input(listTopFacilitatorsInputSchema)
     .query(async ({ input, ctx: { pagination } }) => {
-      return await listTopFacilitators(input, pagination);
+      return listTopFacilitators(input, pagination);
     }),
 
   bucketedStatistics: publicProcedure
     .input(bucketedStatisticsInputSchema)
     .query(async ({ input }) => {
-      return await getBucketedFacilitatorsStatistics(input);
+      return getBucketedFacilitatorsStatistics(input);
     }),
 });

--- a/apps/scan/src/trpc/routers/public/origins.ts
+++ b/apps/scan/src/trpc/routers/public/origins.ts
@@ -34,25 +34,25 @@ function checkRateLimit(originId: string): void {
 
 export const originsRouter = createTRPCRouter({
   get: publicProcedure.input(z.uuid()).query(async ({ input }) => {
-    return await getOrigin(input);
+    return getOrigin(input);
   }),
   list: {
     origins: publicProcedure
       .input(listOriginsSchema)
       .query(async ({ input }) => {
-        return await listOrigins(input);
+        return listOrigins(input);
       }),
 
     withResources: publicProcedure
       .input(listOriginsWithResourcesSchema)
       .query(async ({ input }) => {
-        return await listOriginsWithResources(input);
+        return listOriginsWithResources(input);
       }),
   },
   search: publicProcedure
     .input(searchOriginsSchema)
     .query(async ({ input }) => {
-      return await searchOrigins(input);
+      return searchOrigins(input);
     }),
   updateEmail: publicProcedure
     .input(z.object({ originId: z.string().uuid(), email: z.string().email() }))

--- a/apps/scan/src/trpc/routers/public/resources.ts
+++ b/apps/scan/src/trpc/routers/public/resources.ts
@@ -61,7 +61,7 @@ export const resourcesRouter = createTRPCRouter({
   }),
   list: {
     all: publicProcedure.query(async () => {
-      return await listResources({});
+      return listResources({});
     }),
     paginated: paginatedProcedure
       .input(
@@ -80,7 +80,7 @@ export const resourcesRouter = createTRPCRouter({
         })
       )
       .query(async ({ input, ctx: { pagination } }) => {
-        return await listResourcesWithPagination(
+        return listResourcesWithPagination(
           {
             where: input.where,
             sorting: input.sorting,
@@ -91,7 +91,7 @@ export const resourcesRouter = createTRPCRouter({
       }),
   },
   getById: publicProcedure.input(z.string()).query(async ({ input }) => {
-    return await scanDb.resources.findUnique({
+    return scanDb.resources.findUnique({
       where: { id: input },
       include: {
         accepts: true,
@@ -108,7 +108,7 @@ export const resourcesRouter = createTRPCRouter({
   search: publicProcedure
     .input(searchResourcesSchema)
     .query(async ({ input }) => {
-      return await searchResources(input);
+      return searchResources(input);
     }),
 
   register: publicProcedure
@@ -274,7 +274,7 @@ export const resourcesRouter = createTRPCRouter({
     .query(async ({ input }) => {
       // Return origin-level verification if originId provided
       if (input.originId) {
-        return await getOriginVerificationStatus(input.originId);
+        return getOriginVerificationStatus(input.originId);
       }
 
       // Return resource-level verification if resourceIds provided
@@ -298,11 +298,11 @@ export const resourcesRouter = createTRPCRouter({
     list: publicProcedure
       .input(listTagsSchema.optional())
       .query(async ({ input }) => {
-        return await listTags(input ?? { filterTags: [] });
+        return listTags(input ?? { filterTags: [] });
       }),
 
     getByResource: publicProcedure.input(z.uuid()).query(async ({ input }) => {
-      return await listResourceTags(input);
+      return listResourceTags(input);
     }),
   },
 });

--- a/apps/scan/src/trpc/routers/public/solana.ts
+++ b/apps/scan/src/trpc/routers/public/solana.ts
@@ -9,6 +9,6 @@ export const solanaRouter = createTRPCRouter({
   balance: publicProcedure
     .input(getSolanaTokenBalanceSchema)
     .query(async ({ input }) => {
-      return await getSolanaTokenBalance(input);
+      return getSolanaTokenBalance(input);
     }),
 });

--- a/apps/scan/src/trpc/routers/public/stats.ts
+++ b/apps/scan/src/trpc/routers/public/stats.ts
@@ -26,19 +26,19 @@ export const statsRouter = createTRPCRouter({
   overall: publicProcedure
     .input(overallStatisticsMVInputSchema)
     .query(async ({ input, ctx }) => {
-      return await getOverallStatisticsMV(input, ctx);
+      return getOverallStatisticsMV(input, ctx);
     }),
   bucketed: publicProcedure
     .input(bucketedStatisticsMVInputSchema)
     .query(async ({ input, ctx }) => {
-      return await getBucketedStatisticsMV(input, ctx);
+      return getBucketedStatisticsMV(input, ctx);
     }),
   overallByOrigin: publicProcedure
     .input(overallByOriginInputSchema)
     .query(async ({ input, ctx }) => {
       const { originId, ...rest } = input;
       const addresses = await getOriginPayToAddresses(originId);
-      return await getOverallStatisticsMV(
+      return getOverallStatisticsMV(
         { ...rest, recipients: { include: addresses } },
         ctx
       );
@@ -48,7 +48,7 @@ export const statsRouter = createTRPCRouter({
     .query(async ({ input, ctx }) => {
       const { originId, ...rest } = input;
       const addresses = await getOriginPayToAddresses(originId);
-      return await getBucketedStatisticsMV(
+      return getBucketedStatisticsMV(
         { ...rest, recipients: { include: addresses } },
         ctx
       );

--- a/apps/scan/src/trpc/routers/public/tools.ts
+++ b/apps/scan/src/trpc/routers/public/tools.ts
@@ -15,12 +15,12 @@ export const publicToolsRouter = createTRPCRouter({
   search: publicProcedure
     .input(searchResourcesSchema)
     .query(async ({ input }) => {
-      return await searchX402Tools(input);
+      return searchX402Tools(input);
     }),
 
   top: paginatedProcedure
     .input(listTopToolsSchema)
     .query(async ({ input, ctx: { pagination } }) => {
-      return await listTopTools(input, pagination);
+      return listTopTools(input, pagination);
     }),
 });

--- a/apps/scan/src/trpc/routers/public/transfers.ts
+++ b/apps/scan/src/trpc/routers/public/transfers.ts
@@ -8,6 +8,6 @@ export const transfersRouter = createTRPCRouter({
   list: paginatedProcedure
     .input(listFacilitatorTransfersInputSchema)
     .query(async ({ input, ctx: { pagination } }) => {
-      return await listFacilitatorTransfers(input, pagination);
+      return listFacilitatorTransfers(input, pagination);
     }),
 });

--- a/apps/scan/src/trpc/routers/user/acknowledgements.ts
+++ b/apps/scan/src/trpc/routers/user/acknowledgements.ts
@@ -6,10 +6,10 @@ import {
 
 export const userAcknowledgementsRouter = createTRPCRouter({
   hasAcknowledged: protectedProcedure.query(async ({ ctx }) => {
-    return await hasUserAcknowledgedComposer(ctx.session.user.id);
+    return hasUserAcknowledgedComposer(ctx.session.user.id);
   }),
 
   upsert: protectedProcedure.mutation(async ({ ctx }) => {
-    return await upsertUserAcknowledgement(ctx.session.user.id);
+    return upsertUserAcknowledgement(ctx.session.user.id);
   }),
 });

--- a/apps/scan/src/trpc/routers/user/agent-configurations.ts
+++ b/apps/scan/src/trpc/routers/user/agent-configurations.ts
@@ -13,24 +13,24 @@ import {
 
 export const userAgentConfigurationsRouter = createTRPCRouter({
   list: protectedProcedure.query(async ({ ctx }) => {
-    return await listUserAgentConfigurations(ctx.session.user.id);
+    return listUserAgentConfigurations(ctx.session.user.id);
   }),
 
   create: protectedProcedure
     .input(createAgentConfigurationSchema)
     .mutation(async ({ input, ctx }) => {
-      return await createAgentConfiguration(ctx.session.user.id, input);
+      return createAgentConfiguration(ctx.session.user.id, input);
     }),
 
   update: protectedProcedure
     .input(updateAgentConfigurationSchema)
     .mutation(async ({ input, ctx }) => {
-      return await updateAgentConfiguration(ctx.session.user.id, input);
+      return updateAgentConfiguration(ctx.session.user.id, input);
     }),
 
   delete: protectedProcedure
     .input(z.uuid())
     .mutation(async ({ input, ctx }) => {
-      return await deleteAgentConfiguration(input, ctx.session.user.id);
+      return deleteAgentConfiguration(input, ctx.session.user.id);
     }),
 });

--- a/apps/scan/src/trpc/routers/user/chats.ts
+++ b/apps/scan/src/trpc/routers/user/chats.ts
@@ -12,12 +12,12 @@ export const userChatsRouter = createTRPCRouter({
   list: protectedProcedure
     .input(listChatsSchema)
     .query(async ({ input, ctx }) => {
-      return await listChats(ctx.session.user.id, input);
+      return listChats(ctx.session.user.id, input);
     }),
 
   delete: protectedProcedure
     .input(z.object({ chatId: z.string() }))
     .mutation(async ({ input, ctx }) => {
-      return await deleteChat(input.chatId, ctx.session.user.id);
+      return deleteChat(input.chatId, ctx.session.user.id);
     }),
 });

--- a/apps/scan/src/trpc/routers/user/onramp-sessions.ts
+++ b/apps/scan/src/trpc/routers/user/onramp-sessions.ts
@@ -51,7 +51,7 @@ export const onrampSessionsRouter = createTRPCRouter({
       return onrampSession;
     }
 
-    return await updateOnrampSession(onrampSession.id, {
+    return updateOnrampSession(onrampSession.id, {
       status: transaction.status,
       txHash: transaction.tx_hash,
       failureReason:
@@ -66,8 +66,8 @@ export const onrampSessionsRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const { defaultNetwork } = input;
       const account = ctx.session.user.accounts.find(
-        (account) =>
-          account.provider ===
+        (candidateAccount) =>
+          candidateAccount.provider ===
           (defaultNetwork === Chain.SOLANA
             ? SIWS_PROVIDER_ID
             : SIWE_PROVIDER_ID)

--- a/apps/scan/src/trpc/routers/user/tools.ts
+++ b/apps/scan/src/trpc/routers/user/tools.ts
@@ -10,7 +10,7 @@ export const userToolsRouter = createTRPCRouter({
     getTask: protectedProcedure
       .input(fetchFreepikMysticTaskInputSchema)
       .query(async ({ input }) => {
-        return await fetchFreepikMysticTask(input);
+        return fetchFreepikMysticTask(input);
       }),
   },
 
@@ -19,7 +19,7 @@ export const userToolsRouter = createTRPCRouter({
       getVideo: protectedProcedure
         .input(getSoraVideoInputSchema)
         .query(async ({ input }) => {
-          return await getSoraVideo(input);
+          return getSoraVideo(input);
         }),
     },
   },

--- a/packages/external/facilitators/src/discovery/list-resources.ts
+++ b/packages/external/facilitators/src/discovery/list-resources.ts
@@ -13,7 +13,7 @@ export const listFacilitatorResources = async (
   facilitator: FacilitatorConfig,
   config?: ListDiscoveryResourcesRequest
 ) => {
-  return await facilitatorUtils(facilitator).list(config);
+  return facilitatorUtils(facilitator).list(config);
 };
 
 export const listAllFacilitatorResources = async (

--- a/sync/transfers/db/services.ts
+++ b/sync/transfers/db/services.ts
@@ -8,7 +8,7 @@ import type { Prisma } from "@x402scan/transfers-db";
 export async function createTransferEvent(
   data: Prisma.TransferEventCreateInput
 ) {
-  return await transfersDb.transferEvent.create({
+  return transfersDb.transferEvent.create({
     data,
   });
 }
@@ -19,7 +19,7 @@ export async function createTransferEvent(
 export async function createManyTransferEvents(
   data: Prisma.TransferEventCreateManyInput[]
 ) {
-  return await transfersDb.transferEvent.createMany({
+  return transfersDb.transferEvent.createMany({
     data,
     skipDuplicates: true,
   });
@@ -60,7 +60,7 @@ export async function updateManyTransferEvents(
   where: Prisma.TransferEventWhereInput,
   data: Prisma.TransferEventUpdateManyMutationInput
 ) {
-  return await transfersDb.transferEvent.updateMany({
+  return transfersDb.transferEvent.updateMany({
     where,
     data,
   });
@@ -70,7 +70,7 @@ export async function updateManyTransferEvents(
  * Find a single TransferEvent by transaction hash
  */
 export async function getTransferEventByTxHash(tx_hash: string) {
-  return await transfersDb.transferEvent.findFirst({
+  return transfersDb.transferEvent.findFirst({
     where: { tx_hash },
   });
 }
@@ -86,7 +86,7 @@ export async function getTransferEvents(params?: {
 }) {
   const { where, orderBy, skip, take } = params ?? {};
 
-  return await transfersDb.transferEvent.findMany({
+  return transfersDb.transferEvent.findMany({
     where,
     orderBy,
     skip,
@@ -105,7 +105,7 @@ export async function getTransferEventsByChain(
     take?: number;
   }
 ) {
-  return await transfersDb.transferEvent.findMany({
+  return transfersDb.transferEvent.findMany({
     where: { chain },
     orderBy: params?.orderBy,
     skip: params?.skip,
@@ -124,7 +124,7 @@ export async function getTransferEventsByAddress(
     take?: number;
   }
 ) {
-  return await transfersDb.transferEvent.findMany({
+  return transfersDb.transferEvent.findMany({
     where: { address },
     orderBy: params?.orderBy,
     skip: params?.skip,
@@ -143,7 +143,7 @@ export async function getTransferEventsBySender(
     take?: number;
   }
 ) {
-  return await transfersDb.transferEvent.findMany({
+  return transfersDb.transferEvent.findMany({
     where: { sender },
     orderBy: params?.orderBy,
     skip: params?.skip,
@@ -162,7 +162,7 @@ export async function getTransferEventsByRecipient(
     take?: number;
   }
 ) {
-  return await transfersDb.transferEvent.findMany({
+  return transfersDb.transferEvent.findMany({
     where: { recipient },
     orderBy: params?.orderBy,
     skip: params?.skip,
@@ -176,7 +176,7 @@ export async function getTransferEventsByRecipient(
 export async function countTransferEvents(
   where?: Prisma.TransferEventWhereInput
 ) {
-  return await transfersDb.transferEvent.count({ where });
+  return transfersDb.transferEvent.count({ where });
 }
 
 /**
@@ -185,7 +185,7 @@ export async function countTransferEvents(
 export async function deleteManyTransferEvents(
   where: Prisma.TransferEventWhereInput
 ) {
-  return await transfersDb.transferEvent.deleteMany({
+  return transfersDb.transferEvent.deleteMany({
     where,
   });
 }
@@ -205,7 +205,7 @@ function syncStateWhere(key: TransferSyncStateKey) {
 }
 
 export async function getTransferSyncState(key: TransferSyncStateKey) {
-  return await transfersDb.transferSyncState.findUnique({
+  return transfersDb.transferSyncState.findUnique({
     where: syncStateWhere(key),
   });
 }
@@ -214,7 +214,7 @@ export async function createTransferSyncState(
   key: TransferSyncStateKey,
   cursorTimestamp: Date
 ) {
-  return await transfersDb.transferSyncState.upsert({
+  return transfersDb.transferSyncState.upsert({
     where: syncStateWhere(key),
     create: {
       ...key,
@@ -228,7 +228,7 @@ export async function markTransferSyncStateStarted(
   key: TransferSyncStateKey,
   startedAt: Date
 ) {
-  return await transfersDb.transferSyncState.update({
+  return transfersDb.transferSyncState.update({
     where: syncStateWhere(key),
     data: {
       last_started_at: startedAt,
@@ -242,7 +242,7 @@ export async function advanceTransferSyncState(
   cursorTimestamp: Date,
   completedAt: Date
 ) {
-  return await transfersDb.transferSyncState.update({
+  return transfersDb.transferSyncState.update({
     where: syncStateWhere(key),
     data: {
       cursor_timestamp: cursorTimestamp,
@@ -256,7 +256,7 @@ export async function recordTransferSyncStateError(
   key: TransferSyncStateKey,
   error: string
 ) {
-  return await transfersDb.transferSyncState.update({
+  return transfersDb.transferSyncState.update({
     where: syncStateWhere(key),
     data: {
       last_error: error,

--- a/sync/transfers/trigger/fetch/bigquery/fetch.ts
+++ b/sync/transfers/trigger/fetch/bigquery/fetch.ts
@@ -31,10 +31,5 @@ export async function fetchBigQuery(
 
   logger.log(`[${config.chain}] BigQuery returned ${rows.length} rows`);
 
-  return await config.transformResponse(
-    rows,
-    config,
-    facilitator,
-    facilitatorConfig
-  );
+  return config.transformResponse(rows, config, facilitator, facilitatorConfig);
 }

--- a/sync/transfers/trigger/fetch/cdp/helpers.ts
+++ b/sync/transfers/trigger/fetch/cdp/helpers.ts
@@ -18,7 +18,7 @@ async function generateCdpJwt(request: CdpFetchRequest): Promise<string> {
     expiresIn = 120,
   } = request;
 
-  return await generateJwt({
+  return generateJwt({
     apiKeyId: process.env.CDP_API_KEY_ID!,
     apiKeySecret: process.env.CDP_API_KEY_SECRET!,
     requestMethod,


### PR DESCRIPTION
## Summary

- remove redundant return-await expressions and unnecessary type assertions
- adopt generated Next.js route props and typed fetch mocks where they fit exactly
- resolve mechanical shadowing, callback, and non-mutating sort findings
- modernize deprecated Tailwind utility spellings without changing visual intent
- leave all Merit brand findings and judgment-heavy lint categories unchanged

## Lint impact

- warnings: 1,107 -> 886 (-221)
- errors: 0 -> 0
- Merit brand findings: 211 -> 211

## Validation

- pnpm check
- pnpm build
- pnpm --filter @x402scan/app ui:check
- pnpm --filter @x402scan/app ui:integrity
