### PR TITLE
fix(x402/v1): accept valid CAIP-2 chains missing from ChainIdToNetwork

### DIFF
--- a/apps/scan/src/lib/x402/v1/schema.test.ts
+++ b/apps/scan/src/lib/x402/v1/schema.test.ts
@@ -401,4 +401,35 @@ describe('schema validation edge cases', () => {
       expect(parseResult.errors.length).toBeGreaterThan(0);
     }
   });
+
+  it('should accept a well-formed eip155 network id with no known chain name (e.g. Robinhood Chain 4663) instead of failing the whole accepts[] parse', () => {
+    const response = {
+      x402Version: 1,
+      error: 'PAYMENT_REQUIRED',
+      accepts: [
+        {
+          scheme: 'exact',
+          network: 'eip155:4663',
+          maxAmountRequired: '10000',
+          resource: 'https://gateway.tributex402.com/x402/api/alerts',
+          description: 'TRIBUTE whale alerts — USDG on Robinhood 4663',
+          mimeType: 'application/json',
+          payTo: '0xA59b92F48E2525C364F7F54663b69da68Cd26529',
+          maxTimeoutSeconds: 60,
+          asset: '0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168',
+          extra: { name: 'TRIBUTE', version: '1' },
+        },
+      ],
+    };
+
+    const result = parseV1(response);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.accepts).toHaveLength(1);
+      // Unknown chain ids fall back to the raw CAIP-2 string, mirroring
+      // normalizeChainId's `ChainIdToNetwork[id] ?? chainId` behavior.
+      expect(result.data.accepts?.[0]?.network).toBe('eip155:4663');
+    }
+  });
 });

--- a/apps/scan/src/lib/x402/v1/schema.ts
+++ b/apps/scan/src/lib/x402/v1/schema.ts
@@ -48,14 +48,22 @@ const namedNetwork = z3.enum([
 
 const networkSchemaV1 = z3.union([
   namedNetwork,
+  // Any well-formed CAIP-2 EVM identifier is accepted, even for chain ids
+  // that don't have a human-friendly entry in `ChainIdToNetwork` yet. This
+  // mirrors `normalizeChainId` in `../index.ts`, which already falls back to
+  // the raw `eip155:<id>` string (`ChainIdToNetwork[id] ?? chainId`) instead
+  // of rejecting the response outright. Without this fallback, a single
+  // unrecognized-but-valid chain id in `accepts[]` fails the whole v1 array
+  // parse via Zod, which surfaces to integrators as an opaque "No valid x402
+  // response found" even though the 402 challenge itself is fully spec
+  // compliant (see Merit-Systems/x402scan#782 for the same failure mode on a
+  // different chain).
   z3
     .string()
-    .refine(
-      v =>
-        v.startsWith('eip155:') && !!ChainIdToNetwork[Number(v.split(':')[1])],
-      { message: 'Invalid network' }
-    )
-    .transform(v => ChainIdToNetwork[Number(v.split(':')[1])]),
+    .refine(v => v.startsWith('eip155:') && !Number.isNaN(Number(v.split(':')[1])), {
+      message: 'Invalid network',
+    })
+    .transform(v => ChainIdToNetwork[Number(v.split(':')[1])] ?? v),
 ]);
 
 export const paymentRequirementsSchemaV1 = PaymentRequirementsV1Schema.extend({


### PR DESCRIPTION
## Problem

Registering an x402 server on a chain that isn't in the hardcoded `ChainIdToNetwork` lookup (`apps/scan/src/lib/x402/chain-mapping.ts`) currently fails the whole resource with an opaque **"No valid x402 response found"**, even when the 402 challenge itself is fully spec-compliant (valid `scheme`, non-empty `accepts`, correct `payTo`/`asset`/`maxTimeoutSeconds`, etc).

Root cause: `networkSchemaV1` in `apps/scan/src/lib/x402/v1/schema.ts` `refine()`s that an `eip155:<id>` network string must have an entry in `ChainIdToNetwork`, or the whole field fails Zod validation:

```ts
z3.string().refine(
  v => v.startsWith('eip155:') && !!ChainIdToNetwork[Number(v.split(':')[1])],
  { message: 'Invalid network' }
)
```

Because this is inside `paymentRequirementsSchemaV1`, one unrecognized chain id in `accepts[]` fails the entire array parse via Zod — the integrator sees a generic parse failure with no indication that the actual issue is "your chain isn't in our static allowlist yet."

This is the same failure class already reported in #782 for a different chain (Stacks) — right now, no facilitator/network outside the ~17 hardcoded entries can register at all, regardless of spec compliance.

Concretely hit this running [TRIBUTE](https://gateway.tributex402.com) (x402 gateway on Robinhood Chain, `eip155:4663`, USDG settlement) through the registration flow — `/openapi.json` and `/.well-known/x402` both discover fine, all 6 paid routes return well-formed 402 challenges, but registration fails on every one with "No valid x402 response found."

## Fix

`normalizeChainId()` in `apps/scan/src/lib/x402/index.ts` already treats an unrecognized chain id as non-fatal:

```ts
result = ChainIdToNetwork[id] ?? chainId;
```

This PR brings the v1 schema validator in line with that same fallback instead of hard-rejecting: any well-formed `eip155:<numeric-id>` string is now accepted, and unknown chain ids fall back to the raw CAIP-2 string (exactly like `normalizeChainId` already does) instead of failing the parse.

```diff
- .refine(v => v.startsWith('eip155:') && !!ChainIdToNetwork[Number(v.split(':')[1])], { message: 'Invalid network' })
- .transform(v => ChainIdToNetwork[Number(v.split(':')[1])]),
+ .refine(v => v.startsWith('eip155:') && !Number.isNaN(Number(v.split(':')[1])), { message: 'Invalid network' })
+ .transform(v => ChainIdToNetwork[Number(v.split(':')[1])] ?? v),
```

Malformed input (`eip155:notanumber`, garbage strings) is still correctly rejected — only well-formed-but-unmapped CAIP-2 ids now pass through.

## What this does / doesn't do

- Does **not** touch `SUPPORTED_CHAINS`, CDP server wallets, onramp, or any Base/Solana-specific infra — those are a much bigger surface and out of scope here.
- Does **not** add Robinhood Chain (or any chain) to any "officially supported" list — it just stops the parser from hard-failing valid-but-unrecognized chain ids, so origins on any chain can at least register and display correctly instead of getting an opaque error.

## Testing

Added a regression test (`schema.test.ts`) covering the `eip155:4663` case, plus verified in isolation (outside the monorepo, since `pnpm@11.22.0` wasn't available in my sandbox) that:
- Known chains (`base`, `solana`) still resolve to their friendly names — no change.
- `eip155:4663` (previously failing) now parses and falls back to the raw CAIP-2 string.
- Garbage (`not-a-network`) and malformed (`eip155:notanumber`) input is still correctly rejected — no loosening of actual validation, just removal of the allowlist-only restriction.

```
=== BEFORE ===
eip155:8453 (Base, known)        -> base
eip155:4663 (Robinhood, unknown) -> FAIL: Invalid input
solana (named)                   -> solana
not-a-network (garbage)          -> correctly rejected
eip155:notanumber (malformed)    -> correctly rejected

=== AFTER ===
eip155:8453 (Base, known)        -> base
eip155:4663 (Robinhood, unknown) -> eip155:4663
solana (named)                   -> solana
not-a-network (garbage)          -> correctly rejected
eip155:notanumber (malformed)    -> correctly rejected
```

Happy to adjust scope/approach if maintainers have a preferred direction (e.g. surfacing the raw chain id differently in the UI, or a separate "unsupported chain" state vs silent passthrough).