### PR TITLE
Use Brand fonts and restore browser zoom

### DIFF
--- a/apps/scan/src/app/layout.tsx
+++ b/apps/scan/src/app/layout.tsx
@@ -2,7 +2,6 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { ThemeProvider } from "next-themes";
-import { Geist, Geist_Mono } from "next/font/google";
 import { connection } from "next/server";
 
 import { JsonLd } from "@/components/json-ld";
@@ -17,16 +16,6 @@ import type { Metadata, Viewport } from "next";
 
 // oxfmt-ignore
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 const siteDescription =
   "Explore the x402 ecosystem. View transactions, sellers, origins and resources. Explore the future of agentic commerce.";
@@ -74,9 +63,6 @@ export const viewport: Viewport = {
   width: "device-width",
   height: "device-height",
   initialScale: 1,
-  minimumScale: 1,
-  maximumScale: 1,
-  userScalable: false,
   themeColor: [
     { media: "(prefers-color-scheme: dark)", color: "#090909" },
     { media: "(prefers-color-scheme: light)", color: "white" },
@@ -113,9 +99,7 @@ export default async function RootLayout({ children }: LayoutProps<"/">) {
 
   return (
     <html lang="en" suppressHydrationWarning>
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className="antialiased">
         <JsonLd data={jsonLd} />
         <Toaster />
         <SpeedInsights />


### PR DESCRIPTION
The root layout downloads Geist fonts whose variables have no consumers, while Brand owns the app typography. Remove the unused font registrations and rely on the existing Brand font faces. Remove the viewport restrictions that prevent browser zoom.

Validation: Production build passed. Registration verified at 390px in light/dark mode with no browser errors. Raw viewport metadata contains only width, height and initial-scale, allowing zoom. Independent review confirmed no consumers of removed Geist variables. App TypeScript, 245 tests, UI compliance, source integrity, and repository boundaries pass. Full `pnpm check` now passes with zero lint warnings or errors, including source integrity and repository boundaries.

Stack base: #1177.
