### PR TITLE
Keep public network filters and loading state in sync

### DIFF
--- a/apps/scan/src/app/(app)/(home)/(discover)/_components/stats/index.tsx
+++ b/apps/scan/src/app/(app)/(home)/(discover)/_components/stats/index.tsx
@@ -32,6 +32,7 @@ export function OverallStatsContent({
 
   return (
     <ErrorBoundary
+      key={`${chain ?? "all"}:${timeframe}`}
       fallback={<p>There was an error loading the activity data</p>}
     >
       <Suspense fallback={<LoadingOverallStatsContent />}>

--- a/apps/scan/src/app/(app)/(home)/(discover)/_components/stats/index.tsx
+++ b/apps/scan/src/app/(app)/(home)/(discover)/_components/stats/index.tsx
@@ -32,7 +32,7 @@ export function OverallStatsContent({
 
   return (
     <ErrorBoundary
-      key={`${chain ?? "all"}:${timeframe}`}
+      key={`${chain ?? "all"}:${String(timeframe)}`}
       fallback={<p>There was an error loading the activity data</p>}
     >
       <Suspense fallback={<LoadingOverallStatsContent />}>

--- a/apps/scan/src/app/(app)/_components/layout/navbar/chain-selector.tsx
+++ b/apps/scan/src/app/(app)/_components/layout/navbar/chain-selector.tsx
@@ -30,17 +30,21 @@ export const ChainSelector = () => {
   const pathname = usePathname();
   const replaceSearchParams = useReplaceSearchParams();
 
+  const supportsChainFilter =
+    URL_BACKED_CHAIN_ROUTES.has(pathname) ||
+    /^\/facilitator\/[^/]+$/.test(pathname);
+
+  if (!supportsChainFilter) return null;
+
   const handleSelectChain = (selectedChain: Chain | undefined) => {
-    if (URL_BACKED_CHAIN_ROUTES.has(pathname)) {
-      replaceSearchParams((params) => {
-        if (selectedChain) {
-          params.set("chain", selectedChain);
-        } else {
-          params.delete("chain");
-        }
-        params.delete("p");
-      });
-    }
+    replaceSearchParams((params) => {
+      if (selectedChain) {
+        params.set("chain", selectedChain);
+      } else {
+        params.delete("chain");
+      }
+      params.delete("p");
+    });
   };
 
   return (


### PR DESCRIPTION
Selecting a network on facilitator detail currently updates the cookie without rerunning its server-rendered charts and table. Include facilitator detail in URL-backed filtering, preserving other query parameters and clearing pagination. Hide the selector on routes whose data does not use a chain filter. Key the home stats subtree by chain and timeframe so loading and prior errors reset with the selected data.

Validation: Production build passed. Browser verified that switching Coinbase to Solana updates the URL, shows loading and replaces the metrics. Chain state is now URL-only through the updated base PR. Independent review passed. CI caught a numeric template-key lint issue; it is fixed with explicit String conversion. App TypeScript, 245 tests, UI compliance, source integrity, and repository boundaries pass. Full `pnpm check` now passes with zero lint warnings or errors, including source integrity and repository boundaries.

Stack base: #1175.
