### PR TITLE
Stream server overview independently of analytics

### DIFF
--- a/apps/scan/src/app/(app)/server/[id]/(overview)/_tests/page.test.ts
+++ b/apps/scan/src/app/(app)/server/[id]/(overview)/_tests/page.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getOrigin, overall, bucketed } = vi.hoisted(() => ({
+  getOrigin: vi.fn<() => Promise<unknown>>(),
+  overall: vi.fn<() => Promise<undefined>>(),
+  bucketed: vi.fn<() => Promise<undefined>>(),
+}));
+
+vi.mock("../../_lib/get-origin", () => ({ getServerOrigin: getOrigin }));
+vi.mock("@/trpc/server", () => ({
+  api: {
+    public: {
+      stats: {
+        overallByOrigin: { prefetch: overall },
+        bucketedByOrigin: { prefetch: bucketed },
+      },
+    },
+  },
+  HydrateClient: vi.fn<() => null>(),
+}));
+vi.mock("../_components/overview", () => ({
+  ServerOverview: vi.fn<() => null>(),
+}));
+vi.mock("../_components/resources", () => ({
+  OriginResources: vi.fn<() => null>(),
+  LoadingOriginResources: vi.fn<() => null>(),
+}));
+vi.mock("../_components/stat-cards", () => ({
+  ServerStatCards: vi.fn<() => null>(),
+  LoadingServerStatCards: vi.fn<() => null>(),
+}));
+vi.mock("../_components/usage-error-boundary", () => ({
+  UsageErrorBoundary: vi.fn<() => null>(),
+}));
+
+import OriginPage from "../page";
+
+const id = "b8a06bde-b6e8-4a10-b4e0-cc6a25fb9efb";
+const props = () => ({
+  params: Promise.resolve({ id }),
+  searchParams: Promise.resolve({}),
+});
+
+describe("server overview loading", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns the overview while both analytics requests are still pending", async () => {
+    getOrigin.mockResolvedValue({ id, origin: "https://example.com" });
+    overall.mockReturnValue(Promise.withResolvers<undefined>().promise);
+    bucketed.mockReturnValue(Promise.withResolvers<undefined>().promise);
+
+    const page = await OriginPage(props());
+
+    expect(page).toBeDefined();
+    expect(overall).toHaveBeenCalledWith({ originId: id, timeframe: 30 });
+    expect(bucketed).toHaveBeenCalledWith({
+      originId: id,
+      timeframe: 30,
+      numBuckets: 48,
+    });
+  });
+
+  it("returns not found without starting analytics for an unknown origin", async () => {
+    getOrigin.mockResolvedValue(null);
+
+    await expect(OriginPage(props())).rejects.toThrow(
+      "NEXT_HTTP_ERROR_FALLBACK;404"
+    );
+    expect(overall).not.toHaveBeenCalled();
+    expect(bucketed).not.toHaveBeenCalled();
+  });
+});

--- a/apps/scan/src/app/(app)/server/[id]/(overview)/page.tsx
+++ b/apps/scan/src/app/(app)/server/[id]/(overview)/page.tsx
@@ -5,6 +5,7 @@ import { notFound } from "next/navigation";
 import { api, HydrateClient } from "@/trpc/server";
 import { ActivityTimeframe } from "@/types/timeframes";
 
+import { getServerOrigin } from "../_lib/get-origin";
 import { ServerOverview } from "./_components/overview";
 import {
   LoadingOriginResources,
@@ -20,23 +21,21 @@ export default async function OriginPage({
   params,
 }: PageProps<"/server/[id]">) {
   const { id } = await params;
-  const origin = await api.public.origins.get(id);
+  const origin = await getServerOrigin(id);
 
   if (!origin) {
     notFound();
   }
 
-  await Promise.all([
-    api.public.stats.overallByOrigin.prefetch({
-      originId: id,
-      timeframe: ActivityTimeframe.ThirtyDays,
-    }),
-    api.public.stats.bucketedByOrigin.prefetch({
-      originId: id,
-      numBuckets: 48,
-      timeframe: ActivityTimeframe.ThirtyDays,
-    }),
-  ]);
+  void api.public.stats.overallByOrigin.prefetch({
+    originId: id,
+    timeframe: ActivityTimeframe.ThirtyDays,
+  });
+  void api.public.stats.bucketedByOrigin.prefetch({
+    originId: id,
+    numBuckets: 48,
+    timeframe: ActivityTimeframe.ThirtyDays,
+  });
 
   return (
     <HydrateClient>

--- a/apps/scan/src/app/(app)/server/[id]/_lib/get-origin.ts
+++ b/apps/scan/src/app/(app)/server/[id]/_lib/get-origin.ts
@@ -1,0 +1,9 @@
+import "server-only";
+import { cache } from "react";
+
+import { api } from "@/trpc/server";
+
+// Share the validated lookup between metadata and the page within one render.
+export const getServerOrigin = cache((id: string) =>
+  api.public.origins.get(id)
+);

--- a/apps/scan/src/app/(app)/server/[id]/layout.tsx
+++ b/apps/scan/src/app/(app)/server/[id]/layout.tsx
@@ -1,21 +1,12 @@
-import { notFound } from "next/navigation";
-
 import { cleanExternalText } from "@/lib/utils";
-import { api } from "@/trpc/server";
+
+import { getServerOrigin } from "./_lib/get-origin";
 
 import type { Metadata } from "next";
 
-export default async function OriginLayout({
-  params,
+export default function OriginLayout({
   children,
 }: LayoutProps<"/server/[id]">) {
-  const { id } = await params;
-  const origin = await api.public.origins.get(id);
-
-  if (!origin) {
-    notFound();
-  }
-
   return children;
 }
 
@@ -23,7 +14,7 @@ export async function generateMetadata({
   params,
 }: LayoutProps<"/server/[id]">): Promise<Metadata> {
   const { id } = await params;
-  const origin = await api.public.origins.get(id);
+  const origin = await getServerOrigin(id);
 
   if (!origin) {
     return { title: "Server not found" };

--- a/apps/scan/vitest.config.ts
+++ b/apps/scan/vitest.config.ts
@@ -2,6 +2,7 @@ import { resolve } from "path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  esbuild: { jsx: "automatic" },
   test: {
     environment: "node",
   },


### PR DESCRIPTION
A server detail page currently waits for both analytics queries before returning its overview, and its parent layout repeats the origin lookup above the loading boundary. Make the parent layout synchronous, share the validated origin lookup between metadata and page using React request memoization, and start analytics prefetches without awaiting them. Existing pending-query hydration and section boundaries handle the chart stream.

Validation: Production build passed. Both regression tests pass: pending analytics do not block the overview, and missing origins return 404 without analytics. StableEnrich detail loads its overview, usage and resources without browser errors. Independent production-code review passed. App TypeScript, 245 tests, UI compliance, source integrity, and repository boundaries pass. Full `pnpm check` now passes with zero lint warnings or errors, including source integrity and repository boundaries.

Stack base: #1174.
